### PR TITLE
Fix cleanStructure in Entity

### DIFF
--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -498,6 +498,7 @@ abstract class Entity implements \Comparable, ClaimAggregate, \Serializable, Fin
 				$this->data[$field] = array();
 			}
 		}
+		$this->claims = null;
 	}
 
 	/**

--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -14,6 +14,7 @@ use Wikibase\DataModel\Entity\Entity;
 use Wikibase\DataModel\Entity\EntityDiff;
 use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Internal\ObjectComparer;
 use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
@@ -397,11 +398,16 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 		$entity->setDescription( 'en', 'o_O' );
 		$entity->setLabel( 'en', 'o_O' );
 
+		$claim = new Claim( new PropertyNoValueSnak( new PropertyId( 'P42' ) ) );
+		$claim->setGuid( 'foo-bar-foz' );
+		$entity->addClaim( $claim );
+
 		$entity->clear();
 
 		$this->assertEmpty( $entity->getLabels(), "labels" );
 		$this->assertEmpty( $entity->getDescriptions(), "descriptions" );
 		$this->assertEmpty( $entity->getAllAliases(), "aliases" );
+		$this->assertEmpty( $entity->getClaims(), "claims" );
 
 		$this->assertTrue( $entity->isEmpty() );
 	}


### PR DESCRIPTION
The  field of Entity did not get cleared and thus still returned
all the old claims. Now we set it to an empty array, too.
