### PR TITLE
Don't use array_merge in getAllSnaks methods

### DIFF
--- a/src/Claim/Claim.php
+++ b/src/Claim/Claim.php
@@ -193,11 +193,11 @@ class Claim implements Hashable, Comparable, PropertyIdProvider {
 	 * @return Snak[]
 	 */
 	public function getAllSnaks() {
-		$snaks = array();
+		$snaks = array( $this->getMainSnak() );
 
-		$snaks[] = $this->getMainSnak();
-		$qualifiers = $this->getQualifiers();
-		$snaks = array_merge( $snaks, iterator_to_array( $qualifiers ) );
+		foreach( $this->getQualifiers() as $qualifier ) {
+			$snaks[] = $qualifier;
+		}
 
 		return $snaks;
 	}

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -446,11 +446,12 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 * @return Snak[]
 	 */
 	public function getAllSnaks() {
-		$claims = $this->getClaims();
 		$snaks = array();
 
-		foreach ( $claims as $claim ) {
-			$snaks = array_merge( $snaks, $claim->getAllSnaks() );
+		foreach ( $this->getClaims() as $claim ) {
+			foreach( $claim->getAllSnaks() as $snak ) {
+				$snaks[] = $snak;
+			}
 		}
 
 		return $snaks;

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -145,8 +145,9 @@ class Statement extends Claim {
 
 		/* @var Reference $reference */
 		foreach( $this->getReferences() as $reference ) {
-			$referenceSnaks = $reference->getSnaks();
-			$snaks = array_merge( $snaks, iterator_to_array( $referenceSnaks ) );
+			foreach( $reference->getSnaks() as $referenceSnak ) {
+				$snaks[] = $referenceSnak;
+			}
 		}
 
 		return $snaks;

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -138,9 +138,13 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	 */
 	public function getAllSnaks() {
 		$snaks = array();
+
 		foreach ( $this->statements as $statement ) {
-			$snaks = array_merge( $snaks, $statement->getAllSnaks() );
+			foreach( $statement->getAllSnaks() as $snak ) {
+				$snaks[] = $snak;
+			}
 		}
+
 		return $snaks;
 	}
 


### PR DESCRIPTION
It is unnecessary and more costly, performance-wise.  array_merge consumes the most memory of any method used throughout the data model, Wikibase, and MediaWiki.

Avoiding array_merge here also helps improve the time it takes to load an item in Wikibase.

In a medium-size item, with array_merge:
- Entity::getAllSnaks - called 2 times, takes 109 ms
- Claim::getAllSnaks - called 846 times, takes 188 ms
- Statement::getAllSnaks - called 846 times, takes 148 ms

Without array_merge, on the same item:
- Entity::getAllSnaks - 22 ms
- Claim::getAllSnaks - 63 ms
- Statement::getAllSnaks - 66 ms

StatementList::getAllSnaks appears unused.
