### PR TITLE
Reduce complexity of Claims class

### DIFF
--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -7,6 +7,7 @@ use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpChange;
 use Diff\DiffOp\DiffOpRemove;
+use InvalidArgumentException;
 use ReflectionClass;
 use Wikibase\DataModel\ByPropertyIdArray;
 use Wikibase\DataModel\Claim\Claim;
@@ -313,6 +314,14 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 		$claims[] = $claim2;
 
 		$this->assertCount( 2, $claims );
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testAppendWithNonClaimFails() {
+		$claims = new Claims();
+		$claims->append( 'bad' );
 	}
 
 	public function testOffsetSet() {


### PR DESCRIPTION
In an attempt to reduce the complexity of this class I found that `append` is not necessary. `append` calls `offsetSet` which does the same type check again. I added a test to make sure the type check is not lost.

The change to `$arrayObject[] = $element` does have the same reason. The `[] =` is just an other way to `append` but does _not_ call `append` internally. Instead it calls `offsetSet` directly. Which is what I want.
