### PR TITLE
Implement serializable in ReferenceList

### DIFF
--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -182,4 +182,32 @@ class ReferenceList extends HashableObjectStorage {
 		return null;
 	}
 
+	/**
+	 * @see Serializable::serialize
+	 *
+	 * @since 2.1
+	 *
+	 * @return string
+	 */
+	public function serialize() {
+		$references = array();
+
+		foreach( $this as $reference ) {
+			$references[] = $reference;
+		}
+
+		return serialize( $references );
+	}
+
+	/**
+	 * @see Serializable::unserialize
+	 *
+	 * @since 2.1
+	 *
+	 * @param string $data
+	 */
+	public function unserialize( $data ) {
+		$this->__construct( unserialize( $data ) );
+	}
+
 }

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -67,6 +67,7 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
+
 	public function testGivenCloneOfReferenceInList_hasReferenceReturnsTrue() {
 		$list = new ReferenceList();
 
@@ -274,6 +275,24 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 		$this->setExpectedException( 'InvalidArgumentException' );
 		$references->addNewReference( new PropertyNoValueSnak( 1 ), null );
+	}
+
+	public function testSerializeRoundtrip() {
+		$references = new ReferenceList();
+
+		$references->addReference( new Reference() );
+
+		$references->addReference( new Reference(
+			new SnakList(
+				array(
+					new PropertyNoValueSnak( 2 ),
+					new PropertyNoValueSnak( 3 )
+				)
+			)
+		) );
+
+		$serialized = serialize( $references );
+		$this->assertTrue( $references->equals( unserialize( $serialized ) ) );
 	}
 
 }


### PR DESCRIPTION
Relying on SplObjectStorage serialization seems to be problematic, especially when used with a large Item.

This converts the ReferenceList to a plain array of Reference objects when serializing, which is more reliable.

This appears to resolve the problems with ReferenceList objects becoming corrupt. (tested locally with trying to view a diff or undo)

Bug: 71479
