### PR TITLE
Improve getId type hints

### DIFF
--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -82,6 +82,15 @@ class Item extends Entity {
 	}
 
 	/**
+	 * @since 0.1 return type changed in 0.3
+	 *
+	 * @return ItemId|null
+	 */
+	public function getId() {
+		return $this->id;
+	}
+
+	/**
 	 * @since 0.8
 	 *
 	 * @return SiteLinkList

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -69,6 +69,15 @@ class Property extends Entity {
 	}
 
 	/**
+	 * @since 0.1 return type changed in 0.3
+	 *
+	 * @return PropertyId|null
+	 */
+	public function getId() {
+		return $this->id;
+	}
+
+	/**
 	 * @since 0.4
 	 *
 	 * @param string $dataTypeId


### PR DESCRIPTION
$item->getId()->getNumericId() is a valid non-deprecated call. Since
the type hint currently is `@return EntityId`, ids don't recognize the
last method.
