### PR TITLE
Switch to addSiteLink/addNewSiteLink naming convention

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -53,8 +53,8 @@ Other breaking changes:
 #### Additions
 
 * Added `AliasGroupList::hasGroupForLanguage`
-* Added `SiteLinkList::add`
-* Added `SiteLinkList::addObject`
+* Added `SiteLinkList::addSiteLink`
+* Added `SiteLinkList::addNewSiteLink`
 * Added `SiteLinkList::removeLinkWithSiteId`
 * Added `SiteLinkList::isEmpty`
 * Added `SiteLinkList::removeLinkWithSiteId`

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -83,7 +83,7 @@ class Item extends Entity {
 	 * @param SiteLink $siteLink
 	 */
 	public function addSiteLink( SiteLink $siteLink ) {
-		$this->siteLinks->addObject( $siteLink );
+		$this->siteLinks->addSiteLink( $siteLink );
 	}
 
 	/**
@@ -242,7 +242,7 @@ class Item extends Entity {
 
 		foreach ( $links as $siteId => $linkData ) {
 			if ( array_key_exists( 'name', $linkData ) ) {
-				$this->siteLinks->addObject( new SiteLink(
+				$this->siteLinks->addSiteLink( new SiteLink(
 					$siteId,
 					$linkData['name'],
 					array_map(

--- a/src/SiteLinkList.php
+++ b/src/SiteLinkList.php
@@ -36,7 +36,7 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 				throw new InvalidArgumentException( 'SiteLinkList only accepts SiteLink objects' );
 			}
 
-			$this->addObject( $siteLink );
+			$this->addSiteLink( $siteLink );
 		}
 	}
 
@@ -48,7 +48,7 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	 * @throws InvalidArgumentException
 	 * @return self
 	 */
-	public function addObject( SiteLink $link ) {
+	public function addSiteLink( SiteLink $link ) {
 		if ( array_key_exists( $link->getSiteId(), $this->siteLinks ) ) {
 			throw new InvalidArgumentException( 'Duplicate site id: ' . $link->getSiteId() );
 		}
@@ -59,6 +59,8 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	}
 
 	/**
+	 * @see SiteLink::__construct
+	 *
 	 * @since 1.0
 	 *
 	 * @param string $siteId
@@ -68,8 +70,8 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	 * @throws InvalidArgumentException
 	 * @return self
 	 */
-	public function add( $siteId, $pageName, $badges = array() ) {
-		return $this->addObject( new SiteLink( $siteId, $pageName, $badges ) );
+	public function addNewSiteLink( $siteId, $pageName, $badges = array() ) {
+		return $this->addSiteLink( new SiteLink( $siteId, $pageName, $badges ) );
 	}
 
 	/**

--- a/tests/unit/SiteLinkListTest.php
+++ b/tests/unit/SiteLinkListTest.php
@@ -242,8 +242,8 @@ class SiteLinkListTest extends \PHPUnit_Framework_TestCase {
 	public function testAddHasFluentInterface() {
 		$list = new SiteLinkList();
 
-		$list->add( 'enwiki', 'cats' )
-			->add( 'dewiki', 'katzen', array( new ItemId( 'Q1' ) ) );
+		$list->addNewSiteLink( 'enwiki', 'cats' )
+			->addNewSiteLink( 'dewiki', 'katzen', array( new ItemId( 'Q1' ) ) );
 
 		$this->assertTrue( $list->equals( new SiteLinkList( array (
 			new SiteLink( 'enwiki', 'cats' ),
@@ -254,8 +254,8 @@ class SiteLinkListTest extends \PHPUnit_Framework_TestCase {
 	public function testAddObjectHasFluentInterface() {
 		$list = new SiteLinkList();
 
-		$list->addObject( new SiteLink( 'enwiki', 'cats' ) )
-			->addObject( new SiteLink( 'dewiki', 'katzen' ) );
+		$list->addSiteLink( new SiteLink( 'enwiki', 'cats' ) )
+			->addSiteLink( new SiteLink( 'dewiki', 'katzen' ) );
 
 		$this->assertTrue( $list->equals( new SiteLinkList( array (
 			new SiteLink( 'enwiki', 'cats' ),


### PR DESCRIPTION
Rename `addObject` to `addSiteLink` and `add` to `addNewSiteLink` as discussed in #109.

I'm not 100% sure if we all agree on that naming scheme, therefor the [WIP]. @JeroenDeDauw is fine with it according to #109. @brightbyte seems to be fine with it according to the (very short) discussion I had with him. I'm almost sure I'm fine with it.

Should be merged before releasing 1.0 and possible before releasing the 0.8 branch.
