### PR TITLE
Fix hard-coded Snak alias

### DIFF
--- a/src/Snak/SnakList.php
+++ b/src/Snak/SnakList.php
@@ -26,7 +26,7 @@ class SnakList extends HashArray implements Snaks {
 	 * @return string
 	 */
 	public function getObjectType() {
-		return '\Wikibase\Snak';
+		return '\Wikibase\DataModel\Snak\Snak';
 	}
 
 	/**


### PR DESCRIPTION
**Caution:** It's totally possible this change breaks things. Which code paths use this string? Serializations? I don't think so but I'm not 100% sure.
