### PR TITLE
Stop using deprecated ranks

### DIFF
--- a/src/Claim/Claim.php
+++ b/src/Claim/Claim.php
@@ -32,11 +32,11 @@ class Claim implements Hashable, Comparable, PropertyIdProvider {
 	/** @deprecated since 2.0 */
 	const RANK_TRUTH = 3;
 	/** @deprecated since 2.0 - use Statement::RANK_PREFERRED instead */
-	const RANK_PREFERRED = 2;
+	const RANK_PREFERRED = Statement::RANK_PREFERRED;
 	/** @deprecated since 2.0 - use Statement::RANK_NORMAL instead */
-	const RANK_NORMAL = 1;
+	const RANK_NORMAL = Statement::RANK_NORMAL;
 	/** @deprecated since 2.0 - use Statement::RANK_DEPRECATED instead */
-	const RANK_DEPRECATED = 0;
+	const RANK_DEPRECATED = Statement::RANK_DEPRECATED;
 
 	/**
 	 * @since 0.1
@@ -172,7 +172,7 @@ class Claim implements Hashable, Comparable, PropertyIdProvider {
 
 	/**
 	 * Gets the rank of the claim.
-	 * The rank is an element of the Claim::RANK_ enum.
+	 * The rank is an element of the Statement::RANK_ enum.
 	 *
 	 * @since 0.1
 	 * @deprecated since 2.0

--- a/src/Claim/Claims.php
+++ b/src/Claim/Claims.php
@@ -2,7 +2,6 @@
 
 namespace Wikibase\DataModel\Claim;
 
-use ArrayAccess;
 use ArrayObject;
 use Comparable;
 use Hashable;
@@ -11,6 +10,7 @@ use Traversable;
 use Wikibase\DataModel\ByPropertyIdGrouper;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\Snak;
+use Wikibase\DataModel\Statement\Statement;
 
 /**
  * A claim (identified using it's GUID) can only be added once.
@@ -457,7 +457,7 @@ class Claims extends ArrayObject implements ClaimListAccess, Hashable, Comparabl
 		do {
 			$claims = $this->getByRank( $rank );
 			$rank--;
-		} while ( $claims->isEmpty() && $rank > Claim::RANK_DEPRECATED );
+		} while ( $claims->isEmpty() && $rank > Statement::RANK_DEPRECATED );
 
 		return $claims;
 	}

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -26,9 +26,9 @@ class Statement extends Claim {
 	 *
 	 * @since 2.0
 	 */
-	const RANK_PREFERRED = Claim::RANK_PREFERRED;
-	const RANK_NORMAL = Claim::RANK_NORMAL;
-	const RANK_DEPRECATED = Claim::RANK_DEPRECATED;
+	const RANK_PREFERRED = 2;
+	const RANK_NORMAL = 1;
+	const RANK_DEPRECATED = 0;
 
 	/**
 	 * @var ReferenceList

--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -555,25 +555,25 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 
 	public function provideGetByRank() {
 		$s1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P1" ) ) );
-		$s1->setRank( Claim::RANK_DEPRECATED );
+		$s1->setRank( Statement::RANK_DEPRECATED );
 
 		$s2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P2" ) ) );
-		$s2->setRank( Claim::RANK_PREFERRED );
+		$s2->setRank( Statement::RANK_PREFERRED );
 
 		$s3 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P3" ) ) );
-		$s3->setRank( Claim::RANK_PREFERRED );
+		$s3->setRank( Statement::RANK_PREFERRED );
 
 		return array(
 			// Empty yields empty
 			array(
 				new Claims(),
-				Claim::RANK_NORMAL,
+				Statement::RANK_NORMAL,
 				new Claims()
 			),
 			// One statement with RANK_PREFERRED, so return it
 			array(
 				new Claims( array( $s2 ) ),
-				Claim::RANK_PREFERRED,
+				Statement::RANK_PREFERRED,
 				new Claims( array( $s2 ) ),
 			),
 			// s2 has RANK_PREFERRED, so doesn't match RANK_TRUTH
@@ -585,7 +585,7 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 			// s2 and s3 have RANK_PREFERRED, so return them
 			array(
 				new Claims( array( $s2, $s1, $s3 ) ),
-				Claim::RANK_PREFERRED,
+				Statement::RANK_PREFERRED,
 				new Claims( array( $s2, $s3 ) ),
 			),
 		);
@@ -600,22 +600,22 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 
 	public function provideGetByRanks() {
 		$s1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P1" ) ) );
-		$s1->setRank( Claim::RANK_NORMAL );
+		$s1->setRank( Statement::RANK_NORMAL );
 
 		$s2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P2" ) ) );
-		$s2->setRank( Claim::RANK_PREFERRED );
+		$s2->setRank( Statement::RANK_PREFERRED );
 
 		$ret = array(
 			// s1 has RANK_NORMAL, thus doesn't match
 			array(
 				new Claims( array( $s2, $s1 ) ),
-				array( Claim::RANK_PREFERRED, Claim::RANK_DEPRECATED ),
+				array( Statement::RANK_PREFERRED, Statement::RANK_DEPRECATED ),
 				new Claims( array( $s2 ) ),
 			),
 			// s2 has RANK_PREFERRED and s1 has RANK_NORMAL, so return them
 			array(
 				new Claims( array( $s2, $s1 ) ),
-				array( Claim::RANK_PREFERRED, Claim::RANK_NORMAL ),
+				array( Statement::RANK_PREFERRED, Statement::RANK_NORMAL ),
 				new Claims( array( $s2, $s1 ) ),
 			)
 		);
@@ -645,7 +645,7 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetBestClaimsOnlyOne() {
 		$statement = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P1" ) ) );
-		$statement->setRank( Claim::RANK_NORMAL );
+		$statement->setRank( Statement::RANK_NORMAL );
 
 		$claims = new Claims( array( $statement ) );
 		$this->assertEquals( $claims->getBestClaims(), $claims );
@@ -653,7 +653,7 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetBestClaimsNoDeprecated() {
 		$statement = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P1" ) ) );
-		$statement->setRank( Claim::RANK_DEPRECATED );
+		$statement->setRank( Statement::RANK_DEPRECATED );
 
 		$claims = new Claims( array( $statement ) );
 		$this->assertEquals( $claims->getBestClaims(), new Claims() );
@@ -661,10 +661,10 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetBestClaimsReturnOne() {
 		$s1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P1" ) ) );
-		$s1->setRank( Claim::RANK_DEPRECATED );
+		$s1->setRank( Statement::RANK_DEPRECATED );
 
 		$s2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P2" ) ) );
-		$s2->setRank( Claim::RANK_NORMAL );
+		$s2->setRank( Statement::RANK_NORMAL );
 
 		$claims = new Claims( array( $s1, $s2 ) );
 		$expected = new Claims( array( $s2 ) );
@@ -673,13 +673,13 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetBestClaimsReturnTwo() {
 		$s1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P1" ) ) );
-		$s1->setRank( Claim::RANK_NORMAL );
+		$s1->setRank( Statement::RANK_NORMAL );
 
 		$s2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P2" ) ) );
-		$s2->setRank( Claim::RANK_PREFERRED );
+		$s2->setRank( Statement::RANK_PREFERRED );
 
 		$s3 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P3" ) ) );
-		$s3->setRank( Claim::RANK_PREFERRED );
+		$s3->setRank( Statement::RANK_PREFERRED );
 
 		$claims = new Claims( array( $s3, $s1, $s2 ) );
 		$expected = new Claims( array( $s2, $s3 ) );
@@ -691,7 +691,7 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 		$s1->setGuid( 'kittens' );
 
 		$s2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( "P2" ) ) );
-		$s2->setRank( Claim::RANK_NORMAL );
+		$s2->setRank( Statement::RANK_NORMAL );
 
 		$claims = new Claims( array( $s1, $s2 ) );
 		$expected = new Claims( array( $s1 ) );

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -83,7 +83,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 			$this->getStubStatement( 3, 'six', Statement::RANK_NORMAL ),
 
 			$this->getStubStatement( 4, 'seven', Statement::RANK_PREFERRED ),
-			$this->getStubStatement( 4, 'eight', Statement::RANK_TRUTH ),
+			$this->getStubStatement( 4, 'eight', Claim::RANK_TRUTH ),
 		) );
 
 		$this->assertEquals(
@@ -93,7 +93,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 
 				$this->getStubStatement( 3, 'six', Statement::RANK_NORMAL ),
 
-				$this->getStubStatement( 4, 'eight', Statement::RANK_TRUTH ),
+				$this->getStubStatement( 4, 'eight', Claim::RANK_TRUTH ),
 			),
 			$list->getBestStatementPerProperty()->toArray()
 		);

--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -202,7 +202,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testSetRankToTruth( Statement $statement ) {
 		$this->setExpectedException( 'InvalidArgumentException' );
-		$statement->setRank( Statement::RANK_TRUTH );
+		$statement->setRank( Claim::RANK_TRUTH );
 	}
 
 	public function testStatementRankCompatibility() {


### PR DESCRIPTION
Please note that `TRUTH` is still in `Claim`, not in `Statement`.
