### PR TITLE
Add TypedSnak

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,12 +2,8 @@
 
 ## Version 0.7 (dev)
 
-#### Bug fixes
-
+* Added TypedSnak value object
 * The PHPUnit bootstrap file now works again on Windows
-
-#### Improvements
-
 * Changed class loading from PSR-0 to PSR-4
 
 ## Version 0.6 (2013-12-23)

--- a/src/Snak/TypedSnak.php
+++ b/src/Snak/TypedSnak.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Wikibase\DataModel\Snak;
+
+/**
+ * @since 0.7
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class TypedSnak {
+
+	/**
+	 * @var Snak
+	 */
+	private $snak;
+
+	/**
+	 * @var string
+	 */
+	private $dataTypeId;
+
+	/**
+	 * @param Snak $snak
+	 * @param string $dataTypeId
+	 */
+	public function __construct( Snak $snak, $dataTypeId ) {
+		$this->snak = $snak;
+		$this->dataTypeId = $dataTypeId;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDataTypeId() {
+		return $this->dataTypeId;
+	}
+
+	/**
+	 * @return Snak
+	 */
+	public function getSnak() {
+		return $this->snak;
+	}
+
+}

--- a/tests/unit/Snak/TypedSnakTest.php
+++ b/tests/unit/Snak/TypedSnakTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Wikibase\DataModel\Snak\Test;
+
+use Wikibase\DataModel\Snak\TypedSnak;
+
+/**
+ * @covers Wikibase\DataModel\Snak\TypedSnak
+ *
+ * @group Wikibase
+ * @group WikibaseDataModel
+ * @group WikibaseSnak
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class TypedSnakTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGettersReturnCorrectValues() {
+		$snak = $this->getMock( 'Wikibase\DataModel\Snak\Snak' );
+		$dataTypeId = 'awesome';
+
+		$typedSnak = new TypedSnak( $snak, $dataTypeId );
+
+		$this->assertEquals( $snak, $typedSnak->getSnak() );
+		$this->assertEquals( $dataTypeId, $typedSnak->getDataTypeId() );
+	}
+
+}


### PR DESCRIPTION
Simple value object to encapsulate a concept we already have in the code.
Right now we have a "Snak" serializer that pulls in a datatype id, which
really should not happen in a serializer. This object allows cleaning that
up, and is presumably usefull at other places as well.
