### PR TITLE
Fix Item::patchSiteLinks

### DIFF
--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -262,18 +262,26 @@ class Item extends Entity {
 		$this->siteLinks = new SiteLinkList();
 
 		foreach ( $links as $siteId => $linkData ) {
-			if ( array_key_exists( 'name', $linkData ) ) {
-				$this->siteLinks->addSiteLink( new SiteLink(
-					$siteId,
-					$linkData['name'],
-					array_map(
-						function( $idSerialization ) {
-							return new ItemId( $idSerialization );
-						},
-						$linkData['badges']
-					)
-				) );
+			if ( !isset( $linkData['name'] ) ) {
+				continue;
 			}
+
+			$badges = array();
+
+			if ( is_array( $linkData['badges'] ) ) {
+				$badges = array_map(
+					function( $idSerialization ) {
+						return new ItemId( $idSerialization );
+					},
+					$linkData['badges']
+				);
+			}
+
+			$this->siteLinks->addSiteLink( new SiteLink(
+				$siteId,
+				$linkData['name'],
+				$badges
+			) );
 		}
 	}
 


### PR DESCRIPTION
The `'badges'` array key is not guaranteed to be set because of the way the diff algorithm in `EditEntity::fixEditConflict` works.

This fixes the same bug as #179 but does not invalidate the other patch. I suggest to merge both.
