### PR TITLE
Add @uses tags to tests

### DIFF
--- a/tests/unit/Snak/PropertyValueSnakTest.php
+++ b/tests/unit/Snak/PropertyValueSnakTest.php
@@ -3,14 +3,16 @@
 namespace Wikibase\Test\Snak;
 
 use DataValues\StringValue;
-use DataValues\UnDeserializableValue;
-use Wikibase\DataModel\Entity\ItemId;
-use Wikibase\DataModel\Entity\Property;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 
 /**
  * @covers Wikibase\DataModel\Snak\PropertyValueSnak
+ * @uses DataValues\StringValue
+ * @uses Wikibase\DataModel\Entity\EntityId
+ * @uses Wikibase\DataModel\Entity\PropertyId
+ * @uses Wikibase\DataModel\Snak\SnakObject
+ * @uses DataValues\DataValueObject
  *
  * @group Wikibase
  * @group WikibaseDataModel

--- a/tests/unit/Snak/SnakListTest.php
+++ b/tests/unit/Snak/SnakListTest.php
@@ -12,6 +12,16 @@ use Wikibase\Test\HashArray\HashArrayTest;
 
 /**
  * @covers Wikibase\DataModel\Snak\SnakList
+ * @uses DataValues\StringValue
+ * @uses Wikibase\DataModel\Entity\PropertyId
+ * @uses Wikibase\DataModel\Snak\PropertyNoValueSnak
+ * @uses Wikibase\DataModel\Snak\PropertyValueSnak
+ * @uses Wikibase\DataModel\Snak\Snak
+ * @uses Wikibase\DataModel\Snak\SnakList
+ * @uses Wikibase\DataModel\HashArray
+ * @uses Wikibase\DataModel\Snak\SnakObject
+ * @uses Wikibase\DataModel\MapValueHasher
+ * @uses Wikibase\DataModel\Entity\EntityId
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/unit/Snak/SnakObjectTest.php
+++ b/tests/unit/Snak/SnakObjectTest.php
@@ -3,11 +3,8 @@
 namespace Wikibase\Test\Snak;
 
 use Wikibase\DataModel\Snak\Snak;
-use Wikibase\DataModel\Snak\SnakObject;
 
 /**
- * @covers Wikibase\DataModel\Snak\SnakObject
- *
  * @group Wikibase
  * @group WikibaseDataModel
  * @group WikibaseSnak

--- a/tests/unit/Snak/SnakTest.php
+++ b/tests/unit/Snak/SnakTest.php
@@ -9,10 +9,17 @@ use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Snak\Snak;
-use Wikibase\DataModel\Snak\SnakObject;
 
 /**
- * Unit tests for classes that implement Wikibase\Snak.
+ * @covers Wikibase\DataModel\Snak\PropertyNoValueSnak
+ * @covers Wikibase\DataModel\Snak\PropertySomeValueSnak
+ * @covers Wikibase\DataModel\Snak\PropertyValueSnak
+ * @covers Wikibase\DataModel\Snak\Snak
+ * @uses Wikibase\DataModel\Snak\SnakObject
+ * @uses DataValues\NumberValue
+ * @uses DataValues\StringValue
+ * @uses Wikibase\DataModel\Entity\EntityId
+ * @uses Wikibase\DataModel\Entity\PropertyId
  *
  * @group Wikibase
  * @group WikibaseDataModel

--- a/tests/unit/Term/AliasGroupListTest.php
+++ b/tests/unit/Term/AliasGroupListTest.php
@@ -7,6 +7,7 @@ use Wikibase\DataModel\Term\AliasGroupList;
 
 /**
  * @covers Wikibase\DataModel\Term\AliasGroupList
+ * @uses Wikibase\DataModel\Term\AliasGroup
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/unit/Term/FingerprintTest.php
+++ b/tests/unit/Term/FingerprintTest.php
@@ -11,6 +11,11 @@ use Wikibase\DataModel\Term\TermList;
 
 /**
  * @covers Wikibase\DataModel\Term\Fingerprint
+ * @uses Wikibase\DataModel\Term\AliasGroup
+ * @uses Wikibase\DataModel\Term\AliasGroupList
+ * @uses Wikibase\DataModel\Term\Fingerprint
+ * @uses Wikibase\DataModel\Term\Term
+ * @uses Wikibase\DataModel\Term\TermList
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/unit/Term/TermListTest.php
+++ b/tests/unit/Term/TermListTest.php
@@ -7,6 +7,7 @@ use Wikibase\DataModel\Term\TermList;
 
 /**
  * @covers Wikibase\DataModel\Term\TermList
+ * @uses Wikibase\DataModel\Term\Term
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >


### PR DESCRIPTION
This is needed as of PHPUnit 4, which requires these tags
to be present in strict mode. http://phpunit.de/manual/4.0/en/strict-mode.html

If they are not, the tests are marked as risky and the coverage for them
is not counted.
