### PR TITLE
Add StatementList::isEmpty

### DIFF
--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -155,7 +155,7 @@ class StatementList implements \IteratorAggregate, \Comparable, \Countable {
 	 *
 	 * @param mixed $statementList
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function equals( $statementList ) {
 		if ( !( $statementList instanceof self ) ) {
@@ -181,6 +181,13 @@ class StatementList implements \IteratorAggregate, \Comparable, \Countable {
 		}
 
 		return true;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isEmpty() {
+		return empty( $this->statements );
 	}
 
 }

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -9,7 +9,6 @@ use Diff\DiffOp\DiffOpChange;
 use Diff\DiffOp\DiffOpRemove;
 use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Claim\Claims;
-use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Entity\Diff\ItemDiff;
 use Wikibase\DataModel\Entity\EntityIdValue;
 use Wikibase\DataModel\Entity\Item;
@@ -25,6 +24,7 @@ use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Snak\SnakList;
+use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 use Wikibase\DataModel\Term\Fingerprint;
 
@@ -707,10 +707,10 @@ class ItemTest extends EntityTest {
 		$statements = array( $statement0, $statement1 );
 
 		$item->setClaims( new Claims( $statements ) );
-		$this->assertSameSize( $statements, $item->getStatements(), "added some statements" );
+		$this->assertEquals( count( $statements ), $item->getStatements()->count(), "added some statements" );
 
 		$item->setClaims( new Claims() );
-		$this->assertCount( 0, $item->getStatements(), "should be empty again" );
+		$this->assertTrue( $item->getStatements()->isEmpty(), "should be empty again" );
 	}
 
 
@@ -783,7 +783,7 @@ class ItemTest extends EntityTest {
 		$this->assertEquals( new ItemId( 'Q42' ), $item->getId() );
 		$this->assertTrue( $item->getFingerprint()->isEmpty() );
 		$this->assertTrue( $item->getSiteLinkList()->isEmpty() );
-		$this->assertEmpty( $item->getStatements() );
+		$this->assertTrue( $item->getStatements()->isEmpty() );
 	}
 
 	public function testCanConstructWithStatementList() {
@@ -810,14 +810,14 @@ class ItemTest extends EntityTest {
 		$item->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
 
 		$item->setStatements( new StatementList() );
-		$this->assertEquals( new StatementList(), $item->getStatements() );
+		$this->assertTrue( $item->getStatements()->isEmpty() );
 	}
 
 	public function testGetStatementsReturnsCorrectTypeAfterClear() {
 		$item = Item::newEmpty();
 		$item->clear();
 
-		$this->assertEquals( new StatementList(), $item->getStatements() );
+		$this->assertTrue( $item->getStatements()->isEmpty() );
 	}
 
 	public function testItemsWithDifferentStatementsAreNotEqual() {

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -5,10 +5,10 @@ namespace Wikibase\Test;
 use DataValues\StringValue;
 use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Claim\Claims;
-use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Snak\SnakList;
+use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 
 /**
@@ -362,6 +362,20 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$secondStatements = new StatementList();
 
 		$this->assertFalse( $firstStatements->equals( $secondStatements ) );
+	}
+
+	public function testEmptyListIsEmpty() {
+		$list = new StatementList();
+
+		$this->assertTrue( $list->isEmpty() );
+	}
+
+	public function testNonEmptyListIsNotEmpty() {
+		$list = new StatementList( array(
+			$this->getStatementWithSnak( 1, 'foo' ),
+		));
+
+		$this->assertFalse( $list->isEmpty() );
 	}
 
 }


### PR DESCRIPTION
I wonder what `assertEmpty` and `assertSameSize` do on a `StatementList` object? Why does this fail for me but not on the server?
