### PR TITLE
Create initial version of ByPropertyIdGrouper

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,7 @@
 * The `Statement` constructor now also accepts a `Claim` parameter
 * Added `Statement::setClaim`
 * Added `PropertyIdProvider` interface
+* Added `ByPropertyIdGrouper`
 
 ## Version 1.0 (2014-09-02)
 

--- a/src/ByPropertyIdGrouper.php
+++ b/src/ByPropertyIdGrouper.php
@@ -51,6 +51,7 @@ class ByPropertyIdGrouper {
 
 	private function addPropertyIdProvider( PropertyIdProvider $propertyIdProvider ) {
 		$idSerialization = $propertyIdProvider->getPropertyId()->getSerialization();
+
 		if ( isset( $this->byPropertyId[$idSerialization] ) ) {
 			$this->byPropertyId[$idSerialization][] = $propertyIdProvider;
 		} else {
@@ -67,9 +68,11 @@ class ByPropertyIdGrouper {
 	 */
 	public function getPropertyIds() {
 		$propertyIds = array_keys( $this->byPropertyId );
+
 		array_walk( $propertyIds, function( &$propertyId ) {
 			$propertyId = new PropertyId( $propertyId );
 		} );
+
 		return $propertyIds;
 	}
 
@@ -84,6 +87,7 @@ class ByPropertyIdGrouper {
 	 */
 	public function getByPropertyId( PropertyId $propertyId ) {
 		$idSerialization = $propertyId->getSerialization();
+
 		if ( !isset( $this->byPropertyId[$idSerialization] ) ) {
 			throw new OutOfBoundsException( 'Property id does not exist.' );
 		}

--- a/tests/unit/ByPropertyIdGrouperTest.php
+++ b/tests/unit/ByPropertyIdGrouperTest.php
@@ -2,8 +2,10 @@
 
 namespace Wikibase\DataModel\Test;
 
+use OutOfBoundsException;
 use Wikibase\DataModel\ByPropertyIdGrouper;
 use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\PropertyIdProvider;
 
 /**
  * @covers Wikibase\DataModel\ByPropertyIdGrouper
@@ -16,15 +18,15 @@ class ByPropertyIdGrouperTest extends \PHPUnit_Framework_TestCase {
 	public function provideGetPropertyIds() {
 		$cases = array();
 
-		$cases[] = array(
+		$cases['empty list'] = array(
 			array(),
 			array()
 		);
 
-		$cases[] = array(
+		$cases['some property ids'] = array(
 			array(
-				$this->getPropertyIdProvider( 'P42' ),
-				$this->getPropertyIdProvider( 'P23' )
+				$this->getPropertyIdProviderMock( 'P42' ),
+				$this->getPropertyIdProviderMock( 'P23' )
 			),
 			array(
 				new PropertyId( 'P42' ),
@@ -32,14 +34,8 @@ class ByPropertyIdGrouperTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
-		$cases[] = array(
-			array(
-				$this->getPropertyIdProvider( 'P42' ),
-				$this->getPropertyIdProvider( 'P23' ),
-				$this->getPropertyIdProvider( 'P15' ),
-				$this->getPropertyIdProvider( 'P42' ),
-				$this->getPropertyIdProvider( 'P10' )
-			),
+		$cases['duplicate property ids'] = array(
+			$this->getPropertyIdProviders(),
 			array(
 				new PropertyId( 'P42' ),
 				new PropertyId( 'P23' ),
@@ -63,11 +59,107 @@ class ByPropertyIdGrouperTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( $expectedPropertyIds, $propertyIds );
 	}
 
-	private function getPropertyIdProvider( $propertyId ) {
-		$propertyIdProvider = $this->getMock( 'Wikibase\DataModel\PropertyIdProvider' );
+	public function provideGetByPropertyId() {
+		$cases = array();
+
+		$propertyIdProviders = $this->getPropertyIdProviders();
+
+		$cases[] = array(
+			$propertyIdProviders,
+			'P42',
+			array( 'abc', 'jkl' )
+		);
+
+		$cases[] = array(
+			$propertyIdProviders,
+			'P23',
+			array( 'def' )
+		);
+
+		return $cases;
+	}
+
+	/**
+	 * @dataProvider provideGetByPropertyId
+	 *
+	 * @param PropertyIdProvider[] $propertyIdProviders
+	 * @param string $propertyId
+	 * @param string[] $expectedValues
+	 */
+	public function testGetByPropertyId( array $propertyIdProviders, $propertyId, array $expectedValues ) {
+		$byPropertyIdGrouper = new ByPropertyIdGrouper( $propertyIdProviders );
+		$values = $byPropertyIdGrouper->getByPropertyId( new PropertyId( $propertyId ) );
+		array_walk( $values, function( &$value ) {
+			$value = $value->getType();
+		} );
+		$this->assertEquals( $expectedValues, $values );
+	}
+
+	/**
+	 * @expectedException OutOfBoundsException
+	 */
+	public function testGetByPropertyIdThrowsException() {
+		$byPropertyIdGrouper = new ByPropertyIdGrouper( $this->getPropertyIdProviders() );
+		$byPropertyIdGrouper->getByPropertyId( new PropertyId( 'P11' ) );
+	}
+
+	public function provideHasPropertyId() {
+		$cases = array();
+
+		$propertyIdProviders = $this->getPropertyIdProviders();
+
+		$cases[] = array( $propertyIdProviders, 'P42', true );
+		$cases[] = array( $propertyIdProviders, 'P23', true );
+		$cases[] = array( $propertyIdProviders, 'P15', true );
+		$cases[] = array( $propertyIdProviders, 'P10', true );
+		$cases[] = array( $propertyIdProviders, 'P11', false );
+		
+
+		return $cases;
+	}
+
+	/**
+	 * @dataProvider provideHasPropertyId
+	 *
+	 * @param PropertyIdProvider[] $propertyIdProviders
+	 * @param string $propertyId
+	 * @param boolean $expectedValue
+	 */
+	public function testHasPropertyId( array $propertyIdProviders, $propertyId, $expectedValue ) {
+		$byPropertyIdGrouper = new ByPropertyIdGrouper( $propertyIdProviders );
+		$this->assertEquals( $expectedValue, $byPropertyIdGrouper->hasPropertyId( new PropertyId( $propertyId ) ) );
+	}
+
+	/**
+	 * @return PropertyIdProvider[]
+	 */
+	private function getPropertyIdProviders() {
+		return array(
+			$this->getPropertyIdProviderMock( 'P42', 'abc' ),
+			$this->getPropertyIdProviderMock( 'P23', 'def' ),
+			$this->getPropertyIdProviderMock( 'P15', 'ghi' ),
+			$this->getPropertyIdProviderMock( 'P42', 'jkl' ),
+			$this->getPropertyIdProviderMock( 'P10', 'mno' )
+		);
+	}
+
+	/**
+	 * Creates a PropertyIdProvider mock which can return a value.
+	 *
+	 * @param string $propertyId
+	 * @param string|null $type
+	 * @return PropertyIdProvider
+	 */
+	private function getPropertyIdProviderMock( $propertyId, $type = null ) {
+		$propertyIdProvider = $this->getMock( 'Wikibase\DataModel\Snak\Snak' );
+
 		$propertyIdProvider->expects( $this->any() )
 			->method( 'getPropertyId' )
 			->will( $this->returnValue( new PropertyId( $propertyId ) ) );
+
+		$propertyIdProvider->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( $type ) );
 
 		return $propertyIdProvider;
 	}


### PR DESCRIPTION
This is some initial idea to fix #190. It aims to be a lightweight alternative to `ByPropertyIdArray` by not providing any editing methods but only indexing and querying the data.
### TODO
- Finish tests
- Use in #198
