### PR TITLE
Define behaviour for different ids

### DIFF
--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -10,8 +10,6 @@ use InvalidArgumentException;
 use OutOfBoundsException;
 use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Claim\Claims;
-use Wikibase\DataModel\Entity\Diff\EntityDiff;
-use Wikibase\DataModel\Entity\Diff\ItemDiff;
 use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\SiteLinkList;
 use Wikibase\DataModel\Snak\Snak;
@@ -322,18 +320,16 @@ class Item extends Entity {
 	 * @return boolean
 	 */
 	public function equals( $that ) {
+		if ( $this === $that ) {
+			return true;
+		}
+
 		if ( !( $that instanceof self ) ) {
 			return false;
 		}
 
-		if ( $that === $this ) {
-			return true;
-		}
-
-		/**
-		 * @var $that Item
-		 */
-		return $this->fingerprint->equals( $that->fingerprint )
+		return ( $this->id === null || $that->id === null || $this->id->equals( $that->id ) )
+			&& $this->fingerprint->equals( $that->fingerprint )
 			&& $this->siteLinks->equals( $that->siteLinks )
 			&& $this->statements->equals( $that->statements );
 	}

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -151,7 +151,8 @@ class Property extends Entity {
 			return false;
 		}
 
-		return $this->dataTypeId === $that->dataTypeId
+		return ( $this->id === null || $that->id === null || $this->id->equals( $that->id ) )
+			&& $this->dataTypeId === $that->dataTypeId
 			&& $this->fingerprint->equals( $that->fingerprint )
 			&& $this->statements->equals( $that->statements );
 	}

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -701,14 +701,18 @@ class ItemTest extends EntityTest {
 
 	public function equalsProvider() {
 		$firstItem = Item::newEmpty();
-		$secondItem = Item::newEmpty();
-
 		$firstItem->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
+
+		$secondItem = Item::newEmpty();
 		$secondItem->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
+
+		$secondItemWithId = unserialize( serialize( $secondItem ) );
+		$secondItemWithId->setId( 42 );
 
 		return array(
 			array( Item::newEmpty(), Item::newEmpty() ),
 			array( $firstItem, $secondItem ),
+			array( $secondItem, $secondItemWithId ),
 		);
 	}
 
@@ -734,6 +738,9 @@ class ItemTest extends EntityTest {
 	}
 
 	public function notEqualsProvider() {
+		$differentId = $this->getBaseItem();
+		$differentId->setId( 666 );
+
 		$differentLabel = $this->getBaseItem();
 		$differentLabel->getFingerprint()->setLabel( 'en', 'Different' );
 
@@ -755,6 +762,7 @@ class ItemTest extends EntityTest {
 
 		return array(
 			'empty' => array( $item, Item::newEmpty() ),
+			'id' => array( $item, $differentId ),
 			'label' => array( $item, $differentLabel ),
 			'description' => array( $item, $differentDescription ),
 			'alias' => array( $item, $differentAlias ),

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -164,6 +164,9 @@ class PropertyTest extends EntityTest {
 	}
 
 	public function notEqualsProvider() {
+		$differentId = $this->getBaseProperty();
+		$differentId->setId( 666 );
+
 		$differentLabel = $this->getBaseProperty();
 		$differentLabel->getFingerprint()->setLabel( 'en', 'Different' );
 
@@ -180,6 +183,7 @@ class PropertyTest extends EntityTest {
 
 		return array(
 			'empty' => array( $property, Property::newFromType( 'string' ) ),
+			'id' => array( $property, $differentId ),
 			'label' => array( $property, $differentLabel ),
 			'description' => array( $property, $differentDescription ),
 			'alias' => array( $property, $differentAlias ),


### PR DESCRIPTION
See my comments in #224 and #227.

Short explanation: Ok, I understand that two Items (or two Properties) must still be equal if one does have an id and the other does not. This is relevant in our Wikibase Diff/ChangeOp code. But if two ids are set and they are different the Items (or Properties) should not be equal. This would be odd.
