### PR TITLE
Call getQualifiers and getReferences outside of iterator_to_array

### DIFF
--- a/src/Claim/Claim.php
+++ b/src/Claim/Claim.php
@@ -190,7 +190,8 @@ class Claim implements Hashable, Comparable, PropertyIdProvider {
 		$snaks = array();
 
 		$snaks[] = $this->getMainSnak();
-		$snaks = array_merge( $snaks, iterator_to_array( $this->getQualifiers() ) );
+		$qualifiers = $this->getQualifiers();
+		$snaks = array_merge( $snaks, iterator_to_array( $qualifiers ) );
 
 		return $snaks;
 	}

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -141,7 +141,8 @@ class Statement extends Claim {
 
 		/* @var Reference $reference */
 		foreach( $this->getReferences() as $reference ) {
-			$snaks = array_merge( $snaks, iterator_to_array( $reference->getSnaks() ) );
+			$referenceSnaks = $reference->getSnaks();
+			$snaks = array_merge( $snaks, iterator_to_array( $referenceSnaks ) );
 		}
 
 		return $snaks;


### PR DESCRIPTION
In the getAllSnaks calls in Claim and Statement, it seems in some situations that the Traversable objects are being converted to array, by reference, in the ReferenceList itself and possibly for qualifiers also.

This change may help fix bug 71519.
