### PR TITLE
Add new Term classes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,22 @@
 
 ## Version 0.7.3 (dev)
 
+#### Additions
+
+* Added Term\AbstractTerm
+* Added Term\AliasGroup
+* Added Term\AliasGroupList
+* Added Term\Description
+* Added Term\DescriptionList
+* Added Term\Fingerprint
+* Added Term\FingerprintProvider
+* Added Term\Label
+* Added Term\LabelList
+* Added Term\Term
+* Added Term\TermList
+
+#### Deprecations
+
 * Deprecated Property::newEmpty
 
 ## Version 0.7.2 (2014-03-13)

--- a/src/Term/AbstractTerm.php
+++ b/src/Term/AbstractTerm.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 0.7.3
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+abstract class AbstractTerm implements Term {
+
+	private $languageCode;
+	private $text;
+
+	/**
+	 * @param string $languageCode
+	 * @param string $text
+	 */
+	public function __construct( $languageCode, $text ) {
+		$this->languageCode = $languageCode;
+		$this->text = $text;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getLanguageCode() {
+		return $this->languageCode;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getText() {
+		return $this->text;
+	}
+
+}

--- a/src/Term/AliasGroup.php
+++ b/src/Term/AliasGroup.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 0.7.3
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class AliasGroup {
+
+	private $languageCode;
+	private $aliases;
+
+	/**
+	 * @param string $languageCode
+	 * @param string[] $aliases
+	 */
+	public function __construct( $languageCode, array $aliases ) {
+		$this->languageCode = $languageCode;
+		$this->aliases = $aliases;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getLanguageCode() {
+		return $this->languageCode;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getAliases() {
+		return $this->aliases;
+	}
+
+}

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+use Countable;
+use InvalidArgumentException;
+use IteratorAggregate;
+use OutOfBoundsException;
+use Traversable;
+
+/**
+ * List of alias groups. Immutable.
+ *
+ * Only one group per language code. If multiple groups with the same language code
+ * are provided, only the last one will be retained.
+ *
+ * @since 0.7.3
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class AliasGroupList implements Countable, IteratorAggregate {
+
+	private $groups;
+
+	/**
+	 * @param AliasGroup[] $aliasGroups
+	 * @throws InvalidArgumentException
+	 */
+	public function __construct( array $aliasGroups ) {
+		foreach ( $aliasGroups as $aliasGroup ) {
+			if ( !( $aliasGroup instanceof AliasGroup ) ) {
+				throw new InvalidArgumentException( 'AliasGroupList can only contain AliasGroup instances' );
+			}
+
+			$this->groups[$aliasGroup->getLanguageCode()] = $aliasGroup;
+		}
+	}
+
+	/**
+	 * @see Countable::count
+	 * @return int
+	 */
+	public function count() {
+		return count( $this->groups );
+	}
+
+	/**
+	 * @see IteratorAggregate::getIterator
+	 * @return Traversable
+	 */
+	public function getIterator() {
+		return new \ArrayIterator( $this->groups );
+	}
+
+	/**
+	 * @param $languageCode
+	 *
+	 * @return AliasGroup
+	 * @throws InvalidArgumentException
+	 * @throws OutOfBoundsException
+	 */
+	public function getByLanguage( $languageCode ) {
+		if ( !is_string( $languageCode ) ) {
+			throw new InvalidArgumentException( '$languageCode should be a string' );
+		}
+
+		if ( !array_key_exists( $languageCode, $this->groups ) ) {
+			throw new OutOfBoundsException(
+				'There is no AliasGroup with language code "' . $languageCode . '" in the list'
+			);
+		}
+
+		return $this->groups[$languageCode];
+	}
+
+}

--- a/src/Term/Description.php
+++ b/src/Term/Description.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 0.7.3
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class Description extends AbstractTerm {
+
+	public function __construct( $languageCode, $text ) {
+		// TODO: validity checks
+		parent::__construct( $languageCode, $text );
+	}
+
+}

--- a/src/Term/DescriptionList.php
+++ b/src/Term/DescriptionList.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+use InvalidArgumentException;
+
+/**
+ * @since 0.7.3
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class DescriptionList extends TermList {
+
+	/**
+	 * @param Description[] $descriptions
+	 * @throws InvalidArgumentException
+	 */
+	public function __construct( array $descriptions ) {
+		foreach ( $descriptions as $description ) {
+			if ( !( $description instanceof Description ) ) {
+				throw new InvalidArgumentException( 'DescriptionList can only contain Description instances' );
+			}
+		}
+
+		parent::__construct( $descriptions );
+	}
+
+}

--- a/src/Term/Fingerprint.php
+++ b/src/Term/Fingerprint.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 0.7.3
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class Fingerprint {
+
+	private $labels;
+	private $descriptions;
+	private $aliases;
+
+	public function __construct( LabelList $labels, DescriptionList $descriptions, AliasGroupList $aliases ) {
+		$this->labels = $labels;
+		$this->descriptions = $descriptions;
+		$this->aliases = $aliases;
+	}
+
+	/**
+	 * @return LabelList
+	 */
+	public function getLabels() {
+		return $this->labels;
+	}
+
+	/**
+	 * @return DescriptionList
+	 */
+	public function getDescriptions() {
+		return $this->descriptions;
+	}
+
+	/**
+	 * @return AliasGroupList
+	 */
+	public function getAliases() {
+		return $this->aliases;
+	}
+
+}

--- a/src/Term/FingerprintProvider.php
+++ b/src/Term/FingerprintProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 0.7.3
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+interface FingerprintProvider {
+
+	/**
+	 * @return Fingerprint
+	 */
+	public function getFingerprint();
+
+}

--- a/src/Term/Label.php
+++ b/src/Term/Label.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 0.7.3
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class Label extends AbstractTerm {
+
+	public function __construct( $languageCode, $text ) {
+		// TODO: validity checks
+		parent::__construct( $languageCode, $text );
+	}
+
+}

--- a/src/Term/LabelList.php
+++ b/src/Term/LabelList.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+use InvalidArgumentException;
+
+/**
+ * @since 0.7.3
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LabelList extends TermList {
+
+	/**
+	 * @param Label[] $labels
+	 * @throws InvalidArgumentException
+	 */
+	public function __construct( array $labels ) {
+		foreach ( $labels as $label ) {
+			if ( !( $label instanceof Label ) ) {
+				throw new InvalidArgumentException( 'LabelList can only contain Label instances' );
+			}
+		}
+
+		parent::__construct( $labels );
+	}
+
+}

--- a/src/Term/Term.php
+++ b/src/Term/Term.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * Terms are immutable value objects.
+ *
+ * @since 0.7.3
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+interface Term {
+
+	/**
+	 * @return string
+	 */
+	public function getLanguageCode();
+
+	/**
+	 * @return string
+	 */
+	public function getText();
+
+}

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+use Countable;
+use InvalidArgumentException;
+use IteratorAggregate;
+use OutOfBoundsException;
+use Traversable;
+
+/**
+ * List of terms. Immutable.
+ *
+ * If multiple terms with the same language code are provided, only the last one will be retained.
+ *
+ * @since 0.7.3
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class TermList implements Countable, IteratorAggregate {
+
+	/**
+	 * @var Term[]
+	 */
+	private $terms = array();
+
+	/**
+	 * @param Term[] $terms
+	 */
+	public function __construct( array $terms ) {
+		foreach ( $terms as $term ) {
+			$this->terms[$term->getLanguageCode()] = $term;
+		}
+	}
+
+	/**
+	 * @see Countable::count
+	 * @return int
+	 */
+	public function count() {
+		return count( $this->terms );
+	}
+
+	/**
+	 * Returns an array with language codes as keys and the term text as values.
+	 *
+	 * @return string[]
+	 */
+	public function toTextArray() {
+		$array = array();
+
+		foreach ( $this->terms as $term ) {
+			$array[$term->getLanguageCode()] = $term->getText();
+		}
+
+		return $array;
+	}
+
+	/**
+	 * @see IteratorAggregate::getIterator
+	 * @return Traversable
+	 */
+	public function getIterator() {
+		return new \ArrayIterator( $this->terms );
+	}
+
+	/**
+	 * @param $languageCode
+	 *
+	 * @return AliasGroup
+	 * @throws InvalidArgumentException
+	 * @throws OutOfBoundsException
+	 */
+	public function getByLanguage( $languageCode ) {
+		if ( !is_string( $languageCode ) ) {
+			throw new InvalidArgumentException( '$languageCode should be a string' );
+		}
+
+		if ( !array_key_exists( $languageCode, $this->terms ) ) {
+			throw new OutOfBoundsException(
+				'There is no Term with language code "' . $languageCode . '" in the list'
+			);
+		}
+
+		return $this->terms[$languageCode];
+	}
+
+}

