### PR TITLE
Do not return stuff on unserialize

### DIFF
--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -127,8 +127,6 @@ class EntityId implements Comparable, Serializable {
 	 * @see Serializable::unserialize
 	 *
 	 * @param string $value
-	 *
-	 * @return EntityId
 	 */
 	public function unserialize( $value ) {
 		list( $entityType, $serialization ) = json_decode( $value );

--- a/src/Entity/EntityIdValue.php
+++ b/src/Entity/EntityIdValue.php
@@ -54,7 +54,6 @@ class EntityIdValue extends DataValueObject {
 	 *
 	 * @param string $value
 	 *
-	 * @return EntityId
 	 * @throws IllegalValueException
 	 */
 	public function unserialize( $value ) {
@@ -155,6 +154,5 @@ class EntityIdValue extends DataValueObject {
 
 		return new static( $id );
 	}
-
 
 }

--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -446,8 +446,6 @@ abstract class HashArray extends \ArrayObject implements \Hashable, \Comparable 
 	 * @see Serializable::unserialize
 	 *
 	 * @param string $serialization
-	 *
-	 * @return array
 	 */
 	public function unserialize( $serialization ) {
 		$serializationData = unserialize( $serialization );
@@ -459,8 +457,6 @@ abstract class HashArray extends \ArrayObject implements \Hashable, \Comparable 
 		}
 
 		$this->indexOffset = $serializationData['index'];
-
-		return $serializationData;
 	}
 
 	/**

--- a/src/Snak/PropertyValueSnak.php
+++ b/src/Snak/PropertyValueSnak.php
@@ -62,8 +62,6 @@ class PropertyValueSnak extends SnakObject {
 	 * @since 0.1
 	 *
 	 * @param string $serialized
-	 *
-	 * @return PropertyValueSnak
 	 */
 	public function unserialize( $serialized ) {
 		list( $propertyId, $dataValue ) = unserialize( $serialized );

--- a/src/Snak/SnakObject.php
+++ b/src/Snak/SnakObject.php
@@ -113,8 +113,6 @@ abstract class SnakObject implements Snak {
 	 * @since 0.1
 	 *
 	 * @param string $serialized
-	 *
-	 * @return Snak
 	 */
 	public function unserialize( $serialized ) {
 		$this->propertyId = PropertyId::newFromNumber( unserialize( $serialized ) );


### PR DESCRIPTION
This fixes #217.

I did some regex searches in our code base and could not find a place where `unserialize` is called and expected to have a return value (I tried to search for stuff like `... = ...->unserialize( ... )` as well as `...( ...->unserialize( ... )`).

Also see https://github.com/wmde/Diff/pull/15.
