### PR TITLE
Assert instanceof PropertyId

### DIFF
--- a/tests/unit/Snak/PropertyValueSnakTest.php
+++ b/tests/unit/Snak/PropertyValueSnakTest.php
@@ -28,7 +28,7 @@ class PropertyValueSnakTest extends SnakObjectTest {
 	public function constructorProvider() {
 		return array(
 			array( true, new PropertyId( 'P1' ), new StringValue( 'a' ) ),
-			array( true, new PropertyId( 'P9001' ), new StringValue( 'a' ) ),
+			array( true, new PropertyId( 'P9001' ), new StringValue( 'bc' ) ),
 		);
 	}
 

--- a/tests/unit/Snak/SnakObjectTest.php
+++ b/tests/unit/Snak/SnakObjectTest.php
@@ -115,8 +115,8 @@ abstract class SnakObjectTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetPropertyId( Snak $snak ) {
-		$id = $snak->getPropertyId();
-		$this->assertInstanceOf( 'Wikibase\DataModel\Entity\EntityId', $id );
+		$propertyId = $snak->getPropertyId();
+		$this->assertInstanceOf( 'Wikibase\DataModel\Entity\PropertyId', $propertyId );
 	}
 
 }


### PR DESCRIPTION
Another tiny split from #132.
1. Use two different strings with different lengths.
2. Why should a method called `getPropertyId` not return a `PropertyId`?