--- a/tests/unit/Term/AliasGroupListTest.php
+++ b/tests/unit/Term/AliasGroupListTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Wikibase\DataModel\Term\Test;
+
+use Wikibase\DataModel\Term\AliasGroup;
+use Wikibase\DataModel\Term\AliasGroupList;
+
+/**
+ * @covers Wikibase\DataModel\Term\AliasGroup
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenNoTerms_sizeIsZero() {
+		$list = new AliasGroupList( array() );
+		$this->assertCount( 0, $list );
+	}
+
+	public function testGivenTwoTerms_countReturnsTwo() {
+		$list = new AliasGroupList( $this->getTwoGroups() );
+
+		$this->assertCount( 2, $list );
+	}
+
+	private function getTwoGroups() {
+		return array(
+			'en' => new AliasGroup( 'en', array( 'foo' ) ),
+			'de' => new AliasGroup( 'de', array( 'bar', 'baz' ) ),
+		);
+	}
+
+	public function testGivenTwoGroups_listContainsThem() {
+		$array = $this->getTwoGroups();
+
+		$list = new AliasGroupList( $array );
+
+		$this->assertEquals( $array, iterator_to_array( $list ) );
+	}
+
+	public function testGivenGroupsWithTheSameLanguage_onlyTheLastOnesAreRetained() {
+		$array = array(
+			new AliasGroup( 'en', array( 'foo' ) ),
+			new AliasGroup( 'en', array( 'bar' ) ),
+
+			new AliasGroup( 'de', array( 'baz' ) ),
+
+			new AliasGroup( 'nl', array( 'bah' ) ),
+			new AliasGroup( 'nl', array( 'blah' ) ),
+			new AliasGroup( 'nl', array( 'spam' ) ),
+		);
+
+		$list = new AliasGroupList( $array );
+
+		$this->assertEquals(
+			array(
+				'en' => new AliasGroup( 'en', array( 'bar' ) ),
+				'de' => new AliasGroup( 'de', array( 'baz' ) ),
+				'nl' => new AliasGroup( 'nl', array( 'spam' ) ),
+			),
+			iterator_to_array( $list )
+		);
+	}
+
+	public function testCanIterateOverList() {
+		$group = new AliasGroup( 'en', array( 'foo' ) );
+
+		$list = new AliasGroupList( array( $group ) );
+
+		/**
+		 * @var AliasGroup $aliasGroup
+		 */
+		foreach ( $list as $key => $aliasGroup ) {
+			$this->assertEquals( $group, $aliasGroup );
+			$this->assertEquals( $aliasGroup->getLanguageCode(), $key );
+		}
+	}
+
+	public function testGivenNonAliasGroups_constructorThrowsException() {
+		$this->setExpectedException( 'InvalidArgumentException' );
+		new AliasGroupList( array( $this->getMock( 'Wikibase\DataModel\Term\Term' ) ) );
+	}
+
+	public function testGivenSetLanguageCode_getByLanguageReturnsGroup() {
+		$enGroup = new AliasGroup( 'en', array() );
+
+		$list = new AliasGroupList( array(
+			new AliasGroup( 'de', array() ),
+			$enGroup,
+			new AliasGroup( 'nl', array() ),
+		) );
+
+		$this->assertEquals( $enGroup, $list->getByLanguage( 'en' ) );
+	}
+
+	public function testGivenNonString_getByLanguageThrowsException() {
+		$list = new AliasGroupList( array() );
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$list->getByLanguage( null );
+	}
+
+	public function testGivenNonSetLanguageCode_getByLanguageThrowsException() {
+		$list = new AliasGroupList( array() );
+
+		$this->setExpectedException( 'OutOfBoundsException' );
+		$list->getByLanguage( 'en' );
+	}
+
+}

