### PR TITLE
Remove inheritance between Statement and Claim

### DIFF
--- a/src/Claim/Claim.php
+++ b/src/Claim/Claim.php
@@ -10,7 +10,6 @@ use Wikibase\DataModel\PropertyIdProvider;
 use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Snak\SnakList;
 use Wikibase\DataModel\Snak\Snaks;
-use Wikibase\DataModel\Statement\Statement;
 
 /**
  * Class that represents a single Wikibase claim.
@@ -212,14 +211,14 @@ class Claim implements Hashable, Comparable, PropertyIdProvider {
 	 * @return boolean
 	 */
 	public function equals( $target ) {
-		if ( !( $target instanceof self ) || $target instanceof Statement ) {
+		if ( $target === $this ) {
+			return true;
+		}
+
+		if ( !( $target instanceof self ) ) {
 			return false;
 		}
 
-		return $this->claimFieldsEqual( $target );
-	}
-
-	protected function claimFieldsEqual( Claim $target ) {
 		return $this->guid === $target->guid
 			&& $this->mainSnak->equals( $target->mainSnak )
 			&& $this->qualifiers->equals( $target->qualifiers );

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -82,8 +82,8 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 			$this->getStubStatement( 3, 'five', Statement::RANK_DEPRECATED ),
 			$this->getStubStatement( 3, 'six', Statement::RANK_NORMAL ),
 
-			$this->getStubStatement( 4, 'seven', Statement::RANK_PREFERRED ),
-			$this->getStubStatement( 4, 'eight', Statement::RANK_TRUTH ),
+			$this->getStubStatement( 4, 'seven', Statement::RANK_NORMAL ),
+			$this->getStubStatement( 4, 'eight', Statement::RANK_PREFERRED ),
 		) );
 
 		$this->assertEquals(
@@ -93,7 +93,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 
 				$this->getStubStatement( 3, 'six', Statement::RANK_NORMAL ),
 
-				$this->getStubStatement( 4, 'eight', Statement::RANK_TRUTH ),
+				$this->getStubStatement( 4, 'eight', Statement::RANK_PREFERRED ),
 			),
 			$list->getBestStatementPerProperty()->toArray()
 		);

--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -202,7 +202,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testSetRankToTruth( Statement $statement ) {
 		$this->setExpectedException( 'InvalidArgumentException' );
-		$statement->setRank( Statement::RANK_TRUTH );
+		$statement->setRank( 4 );
 	}
 
 	public function testStatementRankCompatibility() {


### PR DESCRIPTION
This tackels a big part of #22.

Note that the given version 3.0 is only hypothetical but it would be great if we can get this into the next major release. However, I fear that still lots of refactoring is needed in the packages which use WikibaseDataModel. Even in the tests of the DataModel itself lots of refactoring has to be done.
