### PR TITLE
Test if getHash is static

### DIFF
--- a/tests/unit/Snak/PropertyNoValueSnakTest.php
+++ b/tests/unit/Snak/PropertyNoValueSnakTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Wikibase\Test\Snak;
+
+/**
+ * @covers Wikibase\DataModel\Snak\PropertyNoValueSnak
+ *
+ * @group Wikibase
+ * @group WikibaseDataModel
+ * @group WikibaseSnak
+ *
+ * @group Database
+ *
+ * @licence GNU GPL v2+
+ * @author Thiemo Mättig
+ */
+class PropertyNoValueSnakTest extends SnakObjectTest {
+
+	public function getClass() {
+		return 'Wikibase\DataModel\Snak\PropertyNoValueSnak';
+	}
+
+}

--- a/tests/unit/Snak/PropertySomeValueSnakTest.php
+++ b/tests/unit/Snak/PropertySomeValueSnakTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Wikibase\Test\Snak;
+
+/**
+ * @covers Wikibase\DataModel\Snak\PropertySomeValueSnak
+ *
+ * @group Wikibase
+ * @group WikibaseDataModel
+ * @group WikibaseSnak
+ *
+ * @group Database
+ *
+ * @licence GNU GPL v2+
+ * @author Thiemo Mättig
+ */
+class PropertySomeValueSnakTest extends SnakObjectTest {
+
+	public function getClass() {
+		return 'Wikibase\DataModel\Snak\PropertySomeValueSnak';
+	}
+
+}

--- a/tests/unit/Snak/PropertyValueSnakTest.php
+++ b/tests/unit/Snak/PropertyValueSnakTest.php
@@ -3,8 +3,10 @@
 namespace Wikibase\Test\Snak;
 
 use DataValues\StringValue;
+use InvalidArgumentException;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
+use Wikibase\DataModel\Snak\Snak;
 
 /**
  * @covers Wikibase\DataModel\Snak\PropertyValueSnak
@@ -22,6 +24,7 @@ use Wikibase\DataModel\Snak\PropertyValueSnak;
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
 class PropertyValueSnakTest extends SnakObjectTest {
 
@@ -42,6 +45,23 @@ class PropertyValueSnakTest extends SnakObjectTest {
 	public function testGetDataValue( PropertyValueSnak $snak ) {
 		$dataValue = $snak->getDataValue();
 		$this->assertInstanceOf( 'DataValues\DataValue', $dataValue );
+	}
+
+	protected function getPropertiesSerialization( Snak $snak ) {
+		if ( !( $snak instanceof PropertyValueSnak ) ) {
+			throw new InvalidArgumentException( 'Snak must be a PropertyValueSnak.' );
+		}
+
+		$valueClass = get_class( $snak->getDataValue() );
+		$valueSerialization = $snak->getDataValue()->serialize();
+		return sprintf(
+			'a:2:{i:0;i:%s;i:1;C:%d:"%s":%d:{%s}}',
+			$snak->getPropertyId()->getNumericId(),
+			strlen( $valueClass ),
+			$valueClass,
+			strlen( $valueSerialization ),
+			$valueSerialization
+		);
 	}
 
 }


### PR DESCRIPTION
This should fix #130.

It turns out PHP's `serialize()` function just calls the `...->serialize()` methods provided by the `Serializable` interface in `Snak`. See the implementations in `SnakObject::serialize` and `PropertyValueSnak::serialize`. Only properties that are used in these methods become part of the serialization.

This patch:
- Adds tests to make sure the `getHash` implementation is static and doesn't change, e.g. when new fields are introduced.
- Adds basic tests for `No`\- and `SomeValueSnak`.
- Removes strange self-comparisons from tests.
- Simplifies some loops.
- Renames some strange variables.
