### PR TITLE
Add getClaim method to Statement

### DIFF
--- a/src/Claim/Statement.php
+++ b/src/Claim/Statement.php
@@ -153,4 +153,13 @@ class Statement extends Claim {
 			&& $this->references->equals( $target->getReferences() );
 	}
 
+	/**
+	 * @since 1.0
+	 *
+	 * @return Claim
+	 */
+	public function getClaim() {
+		return $this;
+	}
+
 }

--- a/tests/unit/Claim/StatementTest.php
+++ b/tests/unit/Claim/StatementTest.php
@@ -258,4 +258,24 @@ class StatementTest extends ClaimTest {
 		$this->assertFalse( $statement->equals( $differentStatement ) );
 	}
 
+	public function testGetClaim() {
+		$qualifiers = new SnakList( array( new PropertyNoValueSnak( 23 ) ) );
+
+		$statement = new Statement(
+			new PropertyNoValueSnak( 42 ),
+			$qualifiers,
+			new ReferenceList( array(
+				new PropertyNoValueSnak( 1337 ),
+			) )
+		);
+		$statement->setGuid( '~=[,,_,,]:3' );
+
+		$claim = $statement->getClaim();
+		$this->assertInstanceOf( 'Wikibase\DataModel\Claim\Claim', $claim );
+
+		$this->assertEquals( '~=[,,_,,]:3', $claim->getGuid() );
+		$this->assertEquals( new PropertyNoValueSnak( 42 ), $claim->getMainSnak() );
+		$this->assertSame( $qualifiers, $claim->getQualifiers() );
+	}
+
 }


### PR DESCRIPTION
This is preparatory work for changing the relation between Claim and
Statement from inheritance to composition, as listed on
https://github.com/wmde/WikibaseDataModel/issues/22
