### PR TITLE
Don't rely on assert() to bail on assertion failure

### DIFF
--- a/src/Claim/ClaimListDiffer.php
+++ b/src/Claim/ClaimListDiffer.php
@@ -49,7 +49,11 @@ class ClaimListDiffer {
 			$oldClaim = $fromClaims->getClaimWithGuid( $guid );
 			$newClaim = $toClaims->getClaimWithGuid( $guid );
 
-			assert( $oldClaim->getGuid() === $newClaim->getGuid() );
+			if ( !( $oldClaim instanceof Claim
+					&& $newClaim instanceof Claim
+					&& $oldClaim->getGuid() === $newClaim->getGuid() ) ) {
+				throw new UnexpectedValueException( 'Invalid operands' );
+			}
 
 			return new DiffOpChange( $oldClaim, $newClaim );
 		}


### PR DESCRIPTION
The behavior of assert() is variable, depending on the value of the
assert.active / assert.warning / assert.bail / assert.quiet_eval runtime
options. To make the behavior of ClaimListDiffer::getDiffOp consistent and
indempotent, eschew assert() in favor of an explicit check.

Bugzilla bug: https://bugzilla.wikimedia.org/show_bug.cgi?id=65698
