### PR TITLE
Include statements in Property diffing

### DIFF
--- a/src/Entity/Diff/ItemDiffer.php
+++ b/src/Entity/Diff/ItemDiffer.php
@@ -19,6 +19,21 @@ use Wikibase\DataModel\Statement\StatementListDiffer;
 class ItemDiffer implements EntityDifferStrategy {
 
 	/**
+	 * @var MapDiffer
+	 */
+	private $recursiveMapDiffer;
+
+	/**
+	 * @var StatementListDiffer
+	 */
+	private $statementListDiffer;
+
+	public function __construct() {
+		$this->recursiveMapDiffer = new MapDiffer( true );
+		$this->statementListDiffer = new StatementListDiffer();
+	}
+
+	/**
 	 * @param string $entityType
 	 *
 	 * @return bool
@@ -48,11 +63,12 @@ class ItemDiffer implements EntityDifferStrategy {
 	}
 
 	public function diffItems( Item $from, Item $to ) {
-		$differ = new MapDiffer( true );
-		$diffOps = $differ->doDiff( $this->toDiffArray( $from ), $this->toDiffArray( $to ) );
+		$diffOps = $this->recursiveMapDiffer->doDiff(
+			$this->toDiffArray( $from ),
+			$this->toDiffArray( $to )
+		);
 
-		$statementListDiffer = new StatementListDiffer();
-		$diffOps['claim'] = $statementListDiffer->getDiff( $from->getStatements(), $to->getStatements() );
+		$diffOps['claim'] = $this->statementListDiffer->getDiff( $from->getStatements(), $to->getStatements() );
 
 		return new ItemDiff( $diffOps );
 	}

--- a/src/Entity/Diff/PropertyDiffer.php
+++ b/src/Entity/Diff/PropertyDiffer.php
@@ -6,6 +6,8 @@ use Diff\Differ\MapDiffer;
 use InvalidArgumentException;
 use Wikibase\DataModel\Entity\EntityDocument;
 use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Statement\StatementList;
+use Wikibase\DataModel\Statement\StatementListDiffer;
 
 /**
  * @since 1.0
@@ -14,6 +16,21 @@ use Wikibase\DataModel\Entity\Property;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class PropertyDiffer implements EntityDifferStrategy {
+
+	/**
+	 * @var MapDiffer
+	 */
+	private $recursiveMapDiffer;
+
+	/**
+	 * @var StatementListDiffer
+	 */
+	private $statementListDiffer;
+
+	public function __construct() {
+		$this->recursiveMapDiffer = new MapDiffer( true );
+		$this->statementListDiffer = new StatementListDiffer();
+	}
 
 	/**
 	 * @param string $entityType
@@ -45,14 +62,18 @@ class PropertyDiffer implements EntityDifferStrategy {
 	}
 
 	public function diffProperties( Property $from, Property $to ) {
-		return $this->diffPropertyArrays( $this->toDiffArray( $from ), $this->toDiffArray( $to ) );
+		$diffOps = $this->diffPropertyArrays(
+			$this->toDiffArray( $from ),
+			$this->toDiffArray( $to )
+		);
+
+		$diffOps['claim'] = $this->statementListDiffer->getDiff( $from->getStatements(), $to->getStatements() );
+
+		return new EntityDiff( $diffOps );
 	}
 
 	private function diffPropertyArrays( array $from, array $to ) {
-		$differ = new MapDiffer( true );
-		$diffOps = $differ->doDiff( $from, $to );
-
-		return new EntityDiff( $diffOps );
+		return $this->recursiveMapDiffer->doDiff( $from, $to );
 	}
 
 	private function toDiffArray( Property $item ) {
@@ -73,7 +94,11 @@ class PropertyDiffer implements EntityDifferStrategy {
 	 */
 	public function getConstructionDiff( EntityDocument $entity ) {
 		$this->assertIsProperty( $entity );
-		return $this->diffPropertyArrays( array(), $this->toDiffArray( $entity ) );
+
+		$diffOps = $this->diffPropertyArrays( array(), $this->toDiffArray( $entity ) );
+		$diffOps['claim'] = $this->statementListDiffer->getDiff( new StatementList(), $entity->getStatements() );
+
+		return new EntityDiff( $diffOps );
 	}
 
 	/**
@@ -84,7 +109,11 @@ class PropertyDiffer implements EntityDifferStrategy {
 	 */
 	public function getDestructionDiff( EntityDocument $entity ) {
 		$this->assertIsProperty( $entity );
-		return $this->diffPropertyArrays( $this->toDiffArray( $entity ), array() );
+
+		$diffOps = $this->diffPropertyArrays( $this->toDiffArray( $entity ), array() );
+		$diffOps['claim'] = $this->statementListDiffer->getDiff( $entity->getStatements(), new StatementList() );
+
+		return new EntityDiff( $diffOps );
 	}
 
 }

--- a/tests/unit/Entity/Diff/ItemDifferTest.php
+++ b/tests/unit/Entity/Diff/ItemDifferTest.php
@@ -61,9 +61,7 @@ class ItemDifferTest extends \PHPUnit_Framework_TestCase {
 		$firstItem = Item::newEmpty();
 
 		$secondItem = Item::newEmpty();
-		$statement = new Statement( new PropertySomeValueSnak( 42 ) );
-		$statement->setGuid( 'kittens' );
-		$secondItem->addClaim( $statement );
+		$secondItem->getStatements()->addNewStatement( new PropertySomeValueSnak( 42 ), null, null, 'guid' );
 
 		$differ = new ItemDiffer();
 		$diff = $differ->diffItems( $firstItem, $secondItem );

--- a/tests/unit/Entity/Diff/PropertyDifferTest.php
+++ b/tests/unit/Entity/Diff/PropertyDifferTest.php
@@ -4,6 +4,8 @@ namespace Wikibase\Test;
 
 use Wikibase\DataModel\Entity\Diff\PropertyDiffer;
 use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Snak\PropertySomeValueSnak;
+use Wikibase\DataModel\Statement\Statement;
 
 /**
  * @covers Wikibase\DataModel\Entity\Diff\PropertyDiffer
@@ -21,6 +23,18 @@ class PropertyDifferTest extends \PHPUnit_Framework_TestCase {
 	public function testGivenPropertyWithOnlyType_destructionDiffIsEmpty() {
 		$differ = new PropertyDiffer();
 		$this->assertTrue( $differ->getDestructionDiff( Property::newFromType( 'string' ) )->isEmpty() );
+	}
+
+	public function testClaimsAreDiffed() {
+		$firstProperty = Property::newFromType( 'kittens' );
+
+		$secondProperty = Property::newFromType( 'kittens' );
+		$secondProperty->getStatements()->addNewStatement( new PropertySomeValueSnak( 42 ), null, null, 'guid' );
+
+		$differ = new PropertyDiffer();
+		$diff = $differ->diffProperties( $firstProperty, $secondProperty );
+
+		$this->assertCount( 1, $diff->getClaimsDiff()->getAdditions() );
 	}
 
 }


### PR DESCRIPTION
This commit also moves the construction of the used sub differs
to the constructor of their users, so they do not get constructed
on every diff call.
