### PR TITLE
Kill the cat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,6 @@
 		"diff/diff": "~1.0",
 		"data-values/data-values": "~0.1|~1.0"
 	},
-	"require-dev": {
-		"whatthejeff/nyancat-phpunit-resultprinter": "~1.2"
-	},
 	"autoload": {
 		"files" : [
 			"WikibaseDataModel.php"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,9 +11,7 @@
          stopOnIncomplete="false"
          stopOnSkipped="false"
          strict="false"
-         verbose="true"
-         printerFile="vendor/whatthejeff/nyancat-phpunit-resultprinter/src/NyanCat/PHPUnit/ResultPrinter.php"
-         printerClass="NyanCat\PHPUnit\ResultPrinter">
+         verbose="true">
     <testsuites>
         <testsuite name="WikibaseDataModel">
             <directory>tests</directory>


### PR DESCRIPTION
Simple reason: The cat wastes time. Whenever I have to run the DataModel tests locally it takes 11.5 seconds. Which is crazy when you compare it to the 1.4 seconds it takes without the cat. Yes, 88% of the time only for the cat animation. Come on. I think we all learned to appreciate a good joke but this is just not worth it.

Also see https://github.com/wmde/Diff/pull/17.