--- a/tests/unit/Term/AliasGroupTest.php
+++ b/tests/unit/Term/AliasGroupTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Wikibase\DataModel\Term\Test;
+
+use Wikibase\DataModel\Term\AliasGroup;
+
+/**
+ * @covers Wikibase\DataModel\Term\AliasGroup
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class AliasGroupTest extends \PHPUnit_Framework_TestCase {
+
+	public function testConstructorSetsValues() {
+		$language = 'en';
+		$aliases = array( 'foo', 'bar', 'baz' );
+
+		$group = new AliasGroup( $language, $aliases );
+
+		$this->assertEquals( $language, $group->getLanguageCode() );
+		$this->assertEquals( $aliases, $group->getAliases() );
+	}
+
+}

--- a/tests/unit/Term/DescriptionListTest.php
+++ b/tests/unit/Term/DescriptionListTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Wikibase\DataModel\Term\Test;
+
+use Wikibase\DataModel\Term\Description;
+use Wikibase\DataModel\Term\DescriptionList;
+
+/**
+ * @covers Wikibase\DataModel\Term\DescriptionList
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class DescriptionListTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenNonDescriptions_constructorThrowsException() {
+		$this->setExpectedException( 'InvalidArgumentException' );
+		new DescriptionList( array( $this->getMock( 'Wikibase\DataModel\Term\Term' ) ) );
+	}
+
+	public function testGivenDescriptions_descriptionsAreSet() {
+		$descriptions = array(
+			'foo' => new Description( 'foo', 'bar' )
+		);
+
+		$list = new DescriptionList( $descriptions );
+
+		$this->assertEquals( $descriptions, iterator_to_array( $list ) );
+	}
+
+}

--- a/tests/unit/Term/DescriptionTest.php
+++ b/tests/unit/Term/DescriptionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Wikibase\DataModel\Term\Test;
+
+use Wikibase\DataModel\Term\Description;
+
+/**
+ * @covers Wikibase\DataModel\Term\Description
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class DescriptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGetLanguageCodeReturnsSetValue() {
+		$label = new Description( 'foo', 'bar' );
+		$this->assertEquals( 'foo', $label->getLanguageCode() );
+	}
+
+	public function testGetTextReturnsSetValue() {
+		$label = new Description( 'foo', 'bar' );
+		$this->assertEquals( 'bar', $label->getText() );
+	}
+
+}

--- a/tests/unit/Term/FingerprintTest.php
+++ b/tests/unit/Term/FingerprintTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Wikibase\DataModel\Term\Test;
+
+use Wikibase\DataModel\Term\Fingerprint;
+
+/**
+ * @covers Wikibase\DataModel\Term\Fingerprint
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class FingerprintTest extends \PHPUnit_Framework_TestCase {
+
+	public function testConstructorSetsValues() {
+		$labels = $this->getMockBuilder( 'Wikibase\DataModel\Term\LabelList' )
+			->disableOriginalConstructor()->getMock();
+
+		$descriptions = $this->getMockBuilder( 'Wikibase\DataModel\Term\DescriptionList' )
+			->disableOriginalConstructor()->getMock();
+
+		$aliases = $this->getMockBuilder( 'Wikibase\DataModel\Term\AliasGroupList' )
+			->disableOriginalConstructor()->getMock();
+
+		$fingerprint = new Fingerprint( $labels, $descriptions, $aliases );
+
+		$this->assertEquals( $labels, $fingerprint->getLabels() );
+		$this->assertEquals( $descriptions, $fingerprint->getDescriptions() );
+		$this->assertEquals( $aliases, $fingerprint->getAliases() );
+	}
+
+}

--- a/tests/unit/Term/LabelListTest.php
+++ b/tests/unit/Term/LabelListTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Wikibase\DataModel\Term\Test;
+
+use Wikibase\DataModel\Term\Label;
+use Wikibase\DataModel\Term\LabelList;
+
+/**
+ * @covers Wikibase\DataModel\Term\LabelList
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LabelListTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenNonDescriptions_constructorThrowsException() {
+		$this->setExpectedException( 'InvalidArgumentException' );
+		new LabelList( array( $this->getMock( 'Wikibase\DataModel\Term\Term' ) ) );
+	}
+
+	public function testGivenDescriptions_descriptionsAreSet() {
+		$descriptions = array(
+			'foo' => new Label( 'foo', 'bar' )
+		);
+
+		$list = new LabelList( $descriptions );
+
+		$this->assertEquals( $descriptions, iterator_to_array( $list ) );
+	}
+
+}

--- a/tests/unit/Term/LabelTest.php
+++ b/tests/unit/Term/LabelTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Wikibase\DataModel\Term\Test;
+
+use Wikibase\DataModel\Term\Label;
+
+/**
+ * @covers Wikibase\DataModel\Term\Label
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LabelTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGetLanguageCodeReturnsSetValue() {
+		$label = new Label( 'foo', 'bar' );
+		$this->assertEquals( 'foo', $label->getLanguageCode() );
+	}
+
+	public function testGetTextReturnsSetValue() {
+		$label = new Label( 'foo', 'bar' );
+		$this->assertEquals( 'bar', $label->getText() );
+	}
+
+}

--- a/tests/unit/Term/TermListTest.php
+++ b/tests/unit/Term/TermListTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Wikibase\DataModel\Term\Test;
+
+use Wikibase\DataModel\Term\Label;
+use Wikibase\DataModel\Term\TermList;
+
+/**
+ * @covers Wikibase\DataModel\Term\TermList
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class TermListTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenNoTerms_sizeIsZero() {
+		$list = new TermList( array() );
+		$this->assertCount( 0, $list );
+	}
+
+	public function testGivenTwoTerms_countReturnsTwo() {
+		$list = new TermList( $this->getTwoTerms() );
+
+		$this->assertCount( 2, $list );
+	}
+
+	private function getTwoTerms() {
+		return array(
+			'en' => new Label( 'en', 'foo' ),
+			'de' => new Label( 'de', 'bar' ),
+		);
+	}
+
+	public function testGivenTwoTerms_listContainsThem() {
+		$array = $this->getTwoTerms();
+
+		$list = new TermList( $array );
+
+		$this->assertEquals( $array, iterator_to_array( $list ) );
+	}
+
+	public function testGivenTermsWithTheSameLanguage_onlyTheLastOnesAreRetained() {
+		$array = array(
+			new Label( 'en', 'foo' ),
+			new Label( 'en', 'bar' ),
+
+			new Label( 'de', 'baz' ),
+
+			new Label( 'nl', 'bah' ),
+			new Label( 'nl', 'blah' ),
+			new Label( 'nl', 'spam' ),
+		);
+
+		$list = new TermList( $array );
+
+		$this->assertEquals(
+			array(
+				'en' => new Label( 'en', 'bar' ),
+				'de' => new Label( 'de', 'baz' ),
+				'nl' => new Label( 'nl', 'spam' ),
+			),
+			iterator_to_array( $list )
+		);
+	}
+
+	public function testGivenNoTerms_toTextArrayReturnsEmptyArray() {
+		$list = new TermList( array() );
+		$this->assertEquals( array(), $list->toTextArray() );
+	}
+
+	public function testGivenTerms_toTextArrayReturnsTermsInFormat() {
+		$list = new TermList( array(
+			new Label( 'en', 'foo' ),
+			new Label( 'de', 'bar' ),
+		) );
+
+		$this->assertEquals(
+			array(
+				'en' => 'foo',
+				'de' => 'bar',
+			),
+			$list->toTextArray()
+		);
+	}
+
+	public function testCanIterateOverList() {
+		$list = new TermList( array(
+			new Label( 'en', 'foo' ),
+		) );
+
+		foreach ( $list as $key => $term ) {
+			$this->assertEquals( 'en', $key );
+			$this->assertEquals( new Label( 'en', 'foo' ), $term );
+		}
+	}
+
+	public function testGivenSetLanguageCode_getByLanguageReturnsGroup() {
+		$enTerm = new Label( 'en', 'a' );
+
+		$list = new TermList( array(
+			new Label( 'de', 'b' ),
+			$enTerm,
+			new Label( 'nl', 'c' ),
+		) );
+
+		$this->assertEquals( $enTerm, $list->getByLanguage( 'en' ) );
+	}
+
+	public function testGivenNonString_getByLanguageThrowsException() {
+		$list = new TermList( array() );
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$list->getByLanguage( null );
+	}
+
+	public function testGivenNonSetLanguageCode_getByLanguageThrowsException() {
+		$list = new TermList( array() );
+
+		$this->setExpectedException( 'OutOfBoundsException' );
+		$list->getByLanguage( 'en' );
+	}
+
+}


### PR DESCRIPTION
```
Most of this has already been reviewed before it was merged into
https://github.com/wmde/WikibaseInternalSerialization/tree/master/DataModel

This commit moves the code to DataModel, adds tests, adds some validity
checks and adds some new getters
```

This is part of the evil plan to split up Entity as per #22. And the new classes are essentially already used by WikibaseInternalSerialization.
