### PR TITLE
Avoid use of BasicEntityIdParser

### DIFF
--- a/src/Entity/EntityIdValue.php
+++ b/src/Entity/EntityIdValue.php
@@ -5,6 +5,7 @@ namespace Wikibase\DataModel\Entity;
 use DataValues\DataValue;
 use DataValues\DataValueObject;
 use DataValues\IllegalValueException;
+use InvalidArgumentException;
 use Wikibase\DataModel\LegacyIdInterpreter;
 
 /**
@@ -58,7 +59,14 @@ class EntityIdValue extends DataValueObject {
 	 */
 	public function unserialize( $value ) {
 		list( $entityType, $numericId ) = json_decode( $value );
-		$this->__construct( LegacyIdInterpreter::newIdFromTypeAndNumber( $entityType, $numericId ) );
+
+		try {
+			$entityId = LegacyIdInterpreter::newIdFromTypeAndNumber( $entityType, $numericId );
+		} catch ( InvalidArgumentException $ex ) {
+			throw new IllegalValueException( 'Invalid EntityIdValue serialization.' );
+		}
+
+		return $this->__construct( $entityId );
 	}
 
 	/**

--- a/src/LegacyIdInterpreter.php
+++ b/src/LegacyIdInterpreter.php
@@ -3,9 +3,9 @@
 namespace Wikibase\DataModel;
 
 use InvalidArgumentException;
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
 use Wikibase\DataModel\Entity\EntityId;
-use Wikibase\DataModel\Entity\EntityIdParsingException;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\PropertyId;
 
 /**
  * Turns legacy entity id serializations consisting of entity type + numeric id
@@ -29,42 +29,13 @@ class LegacyIdInterpreter {
 	 * @throws InvalidArgumentException
 	 */
 	public static function newIdFromTypeAndNumber( $entityType, $numericId ) {
-		$idParser = new BasicEntityIdParser();
-
-		try {
-			$id = $idParser->parse( self::constructSerialization( $entityType, $numericId ) );
-		}
-		catch ( EntityIdParsingException $ex ) {
-			throw new InvalidArgumentException( $ex->getMessage(), 0, $ex );
+		if ( $entityType === 'item' ) {
+			return ItemId::newFromNumber( $numericId );
+		} elseif ( $entityType === 'property' ) {
+			return PropertyId::newFromNumber( $numericId );
 		}
 
-		return $id;
-	}
-
-	/**
-	 * Constructs the entity id serialization from entity type and numeric id.
-	 *
-	 * @param string $entityType
-	 * @param int|string $numericId
-	 *
-	 * @return string
-	 * @throws InvalidArgumentException
-	 */
-	private static function constructSerialization( $entityType, $numericId ) {
-		if ( !is_string( $entityType ) ) {
-			throw new InvalidArgumentException( '$entityType needs to be a string' );
-		}
-
-		$entityTypes = array(
-			'item' => 'Q',
-			'property' => 'P',
-		);
-
-		if ( !array_key_exists( $entityType, $entityTypes ) ) {
-			throw new InvalidArgumentException( 'Provided a numeric id (deprecated) for an entity type that never supported this' );
-		}
-
-		return $entityTypes[$entityType] . (string)$numericId;
+		throw new InvalidArgumentException( 'Invalid entityType ' . $entityType );
 	}
 
 }


### PR DESCRIPTION
Remove use of BasicEntityIdParser which already has limited knowledge of the types of EntityId objects (only Item and Property).

The LegacyIdInterpreter still has that limitation, but can do the equivalent work without needing to construct a new BasicEntityIdParser object all the time.

The ItemId::newFromNumber and PropertyId::newFromNumber methods are also not great and would be better if we can somehow avoid the entity type + numeric id format in EntityIdValue.
