### PR TITLE
Use full class names instead of aliases

### DIFF
--- a/tests/unit/ByPropertyIdArrayTest.php
+++ b/tests/unit/ByPropertyIdArrayTest.php
@@ -5,15 +5,15 @@ namespace Wikibase\Test;
 use DataValues\StringValue;
 use ReflectionClass;
 use ReflectionMethod;
-use Wikibase\Claims;
 use Wikibase\DataModel\ByPropertyIdArray;
 use Wikibase\DataModel\Claim\Claim;
-use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Snak\Snak;
+use Wikibase\DataModel\Statement\Statement;
 
 /**
  * @covers Wikibase\DataModel\ByPropertyIdArray

--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -74,7 +74,7 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 	public function testConstructorError() {
 		$this->setExpectedException( 'InvalidArgumentException' );
 
-		$class = new ReflectionClass( 'Wikibase\Claims' );
+		$class = new ReflectionClass( 'Wikibase\DataModel\Claim\Claims' );
 		$class->newInstanceArgs( func_get_args() );
 	}
 
@@ -397,7 +397,7 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSameSize( $claims, $snaks );
 
 		foreach ( $snaks as $guid => $snak ) {
-			$this->assertInstanceOf( 'Wikibase\Snak', $snak );
+			$this->assertInstanceOf( 'Wikibase\DataModel\Snak\Snak', $snak );
 			$this->assertTrue( $claims->hasClaimWithGuid( $guid ) );
 		}
 	}
@@ -452,15 +452,15 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 		) );
 
 		$matches = $claims->getClaimsForProperty( new PropertyId( 'P42' ) );
-		$this->assertInstanceOf( 'Wikibase\Claims', $claims );
+		$this->assertInstanceOf( 'Wikibase\DataModel\Claim\Claims', $claims );
 		$this->assertCount( 2, $matches );
 
 		$matches = $claims->getClaimsForProperty( new PropertyId( 'P23' ) );
-		$this->assertInstanceOf( 'Wikibase\Claims', $claims );
+		$this->assertInstanceOf( 'Wikibase\DataModel\Claim\Claims', $claims );
 		$this->assertCount( 1, $matches );
 
 		$matches = $claims->getClaimsForProperty( new PropertyId( 'P9000' ) );
-		$this->assertInstanceOf( 'Wikibase\Claims', $claims );
+		$this->assertInstanceOf( 'Wikibase\DataModel\Claim\Claims', $claims );
 		$this->assertCount( 0, $matches );
 	}
 

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -43,7 +43,7 @@ class PropertyTest extends EntityTest {
 
 	public function testNewFromType() {
 		$property = Property::newFromType( 'string' );
-		$this->assertInstanceOf( 'Wikibase\Property', $property );
+		$this->assertInstanceOf( 'Wikibase\DataModel\Entity\Property', $property );
 		$this->assertEquals( 'string', $property->getDataTypeId() );
 	}
 


### PR DESCRIPTION
This is the simple, easy to merge stuff split from #218.
