### PR TITLE
[Regression] 32 bit compatibility for numeric ids

### DIFF
--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -73,17 +73,17 @@ class ItemId extends EntityId {
 	 * should avoid dealing with just the numeric part, and use the whole
 	 * serialization. Not doing so in new code requires special justification.
 	 *
-	 * @param int|float $number
+	 * @param int|float|string $numericId
 	 *
 	 * @return ItemId
 	 * @throws InvalidArgumentException
 	 */
-	public static function newFromNumber( $number ) {
-		if ( !is_int( $number ) && !is_float( $number ) ) {
-			throw new InvalidArgumentException( '$number needs to be an integer or whole number float.' );
+	public static function newFromNumber( $numericId ) {
+		if ( !is_numeric( $numericId ) ) {
+			throw new InvalidArgumentException( '$number needs to be numeric.' );
 		}
 
-		return new self( 'Q' . $number );
+		return new self( 'Q' . $numericId );
 	}
 
 }

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -73,17 +73,17 @@ class PropertyId extends EntityId {
 	 * should avoid dealing with just the numeric part, and use the whole
 	 * serialization. Not doing so in new code requires special justification.
 	 *
-	 * @param int|float $number
+	 * @param int|float|string $numericId
 	 *
 	 * @return PropertyId
 	 * @throws InvalidArgumentException
 	 */
-	public static function newFromNumber( $number ) {
-		if ( !is_int( $number ) && !is_float( $number ) ) {
-			throw new InvalidArgumentException( '$number needs to be an integer or whole number float.' );
+	public static function newFromNumber( $numericId ) {
+		if ( !is_numeric( $numericId ) ) {
+			throw new InvalidArgumentException( '$number needs to be numeric.' );
 		}
 
-		return new self( 'P' . $number );
+		return new self( 'P' . $numericId );
 	}
 
 }

--- a/src/LegacyIdInterpreter.php
+++ b/src/LegacyIdInterpreter.php
@@ -23,16 +23,12 @@ class LegacyIdInterpreter {
 
 	/**
 	 * @param string $entityType
-	 * @param int|string $numericId
+	 * @param int|float|string $numericId
 	 *
 	 * @return EntityId
 	 * @throws InvalidArgumentException
 	 */
 	public static function newIdFromTypeAndNumber( $entityType, $numericId ) {
-		if ( !is_int( $numericId ) && is_numeric( $numericId ) ) {
-			$numericId = (int)$numericId;
-		}
-
 		if ( $entityType === 'item' ) {
 			return ItemId::newFromNumber( $numericId );
 		} elseif ( $entityType === 'property' ) {

--- a/tests/unit/Entity/ItemIdTest.php
+++ b/tests/unit/Entity/ItemIdTest.php
@@ -79,8 +79,11 @@ class ItemIdTest extends \PHPUnit_Framework_TestCase {
 	public function numericIdProvider() {
 		return array(
 			array( 42 ),
+			array( '42' ),
 			array( 42.0 ),
+			// Check for 32-bit integer overflow on 32-bit PHP systems.
 			array( 2147483648 ),
+			array( '2147483648' ),
 		);
 	}
 
@@ -94,7 +97,8 @@ class ItemIdTest extends \PHPUnit_Framework_TestCase {
 
 	public function invalidNumericIdProvider() {
 		return array(
-			array( '42' ),
+			array( '42.1' ),
+			array( 42.1 ),
 			array( 2147483648.1 ),
 		);
 	}

--- a/tests/unit/Entity/PropertyIdTest.php
+++ b/tests/unit/Entity/PropertyIdTest.php
@@ -79,8 +79,11 @@ class PropertyIdTest extends \PHPUnit_Framework_TestCase {
 	public function numericIdProvider() {
 		return array(
 			array( 42 ),
+			array( '42' ),
 			array( 42.0 ),
+			// Check for 32-bit integer overflow on 32-bit PHP systems.
 			array( 2147483648 ),
+			array( '2147483648' ),
 		);
 	}
 
@@ -94,7 +97,8 @@ class PropertyIdTest extends \PHPUnit_Framework_TestCase {
 
 	public function invalidNumericIdProvider() {
 		return array(
-			array( '42' ),
+			array( '42.1' ),
+			array( 42.1 ),
 			array( 2147483648.1 ),
 		);
 	}


### PR DESCRIPTION
The big problem here is the `(int)` type cast in the `LegacyIdInterpreter`. This leads to unexpected results (negative numbers) on 32 bit PHP installations (which I happen to have for some reason).

Fix is simple: If it's a numeric string, just pass it. Sure, `is_numeric` doesn't check for whole numbers, but that's not a problem. The final validation for whole numbers is done by the `ItemId::PATTERN` and `PropertyId::PATTERN` regular expressions.
