### PR TITLE
Updated inline documentation of EntityId::newFromPrefixedId

### DIFF
--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -145,24 +145,6 @@ class EntityId implements Comparable, Serializable {
 	}
 
 	/**
-	 * Constructs an EntityId object from an entity type and a numeric id.
-	 * This is intended to mark legacy code that still relies on numeric ids and needs to be fixed.
-	 *
-	 * @deprecated since 0.7.2, use serializations (prefixed ids) instead
-	 *
-	 * @param string $entityType
-	 * @param int $numericId
-	 *
-	 * @return EntityId|null
-	 *
-	 * @see LegacyIdInterpreter::newIdFromTypeAndNumber
-	 */
-	public static function newIdFromTypeAndNumber( $entityType, $numericId ) {
-		$entityId = new self( $entityType, $numericId );
-		return self::newFromPrefixedId( $entityId->getSerialization() );
-	}
-
-	/**
 	 * Constructs an EntityId object from a serialization (prefixed id).
 	 * This only works for ids of entity types defined in BasicEntityIdParser::getBuilders.
 	 *


### PR DESCRIPTION
This was suggested by Daniel.

Currently we do have many places in the code where a numeric id is converted to an EntityId object in some way. The new (deprecated) method is supposed to be an intermediate step to get rid of all numeric ids. If it's used (we have to do this in other patches since it's used in other modules) it will make it a lot easier to find and fix code that still relies on numeric ids.
