### PR TITLE
Remove broken error_reporting code

### DIFF
--- a/tests/unit/Entity/Diff/ItemDiffTest.php
+++ b/tests/unit/Entity/Diff/ItemDiffTest.php
@@ -258,7 +258,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 	 * diffs for substructures even in recursive mode (bug 51363).
 	 */
 	public function testAtomicSubstructureWorkaround() {
-		$oldErrorLevel = error_reporting( E_ERROR );
+		$oldErrorLevel = error_reporting( E_USER_ERROR );
 		
 		$atomicListDiff = new DiffOpChange(
 			array( 'a' => 'A', 'b' => 'B' ),


### PR DESCRIPTION
The error level was only set back when an exception was catched, which never happened. Ouch.

Ping @brightbyte.
