### PR TITLE
Disable original constructor when mocking Term

### DIFF
--- a/tests/unit/Term/AliasGroupListTest.php
+++ b/tests/unit/Term/AliasGroupListTest.php
@@ -79,7 +79,11 @@ class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGivenNonAliasGroups_constructorThrowsException() {
 		$this->setExpectedException( 'InvalidArgumentException' );
-		new AliasGroupList( array( $this->getMock( 'Wikibase\DataModel\Term\Term' ) ) );
+
+		$term = $this->getMockBuilder( 'Wikibase\DataModel\Term\Term' )
+			->disableOriginalConstructor()->getMock();
+
+		new AliasGroupList( array( $term ) );
 	}
 
 	public function testGivenSetLanguageCode_getByLanguageReturnsGroup() {


### PR DESCRIPTION
When I try to run all Term/... tests locally I get an exception: Missing argument 1 for Wikibase\DataModel\Term\Term::__construct(), called in phar:///usr/local/bin/phpunit/phpunit-mock-objects/Framework/MockObject/Generator.php
