### PR TITLE
More efficient EntityId construction

### DIFF
--- a/src/Entity/BasicEntityIdParser.php
+++ b/src/Entity/BasicEntityIdParser.php
@@ -15,7 +15,7 @@ class BasicEntityIdParser implements EntityIdParser {
 	/**
 	 * @param string $idSerialization
 	 *
-	 * @return mixed
+	 * @return ItemId|PropertyId
 	 * @throws EntityIdParsingException
 	 */
 	public function parse( $idSerialization ) {

--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -48,20 +48,16 @@ class EntityId implements Comparable, Serializable {
 	}
 
 	private function setIdSerialization( $idSerialization ) {
-		if ( is_int( $idSerialization ) ) {
-			$idSerialization = $this->replaceNumericIdArgument( $idSerialization );
-		}
-
-		if ( !is_string( $idSerialization ) ) {
+		if ( is_string( $idSerialization ) ) {
+			$this->serialization = strtoupper( $idSerialization );
+		} elseif ( is_int( $idSerialization ) ) {
+			$this->serialization = LegacyIdInterpreter::newIdFromTypeAndNumber(
+				$this->entityType,
+				$idSerialization
+			)->getSerialization();
+		} else {
 			throw new InvalidArgumentException( '$idSerialization needs to be a string' );
 		}
-
-		$this->serialization = strtoupper( $idSerialization );
-	}
-
-	private function replaceNumericIdArgument( $numericId ) {
-		return LegacyIdInterpreter::newIdFromTypeAndNumber( $this->entityType, $numericId )
-			->getSerialization();
 	}
 
 	/**


### PR DESCRIPTION
The EntityId construction popped up in my profiling. No, it's not a bottleneck. Just called a lot of times. Which sums up a bit.

This actually changes:
- Inline one one-line private method.
- Check for string first (should be the most relevant case) and shorten out.
- What the legacy interpreter does is accepted and neither checked nor uppercased.
