### PR TITLE
Stop Statement requiring a Claim

### DIFF
--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -208,7 +208,7 @@ class Item extends Entity implements StatementListProvider {
 	 * @return Statement
 	 */
 	public function newClaim( Snak $mainSnak ) {
-		return new Statement( new Claim( $mainSnak ) );
+		return new Statement( $mainSnak );
 	}
 
 	/**

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -8,6 +8,7 @@ use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\ReferenceList;
 use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Snak\SnakList;
+use Wikibase\DataModel\Snak\Snaks;
 
 /**
  * Class representing a Wikibase statement.
@@ -43,11 +44,17 @@ class Statement extends Claim {
 	/**
 	 * @since 2.0
 	 *
-	 * @param Claim $claim
+	 * @param Snak $mainSnak
+	 * @param Snaks|null $qualifiers
 	 * @param ReferenceList|null $references
 	 */
-	public function __construct( Claim $claim, ReferenceList $references = null ) {
-		$this->setClaim( $claim );
+	public function __construct(
+		Snak $mainSnak,
+		Snaks $qualifiers = null,
+		ReferenceList $references = null
+	) {
+		$this->mainSnak = $mainSnak;
+		$this->qualifiers = $qualifiers ?: new SnakList();
 		$this->references = $references ?: new ReferenceList();
 	}
 
@@ -125,7 +132,7 @@ class Statement extends Claim {
 		return sha1( implode(
 			'|',
 			array(
-				parent::getHash(),
+				sha1( $this->mainSnak->getHash() . $this->qualifiers->getHash() ),
 				$this->rank,
 				$this->references->getValueHash(),
 			)
@@ -141,7 +148,11 @@ class Statement extends Claim {
 	 * @return Snak[]
 	 */
 	public function getAllSnaks() {
-		$snaks = parent::getAllSnaks();
+		$snaks = array( $this->mainSnak );
+
+		foreach( $this->qualifiers as $qualifier ) {
+			$snaks[] = $qualifier;
+		}
 
 		/* @var Reference $reference */
 		foreach( $this->getReferences() as $reference ) {
@@ -171,26 +182,6 @@ class Statement extends Claim {
 			&& $this->claimFieldsEqual( $target )
 			&& $this->rank === $target->getRank()
 			&& $this->references->equals( $target->references );
-	}
-
-	/**
-	 * @since 1.1
-	 *
-	 * @param Claim $claim
-	 */
-	public function setClaim( Claim $claim ) {
-		$this->mainSnak = $claim->getMainSnak();
-		$this->qualifiers = $claim->getQualifiers();
-		$this->guid = $claim->getGuid();
-	}
-
-	/**
-	 * @since 1.0
-	 *
-	 * @return Claim
-	 */
-	public function getClaim() {
-		return $this;
 	}
 
 }

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -96,7 +96,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 		$qualifiers = is_array( $qualifiers ) ? new SnakList( $qualifiers ) : $qualifiers;
 		$references = is_array( $references ) ? new ReferenceList( $references ) : $references;
 
-		$statement = new Statement( new Claim( $mainSnak, $qualifiers ), $references );
+		$statement = new Statement( $mainSnak, $qualifiers, $references );
 		$statement->setGuid( $guid );
 
 		$this->addStatement( $statement );

--- a/tests/unit/ByPropertyIdArrayTest.php
+++ b/tests/unit/ByPropertyIdArrayTest.php
@@ -80,7 +80,7 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 
 		$lists[] = array_map(
 			function( Snak $snak ) {
-				return new Statement( new Claim( $snak ) );
+				return new Statement( $snak );
 			},
 			$snaks
 		);

--- a/tests/unit/Claim/ClaimStandaloneTest.php
+++ b/tests/unit/Claim/ClaimStandaloneTest.php
@@ -81,7 +81,7 @@ class ClaimStandaloneTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGivenSimilarStatement_equalsReturnsFalse() {
 		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
-		$this->assertFalse( $claim->equals( new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) ) ) );
+		$this->assertFalse( $claim->equals( new Statement( new PropertyNoValueSnak( 42 ) ) ) );
 	}
 
 }

--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -47,7 +47,7 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 			$guid = 'TEST$statement-' . $this->guidCounter;
 		}
 
-		$claim = new Statement( new Claim( $mainSnak ) );
+		$claim = new Statement( $mainSnak );
 		$claim->setGuid( $guid );
 
 		return $claim;

--- a/tests/unit/Entity/Diff/EntityDiffTest.php
+++ b/tests/unit/Entity/Diff/EntityDiffTest.php
@@ -6,7 +6,6 @@ use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpChange;
 use Diff\DiffOp\DiffOpRemove;
-use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Entity\Diff\EntityDiff;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Statement\Statement;
@@ -89,7 +88,7 @@ class EntityDiffTest extends \PHPUnit_Framework_TestCase {
 
 		$diffs[] = new EntityDiff( $diffOps );
 
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setGuid( 'EntityDiffTest$foo' );
 
 		$statementListDiffer = new StatementListDiffer();

--- a/tests/unit/Entity/Diff/PropertyPatcherTest.php
+++ b/tests/unit/Entity/Diff/PropertyPatcherTest.php
@@ -5,7 +5,6 @@ namespace Wikibase\Test\Entity\Diff;
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpRemove;
-use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Entity\Diff\EntityDiff;
 use Wikibase\DataModel\Entity\Diff\PropertyPatcher;
 use Wikibase\DataModel\Entity\Item;
@@ -57,13 +56,13 @@ class PropertyPatcherTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testStatementsArePatched() {
-		$s1337 = new Statement( new Claim( new PropertyNoValueSnak( 1337 ) ) );
+		$s1337 = new Statement( new PropertyNoValueSnak( 1337 ) );
 		$s1337->setGuid( 's1337' );
 
-		$s23 = new Statement( new Claim( new PropertyNoValueSnak( 23 ) ) );
+		$s23 = new Statement( new PropertyNoValueSnak( 23 ) );
 		$s23->setGuid( 's23' );
 
-		$s42 = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$s42 = new Statement( new PropertyNoValueSnak( 42 ) );
 		$s42->setGuid( 's42' );
 
 		$patch = new EntityDiff( array(
@@ -89,4 +88,3 @@ class PropertyPatcherTest extends \PHPUnit_Framework_TestCase {
 	}
 
 }
-

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -62,7 +62,8 @@ class ItemTest extends EntityTest {
 		$claims[] = new Claim( new PropertyNoValueSnak( 42 ) );
 
 		$claims[] = new Statement(
-			new Claim( new PropertyNoValueSnak( 42 ), null ),
+			new PropertyNoValueSnak( 42 ),
+			null,
 			new ReferenceList( array(
 				new Reference( new SnakList( array(
 					new PropertyNoValueSnak( 24 ),
@@ -573,10 +574,10 @@ class ItemTest extends EntityTest {
 	public function testSetClaims() {
 		$item = Item::newEmpty();
 
-		$statement0 = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement0 = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement0->setGuid( 'TEST$NVS42' );
 
-		$statement1 = new Statement( new Claim( new PropertySomeValueSnak( 42 ) ) );
+		$statement1 = new Statement( new PropertySomeValueSnak( 42 ) );
 		$statement1->setGuid( 'TEST$SVS42' );
 
 		$statements = array( $statement0, $statement1 );
@@ -640,7 +641,7 @@ class ItemTest extends EntityTest {
 	}
 
 	private function newStatement() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setGuid( 'kittens' );
 		return $statement;
 	}
@@ -662,7 +663,7 @@ class ItemTest extends EntityTest {
 	}
 
 	public function testCanConstructWithStatementList() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setGuid( 'meh' );
 
 		$statements = new StatementList( array( $statement ) );

--- a/tests/unit/Statement/StatementListDifferTest.php
+++ b/tests/unit/Statement/StatementListDifferTest.php
@@ -7,7 +7,6 @@ use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpChange;
 use Diff\DiffOp\DiffOpRemove;
-use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
@@ -43,7 +42,7 @@ class StatementListDifferTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	private function getNewStatement( $guid, $hash ) {
-		$statement = new Statement( new Claim( new PropertyValueSnak( 1, new StringValue( $hash ) ) ) );
+		$statement = new Statement( new PropertyValueSnak( 1, new StringValue( $hash ) ) );
 		$statement->setGuid( $guid );
 		return $statement;
 	}

--- a/tests/unit/Statement/StatementListPatcherTest.php
+++ b/tests/unit/Statement/StatementListPatcherTest.php
@@ -34,16 +34,16 @@ class StatementListPatcherTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testFoo() {
-		$statement0 = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement0 = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement0->setGuid( 's0' );
 
-		$statement1 = new Statement( new Claim( new PropertySomeValueSnak( 42 ) ) );
+		$statement1 = new Statement( new PropertySomeValueSnak( 42 ) );
 		$statement1->setGuid( 's1' );
 
-		$statement2 = new Statement( new Claim( new PropertyValueSnak( 42, new StringValue( 'ohi' ) ) ) );
+		$statement2 = new Statement( new PropertyValueSnak( 42, new StringValue( 'ohi' ) ) );
 		$statement2->setGuid( 's2' );
 
-		$statement3 = new Statement( new Claim( new PropertyNoValueSnak( 1 ) ) );
+		$statement3 = new Statement( new PropertyNoValueSnak( 1 ) );
 		$statement3->setGuid( 's3' );
 
 		$patch = new Diff( array(

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -158,7 +158,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 
 	private function getStatementWithSnak( $propertyId, $stringValue ) {
 		$snak = $this->newSnak( $propertyId, $stringValue );
-		$statement = new Statement( new Claim( $snak ) );
+		$statement = new Statement( $snak );
 		$statement->setGuid( sha1( $snak->getHash() ) );
 		return $statement;
 	}
@@ -174,7 +174,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			new StatementList( array(
-				new Statement( new Claim( $this->newSnak( 42, 'foo' ) ) )
+				new Statement( $this->newSnak( 42, 'foo' ) )
 			) ),
 			$list
 		);
@@ -192,12 +192,12 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			new StatementList( array(
-				new Statement( new Claim(
+				new Statement(
 					$this->newSnak( 42, 'foo' ),
 					new SnakList( array(
 						$this->newSnak( 1, 'bar' )
 					) )
-				) )
+				)
 			) ),
 			$list
 		);
@@ -216,10 +216,10 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			new StatementList( array(
-				new Statement( new Claim(
+				new Statement(
 					$this->newSnak( 42, 'foo' ),
 					$snakList
-				) )
+				)
 			) ),
 			$list
 		);
@@ -235,10 +235,10 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 			'kittens'
 		);
 
-		$statement = new Statement( new Claim(
+		$statement = new Statement(
 			$this->newSnak( 42, 'foo' ),
 			null
-		) );
+		);
 
 		$statement->setGuid( 'kittens' );
 

--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -25,13 +25,6 @@ use Wikibase\DataModel\Statement\Statement;
  */
 class StatementTest extends \PHPUnit_Framework_TestCase {
 
-	public function testConstructorTakesGuidFromClaim() {
-		$claim = new Claim( new PropertyNoValueSnak( new PropertyId( 'P42' ) ) );
-		$claim->setGuid( 'meh' );
-		$statement = new Statement( $claim );
-		$this->assertEquals( 'meh', $statement->getGuid() );
-	}
-
 	/**
 	 * @dataProvider instanceProvider
 	 */
@@ -54,7 +47,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 
 	public function testSetAndGetMainSnak() {
 		$snak = new PropertyNoValueSnak( new PropertyId( 'P42' ) );
-		$statement = new Statement( new Claim( $snak ) );
+		$statement = new Statement( $snak );
 		$this->assertSame( $snak, $statement->getMainSnak() );
 	}
 
@@ -63,10 +56,10 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 			new PropertyValueSnak( new PropertyId( 'P42' ), new StringValue( 'a' ) )
 		) );
 
-		$statement = new Statement( new Claim(
+		$statement = new Statement(
 			new PropertyNoValueSnak( new PropertyId( 'P42' ) ),
 			$qualifiers
-		) );
+		);
 
 		$this->assertSame( $qualifiers, $statement->getQualifiers() );
 	}
@@ -81,17 +74,17 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGuidDoesNotAffectHash() {
-		$statement0 = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement0 = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement0->setGuid( 'statement0' );
 
-		$statement1 = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement1 = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement1->setGuid( 'statement1' );
 
 		$this->assertEquals( $statement0->getHash(), $statement1->getHash() );
 	}
 
 	public function testSetInvalidGuidCausesException() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 
 		$this->setExpectedException( 'InvalidArgumentException' );
 		$statement->setGuid( 42 );
@@ -102,7 +95,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 
 		$id42 = new PropertyId( 'P42' );
 
-		$baseInstance = new Statement( new Claim( new PropertyNoValueSnak( $id42 ) ) );
+		$baseInstance = new Statement( new PropertyNoValueSnak( $id42 ) );
 
 		$instances[] = $baseInstance;
 
@@ -245,7 +238,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenNonStatement_equalsReturnsFalse() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 
 		$this->assertFalse( $statement->equals( null ) );
 		$this->assertFalse( $statement->equals( 42 ) );
@@ -254,12 +247,10 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGivenSameStatement_equalsReturnsTrue() {
 		$statement = new Statement(
-			new Claim(
-				new PropertyNoValueSnak( 42 ),
-				new SnakList( array(
-					new PropertyNoValueSnak( 1337 ),
-				) )
-			),
+			new PropertyNoValueSnak( 42 ),
+			new SnakList( array(
+				new PropertyNoValueSnak( 1337 ),
+			) ),
 			new ReferenceList( array(
 				new PropertyNoValueSnak( 1337 ),
 			) )
@@ -272,37 +263,37 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenStatementWithDifferentProperty_equalsReturnsFalse() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
-		$this->assertFalse( $statement->equals( new Statement( new Claim( new PropertyNoValueSnak( 43 ) ) ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$this->assertFalse( $statement->equals( new Statement( new PropertyNoValueSnak( 43 ) ) ) );
 	}
 
 	public function testGivenStatementWithDifferentSnakType_equalsReturnsFalse() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
-		$this->assertFalse( $statement->equals( new Statement( new Claim( new PropertySomeValueSnak( 42 ) ) ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$this->assertFalse( $statement->equals( new Statement( new PropertySomeValueSnak( 42 ) ) ) );
 	}
 
 	public function testStatementClaimWithDifferentQualifiers_equalsReturnsFalse() {
-		$statement = new Statement( new Claim(
+		$statement = new Statement(
 			new PropertyNoValueSnak( 42 ),
 			new SnakList( array(
 				new PropertyNoValueSnak( 1337 ),
 			) )
-		) );
+		);
 
-		$differentStatement = new Statement( new Claim(
+		$differentStatement = new Statement(
 			new PropertyNoValueSnak( 42 ),
 			new SnakList( array(
 				new PropertyNoValueSnak( 32202 ),
 			) )
-		) );
+		);
 
 		$this->assertFalse( $statement->equals( $differentStatement ) );
 	}
 
 	public function testGivenStatementWithDifferentGuids_equalsReturnsFalse() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 
-		$differentStatement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$differentStatement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$differentStatement->setGuid( 'kittens' );
 
 		$this->assertFalse( $statement->equals( $differentStatement ) );
@@ -310,61 +301,22 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 
 	public function testStatementClaimWithDifferentReferences_equalsReturnsFalse() {
 		$statement = new Statement(
-			new Claim(
-				new PropertyNoValueSnak( 42 ),
-				new SnakList( array() )
-			),
+			new PropertyNoValueSnak( 42 ),
+			new SnakList( array() ),
 			new ReferenceList( array(
 				new PropertyNoValueSnak( 1337 ),
 			) )
 		);
 
 		$differentStatement = new Statement(
-			new Claim(
-				new PropertyNoValueSnak( 42 ),
-				new SnakList( array() )
-			),
+			new PropertyNoValueSnak( 42 ),
+			new SnakList( array() ),
 			new ReferenceList( array(
 				new PropertyNoValueSnak( 32202 ),
 			) )
 		);
 
 		$this->assertFalse( $statement->equals( $differentStatement ) );
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 */
-	public function testSetClaim( Statement $statement ) {
-		$mainSnak = new PropertyNoValueSnak( new PropertyId( 'P42' ) );
-		$qualifiers = new SnakList( array( new PropertyNoValueSnak( 23 ) ) );
-		$claim = new Claim( $mainSnak, $qualifiers );
-
-		$statement->setClaim( $claim );
-
-		$this->assertEquals( $mainSnak, $statement->getClaim()->getMainSnak() );
-		$this->assertEquals( $mainSnak, $statement->getMainSnak() );
-		$this->assertEquals( $qualifiers, $statement->getClaim()->getQualifiers() );
-		$this->assertEquals( $qualifiers, $statement->getQualifiers() );
-	}
-
-	public function testGetClaim() {
-		$qualifiers = new SnakList( array( new PropertyNoValueSnak( 23 ) ) );
-
-		$statement = new Statement(
-			new Claim( new PropertyNoValueSnak( 42 ), $qualifiers ),
-			new ReferenceList( array(
-				new PropertyNoValueSnak( 1337 ),
-			) )
-		);
-		$statement->setGuid( '~=[,,_,,]:3' );
-
-		$claim = $statement->getClaim();
-		$this->assertInstanceOf( 'Wikibase\DataModel\Claim\Claim', $claim );
-
-		$this->assertEquals( '~=[,,_,,]:3', $claim->getGuid() );
-		$this->assertEquals( new PropertyNoValueSnak( 42 ), $claim->getMainSnak() );
-		$this->assertSame( $qualifiers, $claim->getQualifiers() );
 	}
 
 	public function testEquals() {
@@ -385,7 +337,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 		$statement = $this->newStatement();
 
 		$statementWithoutQualifiers = $this->newStatement();
-		$statementWithoutQualifiers->getClaim()->setQualifiers( new SnakList() );
+		$statementWithoutQualifiers->setQualifiers( new SnakList() );
 
 		$statementWithoutReferences = $this->newStatement();
 		$statementWithoutReferences->setReferences( new ReferenceList() );
@@ -394,9 +346,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 		$statementWithPreferredRank->setRank( Statement::RANK_PREFERRED );
 
 		$statementMainSnakNotEqual = $this->newStatement();
-		$statementMainSnakNotEqual->setClaim(
-			new Claim( new PropertyNoValueSnak( 9000 ) )
-		);
+		$statementMainSnakNotEqual->setMainSnak( new PropertyNoValueSnak( 9000 ) );
 
 		return array(
 			array( $statement, $statementWithoutQualifiers, 'qualifiers not equal' ),
@@ -410,7 +360,8 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 		$qualifiers = new SnakList( array( new PropertyNoValueSnak( 23 ) ) );
 
 		$statement = new Statement(
-			new Claim( new PropertyNoValueSnak( 42 ), $qualifiers ),
+			new PropertyNoValueSnak( 42 ),
+			$qualifiers,
 			new ReferenceList( array( new PropertyNoValueSnak( 1337 ) ) )
 		);
 


### PR DESCRIPTION
This fixes #264.

This basically reverts #188 and a lot of related breaking changes. I know I'm part of the problem because I did not commented enough on these changes and even tried to adapt code. But after running into more and more ugly, painful code (see #264) and thinking about this for days I came to the conclusion that this is the most sane way. Yes, the fact that Statement extends Claim is painful. But the current state of a Statement requiring a Claim is in no way better.
