### PR TITLE
Ensure LegacyIdInterpreter can accept numeric id as string

### DIFF
--- a/src/LegacyIdInterpreter.php
+++ b/src/LegacyIdInterpreter.php
@@ -29,6 +29,10 @@ class LegacyIdInterpreter {
 	 * @throws InvalidArgumentException
 	 */
 	public static function newIdFromTypeAndNumber( $entityType, $numericId ) {
+		if ( !is_int( $numericId ) && is_numeric( $numericId ) ) {
+			$numericId = (int)$numericId;
+		}
+
 		if ( $entityType === 'item' ) {
 			return ItemId::newFromNumber( $numericId );
 		} elseif ( $entityType === 'property' ) {

--- a/tests/unit/LegacyIdInterpreterTest.php
+++ b/tests/unit/LegacyIdInterpreterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Wikibase\Test;
+
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\LegacyIdInterpreter;
+
+/**
+ * @covers Wikibase\DataModel\LegacyIdInterpreter
+ *
+ * @group Wikibase
+ * @group WikibaseDataModel
+ *
+ * @licence GNU GPL v2+
+ * @author Katie FIlbert < aude.wiki@gmail.com >
+ */
+class LegacyIdInterpreterTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider idProvider
+	 */
+	public function testNewIdFromTypeAndNumber( EntityId $expected, $type, $number ) {
+		$actual = LegacyIdInterpreter::newIdFromTypeAndNumber( $type, $number );
+
+		$this->assertEquals( $actual, $expected );
+	}
+
+	public function idProvider() {
+		return array(
+			array( new ItemId( 'Q42' ), 'item', 42 ),
+			array( new PropertyId( 'P42' ), 'property', 42 ),
+		);
+	}
+
+	/**
+	 * @dataProvider invalidInputProvider
+	 */
+	public function testNewIdFromTypeAndNumber_withInvalidInput( $type, $number ) {
+		$this->setExpectedException( 'InvalidArgumentException' );
+		LegacyIdInterpreter::newIdFromTypeAndNumber( $type, $number );
+	}
+
+	public function invalidInputProvider() {
+		return array(
+			array( 'kittens', 42 ),
+			array( 'item', array( 'kittens' ) ),
+			array( 'item', true ),
+		);
+	}
+
+}


### PR DESCRIPTION
For backwards compatibility, LegacyIdInterpreter also accepts $numericId as a string.

Also added tests for LegacyIdInterpreter, which apparently never had tests.
