### PR TITLE
Rename getAliases to getAliasGroups

### DIFF
--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -966,7 +966,7 @@ abstract class Entity implements \Comparable, ClaimAggregate, \Serializable, Fin
 	public function setFingerprint( Fingerprint $fingerprint ) {
 		$this->setLabels( $fingerprint->getLabels()->toTextArray() );
 		$this->setDescriptions( $fingerprint->getDescriptions()->toTextArray() );
-		$this->setAliasGroupList( $fingerprint->getAliases() );
+		$this->setAliasGroupList( $fingerprint->getAliasGroups() );
 
 	}
 

--- a/src/Term/Fingerprint.php
+++ b/src/Term/Fingerprint.php
@@ -23,12 +23,12 @@ class Fingerprint {
 
 	private $labels;
 	private $descriptions;
-	private $aliases;
+	private $aliasGroups;
 
-	public function __construct( TermList $labels, TermList $descriptions, AliasGroupList $aliases ) {
+	public function __construct( TermList $labels, TermList $descriptions, AliasGroupList $aliasGroups ) {
 		$this->labels = $labels;
 		$this->descriptions = $descriptions;
-		$this->aliases = $aliases;
+		$this->aliasGroups = $aliasGroups;
 	}
 
 	/**
@@ -48,8 +48,8 @@ class Fingerprint {
 	/**
 	 * @return AliasGroupList
 	 */
-	public function getAliases() {
-		return $this->aliases;
+	public function getAliasGroups() {
+		return $this->aliasGroups;
 	}
 
 }

--- a/tests/unit/Term/FingerprintTest.php
+++ b/tests/unit/Term/FingerprintTest.php
@@ -14,7 +14,7 @@ class FingerprintTest extends \PHPUnit_Framework_TestCase {
 
 	private $labels;
 	private $descriptions;
-	private $aliases;
+	private $aliasGroups;
 
 	public function setUp() {
 		$this->labels = $this->getMockBuilder( 'Wikibase\DataModel\Term\TermList' )
@@ -23,16 +23,16 @@ class FingerprintTest extends \PHPUnit_Framework_TestCase {
 		$this->descriptions = $this->getMockBuilder( 'Wikibase\DataModel\Term\TermList' )
 			->disableOriginalConstructor()->getMock();
 
-		$this->aliases = $this->getMockBuilder( 'Wikibase\DataModel\Term\AliasGroupList' )
+		$this->aliasGroups = $this->getMockBuilder( 'Wikibase\DataModel\Term\AliasGroupList' )
 			->disableOriginalConstructor()->getMock();
 	}
 
 	public function testConstructorSetsValues() {
-		$fingerprint = new Fingerprint( $this->labels, $this->descriptions, $this->aliases );
+		$fingerprint = new Fingerprint( $this->labels, $this->descriptions, $this->aliasGroups );
 
 		$this->assertEquals( $this->labels, $fingerprint->getLabels() );
 		$this->assertEquals( $this->descriptions, $fingerprint->getDescriptions() );
-		$this->assertEquals( $this->aliases, $fingerprint->getAliases() );
+		$this->assertEquals( $this->aliasGroups, $fingerprint->getAliasGroups() );
 	}
 
 }


### PR DESCRIPTION
This is split from #59 to be able to discuss the rename separately. Reasons:
- This doesn't return a collection of aliases (e.g. an `AliasList` object or an array of `Alias` objects or strings). It returns a collection of alias groups.
- The `AliasGroup` class also haves a `getAliases` method. You would end with something like `$fingerprint->getAliases()->getByLanguage( 'en' )->getAliases()` which looks strange.
