### PR TITLE
Add more equals tests for Property

### DIFF
--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -132,9 +132,7 @@ class Property extends Entity {
 	 * @see Comparable::equals
 	 *
 	 * Two items are considered equal if they are of the same
-	 * type and have the same value. The value does not include
-	 * the id, so entities with the same value but different id
-	 * are considered equal.
+	 * type and have the same value.
 	 *
 	 * @since 0.1
 	 *
@@ -143,21 +141,19 @@ class Property extends Entity {
 	 * @return boolean
 	 */
 	public function equals( $that ) {
-		if ( $that === $this ) {
+		if ( $this === $that ) {
 			return true;
 		}
 
-		if ( !( $that instanceof self ) ) {
+		if ( !( $that instanceof self )
+			|| is_null( $this->id ) !== is_null( $that->id )
+			|| ( $this->id !== null && !$this->id->equals( $that->id ) )
+		) {
 			return false;
 		}
 
-		return $this->fieldsEqual( $that );
-	}
-
-	private function fieldsEqual( Property $that ) {
-		return ( $this->id === null && $that->id === null || $this->id->equals( $that->id ) )
+		return $this->dataTypeId == $that->dataTypeId
 			&& $this->fingerprint->equals( $that->fingerprint )
-			&& $this->dataTypeId == $that->dataTypeId
 			&& $this->statements->equals( $that->statements );
 	}
 

--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -6,12 +6,13 @@ use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpChange;
 use Diff\DiffOp\DiffOpRemove;
-use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Entity\Diff\EntityDiff;
 use Wikibase\DataModel\Entity\Entity;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
+use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;
 use Wikibase\DataModel\Term\Fingerprint;
@@ -34,7 +35,7 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * Returns several more or less complex claims
 	 *
-	 * @return array
+	 * @return Claim[]
 	 */
 	public abstract function makeClaims();
 
@@ -251,7 +252,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider aliasesProvider
 	 */
 	public function testSetAllAliases( array $aliasGroups ) {
-
 		$entity = $this->getNewEmpty();
 		$entity->addAliases( 'zh' , array( 'qwertyuiop123' , '321poiuytrewq' ) );
 
@@ -524,7 +524,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 	 * @param EntityDiff $expected
 	 */
 	public function testDiffEntities( Entity $entity0, Entity $entity1, EntityDiff $expected ) {
-
 		$actual = $entity0->getDiff( $entity1 );
 
 		$this->assertInstanceOf( 'Wikibase\DataModel\Entity\Diff\EntityDiff', $actual );
@@ -638,7 +637,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGivenEmptyFingerprint_noTermsAreSet() {
 		$entity = $this->getNewEmpty();
-
 		$entity->setFingerprint( Fingerprint::newEmpty() );
 
 		$this->assertHasNoTerms( $entity );
@@ -676,9 +674,7 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$entity = $this->getNewEmpty();
-
 		$entity->setFingerprint( $fingerprint );
-
 		$newFingerprint = $entity->getFingerprint();
 
 		$this->assertEquals( $fingerprint, $newFingerprint );

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -13,7 +13,6 @@ use Wikibase\DataModel\Entity\Diff\ItemDiff;
 use Wikibase\DataModel\Entity\EntityIdValue;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\ItemId;
-use Wikibase\DataModel\Entity\ItemIdSet;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\ReferenceList;
@@ -52,7 +51,7 @@ class ItemTest extends EntityTest {
 	/**
 	 * Returns several more or less complex claims
 	 *
-	 * @return array
+	 * @return Claim[]
 	 */
 	public function makeClaims() {
 		$id9001 = new EntityIdValue( new ItemId( 'q9001' ) );
@@ -702,9 +701,9 @@ class ItemTest extends EntityTest {
 
 	public function equalsProvider() {
 		$firstItem = Item::newEmpty();
-		$firstItem->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
-
 		$secondItem = Item::newEmpty();
+
+		$firstItem->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
 		$secondItem->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
 
 		return array(
@@ -718,6 +717,7 @@ class ItemTest extends EntityTest {
 	 */
 	public function testEquals( Item $firstItem, Item $secondItem ) {
 		$this->assertTrue( $firstItem->equals( $secondItem ) );
+		$this->assertTrue( $secondItem->equals( $firstItem ) );
 	}
 
 	private function getBaseItem() {
@@ -754,12 +754,12 @@ class ItemTest extends EntityTest {
 		$item = $this->getBaseItem();
 
 		return array(
-			array( $item, Item::newEmpty() ),
-			array( $item, $differentLabel ),
-			array( $item, $differentDescription ),
-			array( $item, $differentAlias ),
-			array( $item, $differentSiteLink ),
-			array( $item, $differentStatement ),
+			'empty' => array( $item, Item::newEmpty() ),
+			'label' => array( $item, $differentLabel ),
+			'description' => array( $item, $differentDescription ),
+			'alias' => array( $item, $differentAlias ),
+			'siteLink' => array( $item, $differentSiteLink ),
+			'statement' => array( $item, $differentStatement ),
 		);
 	}
 
@@ -768,6 +768,7 @@ class ItemTest extends EntityTest {
 	 */
 	public function testNotEquals( Item $firstItem, Item $secondItem ) {
 		$this->assertFalse( $firstItem->equals( $secondItem ) );
+		$this->assertFalse( $secondItem->equals( $firstItem ) );
 	}
 
 }


### PR DESCRIPTION
In #177 I said "more to come" which I never did. Property still misses some tests, at least an equals test. What about this?

**Edit:** This also fixes an actual bug I found in `Property::equals`! It crashed for $this->id === null && $that->id !== null.
