### PR TITLE
Reduce Claims::insertClaimAtIndex complexity

### DIFF
--- a/src/Claim/Claims.php
+++ b/src/Claim/Claims.php
@@ -115,15 +115,8 @@ class Claims extends ArrayObject implements ClaimListAccess, Hashable, Comparabl
 	 * @param int $index
 	 */
 	protected function insertClaimAtIndex( Claim $claim, $index ) {
-		$claimsToShift = array();
-		$i = 0;
-
 		// Determine the claims to shift and remove them from the array:
-		foreach( $this as $object ) {
-			if( $i++ >= $index ) {
-				$claimsToShift[] = $object;
-			}
-		}
+		$claimsToShift = array_slice( (array)$this, $index );
 
 		foreach( $claimsToShift as $object ) {
 			$this->offsetUnset( $this->getClaimKey( $object ) );


### PR DESCRIPTION
The original idea was to reduce the complexity of this class a little bit.

I also did a little benchmark just to be sure. Turns out this is 4 times faster. Not that runtime matters in this case. It's barely measurable for average sized Claim lists. Just to let you know.
