### PR TITLE
Restore Property::equals behaviour

### DIFF
--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -131,8 +131,10 @@ class Property extends Entity {
 	/**
 	 * @see Comparable::equals
 	 *
-	 * Two items are considered equal if they are of the same
-	 * type and have the same value.
+	 * Two properties are considered equal if they are of the same
+	 * type and have the same value. The value does not include
+	 * the id, so entities with the same value but different id
+	 * are considered equal.
 	 *
 	 * @since 0.1
 	 *
@@ -145,14 +147,11 @@ class Property extends Entity {
 			return true;
 		}
 
-		if ( !( $that instanceof self )
-			|| is_null( $this->id ) !== is_null( $that->id )
-			|| ( $this->id !== null && !$this->id->equals( $that->id ) )
-		) {
+		if ( !( $that instanceof self ) ) {
 			return false;
 		}
 
-		return $this->dataTypeId == $that->dataTypeId
+		return $this->dataTypeId === $that->dataTypeId
 			&& $this->fingerprint->equals( $that->fingerprint )
 			&& $this->statements->equals( $that->statements );
 	}

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -128,14 +128,18 @@ class PropertyTest extends EntityTest {
 
 	public function equalsProvider() {
 		$firstProperty = Property::newFromType( 'string' );
-		$secondProperty = Property::newFromType( 'string' );
-
 		$firstProperty->setStatements( $this->newNonEmptyStatementList() );
+
+		$secondProperty = Property::newFromType( 'string' );
 		$secondProperty->setStatements( $this->newNonEmptyStatementList() );
+
+		$secondPropertyWithId = unserialize( serialize( $secondProperty ) );
+		$secondPropertyWithId->setId( 42 );
 
 		return array(
 			array( Property::newFromType( 'string' ), Property::newFromType( 'string' ) ),
 			array( $firstProperty, $secondProperty ),
+			array( $secondProperty, $secondPropertyWithId ),
 		);
 	}
 


### PR DESCRIPTION
Caught by @thiemowmde in #224

Looks like this regression was introduced between 0.9 and 1.0, when moving the comparison code out of `Entity`.
