### PR TITLE
Restore support for badges being null

### DIFF
--- a/src/SiteLink.php
+++ b/src/SiteLink.php
@@ -32,7 +32,7 @@ class SiteLink implements Comparable {
 	/**
 	 * @param string $siteId
 	 * @param string $pageName
-	 * @param ItemIdSet|ItemId[] $badges
+	 * @param ItemIdSet|ItemId[]|null $badges
 	 *
 	 * @throws InvalidArgumentException
 	 */
@@ -51,11 +51,12 @@ class SiteLink implements Comparable {
 	}
 
 	private function setBadges( $badges ) {
-		if ( is_array( $badges ) ) {
+		if ( $badges === null ) {
+			$badges = new ItemIdSet();
+		} elseif ( is_array( $badges ) ) {
 			$badges = new ItemIdSet( $badges );
-		}
-		elseif ( !( $badges instanceof ItemIdSet ) ) {
-			throw new InvalidArgumentException( '$badges needs to be ItemIdSet or ItemId[]' );
+		} elseif ( !( $badges instanceof ItemIdSet ) ) {
+			throw new InvalidArgumentException( '$badges needs to be ItemIdSet, ItemId[] or null' );
 		}
 
 		$this->badges = $badges;
@@ -97,9 +98,13 @@ class SiteLink implements Comparable {
 	 *
 	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function equals( $target ) {
+		if ( $target === $this ) {
+			return true;
+		}
+
 		if ( !( $target instanceof self ) ) {
 			return false;
 		}

--- a/tests/unit/SiteLinkTest.php
+++ b/tests/unit/SiteLinkTest.php
@@ -98,6 +98,8 @@ class SiteLinkTest extends \PHPUnit_Framework_TestCase {
 	public function badgesProvider() {
 		$argLists = array();
 
+		$argLists[] = array( null, array() );
+
 		$badges = array();
 		$expected = array_values( $badges );
 
@@ -147,7 +149,6 @@ class SiteLinkTest extends \PHPUnit_Framework_TestCase {
 		$argLists[] = array( 42 );
 		$argLists[] = array( true );
 		$argLists[] = array( 'nyan nyan' );
-		$argLists[] = array( null );
 
 		return $argLists;
 	}


### PR DESCRIPTION
I'm not sure what changed but this seems to be the easiest way to fix an actual bug in the current Wikibase master. Adding a SiteLink sometimes fails because $badges is null. It's null because of the way the Diff operations work. I think it's perfectly valid to allow null. That's why I'm proposing this patch.
