### PR TITLE
Add type hints to Fingerprint

### DIFF
--- a/src/Term/Fingerprint.php
+++ b/src/Term/Fingerprint.php
@@ -36,9 +36,11 @@ class Fingerprint implements Comparable {
 	}
 
 	/**
+	 * Returns a TermList containing all the labels.
+	 *
 	 * @since 0.7.3
 	 *
-	 * @return TermList
+	 * @return TermList|Term[]
 	 */
 	public function getLabels() {
 		return $this->labels;
@@ -76,9 +78,11 @@ class Fingerprint implements Comparable {
 	}
 
 	/**
+	 * Returns a TermList containing all the descriptions.
+	 *
 	 * @since 0.7.3
 	 *
-	 * @return TermList
+	 * @return TermList|Term[]
 	 */
 	public function getDescriptions() {
 		return $this->descriptions;
@@ -116,9 +120,11 @@ class Fingerprint implements Comparable {
 	}
 
 	/**
+	 * Returns an AliasGroupList containing all the alias groups.
+	 *
 	 * @since 0.7.4
 	 *
-	 * @return AliasGroupList
+	 * @return AliasGroupList|AliasGroup[]
 	 */
 	public function getAliasGroups() {
 		return $this->aliasGroups;


### PR DESCRIPTION
These hints allow creating loops such as this one without tools
losing track of the type of the elements.

foreach ( $fingerprint->getLabels() as $label ) {}
