### PR TITLE
Draft of how we can change EntityId

### DIFF
--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -3,9 +3,7 @@
 namespace Wikibase\DataModel\Entity;
 
 use Comparable;
-use InvalidArgumentException;
 use Serializable;
-use Wikibase\DataModel\LegacyIdInterpreter;
 
 /**
  * @since 0.5
@@ -13,59 +11,14 @@ use Wikibase\DataModel\LegacyIdInterpreter;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com
  */
-class EntityId implements Comparable, Serializable {
+abstract class EntityId implements Comparable, Serializable {
 
-	protected $entityType;
 	protected $serialization;
-
-	/**
-	 * Construct a derivative such as ItemId or PropertyId directly.
-	 * In the long term this class is meant to become abstract.
-	 *
-	 * The second argument, $idSerialization, should be the entire
-	 * id serialization. For compatibility reasons this also accepts
-	 * the numeric part for item and property ids. This is however
-	 * highly deprecated.
-	 *
-	 * Derivatives are allowed (and required) to use this constructor.
-	 *
-	 * @param string $entityType
-	 * @param string|int $idSerialization
-	 *
-	 * @throws InvalidArgumentException
-	 */
-	protected function __construct( $entityType, $idSerialization ) {
-		$this->setEntityType( $entityType );
-		$this->setIdSerialization( $idSerialization );
-	}
-
-	private function setEntityType( $entityType ) {
-		if ( !is_string( $entityType ) ) {
-			throw new InvalidArgumentException( '$entityType needs to be a string' );
-		}
-
-		$this->entityType = $entityType;
-	}
-
-	private function setIdSerialization( $idSerialization ) {
-		if ( is_string( $idSerialization ) ) {
-			$this->serialization = strtoupper( $idSerialization );
-		} elseif ( is_int( $idSerialization ) ) {
-			$this->serialization = LegacyIdInterpreter::newIdFromTypeAndNumber(
-				$this->entityType,
-				$idSerialization
-			)->getSerialization();
-		} else {
-			throw new InvalidArgumentException( '$idSerialization needs to be a string' );
-		}
-	}
 
 	/**
 	 * @return string
 	 */
-	public function getEntityType() {
-		return $this->entityType;
-	}
+	public abstract function getEntityType();
 
 	/**
 	 * @return string
@@ -108,33 +61,6 @@ class EntityId implements Comparable, Serializable {
 	public function equals( $target ) {
 		return $target instanceof self
 			&& $target->serialization === $this->serialization;
-	}
-
-	/**
-	 * @see Serializable::serialize
-	 *
-	 * @return string
-	 */
-	public function serialize() {
-		return json_encode( array( $this->entityType, $this->serialization ) );
-	}
-
-	/**
-	 * @see Serializable::unserialize
-	 *
-	 * @param string $value
-	 */
-	public function unserialize( $value ) {
-		list( $entityType, $serialization ) = json_decode( $value );
-
-		// Compatibility with < 0.5.
-		// Numeric ids where stored in the serialization.
-		// Pass explicitly as int, so it is recognized properly.
-		if ( ctype_digit( $serialization ) ) {
-			$serialization = (int)$serialization;
-		}
-
-		self::__construct( $entityType, $serialization );
 	}
 
 }

--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -21,11 +21,7 @@ class ItemId extends EntityId {
 	 */
 	public function __construct( $idSerialization ) {
 		$this->assertValidIdFormat( $idSerialization );
-
-		parent::__construct(
-			Item::ENTITY_TYPE,
-			 $idSerialization
-		);
+		$this->serialization = strtoupper( $idSerialization );
 	}
 
 	protected function assertValidIdFormat( $idSerialization ) {
@@ -43,6 +39,48 @@ class ItemId extends EntityId {
 	 */
 	public function getNumericId() {
 		return (int)substr( $this->serialization, 1 );
+	}
+
+	/**
+	 * @see Comparable::equals
+	 *
+	 * @since 0.5
+	 *
+	 * @param mixed $target
+	 *
+	 * @return boolean
+	 */
+	public function equals( $target ) {
+		return $target instanceof self
+			&& $target->serialization === $this->serialization;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getEntityType() {
+		return 'item';
+	}
+
+	/**
+	 * @see Serializable::serialize
+	 *
+	 * @return string
+	 */
+	public function serialize() {
+		return json_encode( array( 'item', $this->serialization ) );
+	}
+
+	/**
+	 * @see Serializable::unserialize
+	 *
+	 * @param string $value
+	 *
+	 * @return EntityId
+	 */
+	public function unserialize( $value ) {
+		list( , $serialization ) = json_decode( $value );
+		self::__construct( $serialization );
 	}
 
 	/**

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -21,11 +21,7 @@ class PropertyId extends EntityId {
 	 */
 	public function __construct( $idSerialization ) {
 		$this->assertValidIdFormat( $idSerialization );
-
-		parent::__construct(
-			Property::ENTITY_TYPE,
-			$idSerialization
-		);
+		$this->serialization = strtoupper( $idSerialization );
 	}
 
 	protected function assertValidIdFormat( $idSerialization ) {
@@ -43,6 +39,48 @@ class PropertyId extends EntityId {
 	 */
 	public function getNumericId() {
 		return (int)substr( $this->serialization, 1 );
+	}
+
+	/**
+	 * @see Comparable::equals
+	 *
+	 * @since 0.5
+	 *
+	 * @param mixed $target
+	 *
+	 * @return boolean
+	 */
+	public function equals( $target ) {
+		return $target instanceof self
+			&& $target->serialization === $this->serialization;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getEntityType() {
+		return 'property';
+	}
+
+	/**
+	 * @see Serializable::serialize
+	 *
+	 * @return string
+	 */
+	public function serialize() {
+		return json_encode( array( 'property', $this->serialization ) );
+	}
+
+	/**
+	 * @see Serializable::unserialize
+	 *
+	 * @param string $value
+	 *
+	 * @return EntityId
+	 */
+	public function unserialize( $value ) {
+		list( , $serialization ) = json_decode( $value );
+		self::__construct( $serialization );
 	}
 
 	/**

--- a/tests/unit/Entity/EntityIdTest.php
+++ b/tests/unit/Entity/EntityIdTest.php
@@ -50,19 +50,6 @@ class EntityIdTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( $id, unserialize( serialize( $id ) ) );
 	}
 
-	public function testDeserializationCompatibility() {
-		$v04serialization = 'C:17:"Wikibase\EntityId":12:{["item",123]}';
-
-		$id = new ItemId( 'q123' );
-		$this->assertTrue( $id->equals( unserialize( $v04serialization ) ) );
-
-		$v05serialization = 'C:32:"Wikibase\DataModel\Entity\ItemId":15:{["item","Q123"]}';
-
-		$this->assertEquals(
-			new ItemId( 'q123' ),
-			unserialize( $v05serialization )
-		);
-	}
 
 	/**
 	 * This test will change when the serialization format changes.


### PR DESCRIPTION
DO NOT MERGE.

This is a breaking change that drops insatiability of `EntityId` and support for some of the very old serialization formats.
