### PR TITLE
Show better error for "wrong" objects in HashArray

### DIFF
--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -413,8 +413,11 @@ abstract class HashArray extends \ArrayObject implements \Hashable, \Comparable 
 	 */
 	protected function setElement( $index, $value ) {
 		if ( !$this->hasValidType( $value ) ) {
+			$type = is_object( $value ) ? get_class( $value ) : gettype( $value );
+
 			throw new InvalidArgumentException(
-				'Can only add ' . $this->getObjectType() . ' implementing objects to ' . get_called_class() . '.'
+				'Can only add ' . $this->getObjectType() . ' implementing objects to ' . get_called_class() . ', ' .
+				'but found a ' . $type . ' instead'
 			);
 		}
 


### PR DESCRIPTION
The error message now includes the actual type of the object,
not just the expected class. This is intended to help us track
down https://bugzilla.wikimedia.org/show_bug.cgi?id=71479
