### PR TITLE
Back to 0.7.3 description

### DIFF
--- a/WikibaseDataModel.mw.php
+++ b/WikibaseDataModel.mw.php
@@ -22,6 +22,5 @@ $GLOBALS['wgExtensionCredits']['wikibase'][] = array(
 		'[https://www.mediawiki.org/wiki/User:Jeroen_De_Dauw Jeroen De Dauw]',
 	),
 	'url' => 'https://github.com/wmde/WikibaseDataModel',
-	'description' => 'PHP implementation of the Wikibase DataModel'
+	'description' => 'Component defining the Wikibase data model'
 );
-


### PR DESCRIPTION
Reasons:
- Don't mention PHP. No other extension on https://www.wikidata.org/wiki/Special:Version does that.
- Use normal casing. Describing a component that's named "Wikibase DataModel" as an implementation of the "Wikibase DataModel" seems odd.

See the canceled discussion at #113.
