### PR TITLE
Make exception error message style more uniform.

### DIFF
--- a/src/ByPropertyIdArray.php
+++ b/src/ByPropertyIdArray.php
@@ -122,7 +122,7 @@ class ByPropertyIdArray extends \ArrayObject {
 		$this->assertIndexIsBuild();
 
 		if ( !( array_key_exists( $propertyId->getSerialization(), $this->byId ) ) ) {
-			throw new OutOfBoundsException( 'Property id array key does not exist.' );
+			throw new OutOfBoundsException( 'Object with propertyId "' . $propertyId->getSerialization() . '" not found' );
 		}
 
 		return $this->byId[$propertyId->getSerialization()];

--- a/src/ByPropertyIdGrouper.php
+++ b/src/ByPropertyIdGrouper.php
@@ -33,12 +33,12 @@ class ByPropertyIdGrouper {
 
 	private function assertArePropertyIdProviders( $propertyIdProviders ) {
 		if ( !is_array( $propertyIdProviders ) && !( $propertyIdProviders instanceof Traversable ) ) {
-			throw new InvalidArgumentException( '$propertyIdProviders should be an array or a Traversable' );
+			throw new InvalidArgumentException( '$propertyIdProviders must be an array or an instance of Traversable' );
 		}
 
 		foreach ( $propertyIdProviders as $propertyIdProvider ) {
 			if ( !( $propertyIdProvider instanceof PropertyIdProvider ) ) {
-				throw new InvalidArgumentException( 'All elements need implement PropertyIdProvider' );
+				throw new InvalidArgumentException( 'Every element in $propertyIdProviders must be an instance of PropertyIdProvider' );
 			}
 		}
 	}
@@ -89,7 +89,7 @@ class ByPropertyIdGrouper {
 		$idSerialization = $propertyId->getSerialization();
 
 		if ( !isset( $this->byPropertyId[$idSerialization] ) ) {
-			throw new OutOfBoundsException( 'Property id does not exist.' );
+			throw new OutOfBoundsException( 'PropertyIdProvider with propertyId "' . $idSerialization . '" not found' );
 		}
 
 		return $this->byPropertyId[$idSerialization];

--- a/src/Claim/Claim.php
+++ b/src/Claim/Claim.php
@@ -164,7 +164,7 @@ class Claim implements Hashable, Comparable, PropertyIdProvider {
 	 */
 	public function setGuid( $guid ) {
 		if ( !is_string( $guid ) && $guid !== null ) {
-			throw new InvalidArgumentException( 'Can only set the GUID to string values or null' );
+			throw new InvalidArgumentException( '$guid must be a string or null; got ' . gettype( $guid ) );
 		}
 
 		$this->guid = $guid;

--- a/src/Claim/ClaimGuid.php
+++ b/src/Claim/ClaimGuid.php
@@ -30,10 +30,10 @@ class ClaimGuid implements Comparable {
 	 */
 	public function __construct( $entityId, $guid ) {
 		if( !$entityId instanceof EntityId ){
-			throw new InvalidArgumentException( '$entityId needs to be an EntityId' );
+			throw new InvalidArgumentException( '$entityId must be an instance of EntityId' );
 		}
 		if( !is_string( $guid ) ){
-			throw new InvalidArgumentException( '$guid needs to be a string' );
+			throw new InvalidArgumentException( '$guid must be a string; got ' . gettype( $guid ) );
 		}
 
 		$this->serialization = $entityId->getSerialization() . self::SEPARATOR . $guid;

--- a/src/Claim/ClaimGuidParser.php
+++ b/src/Claim/ClaimGuidParser.php
@@ -32,7 +32,7 @@ class ClaimGuidParser {
 	 */
 	public function parse( $serialization ) {
 		if ( !is_string( $serialization ) ) {
-			throw new ClaimGuidParsingException( '$serialization needs to be a string' );
+			throw new ClaimGuidParsingException( '$serialization must be a string; got ' . gettype( $serialization ) );
 		}
 
 		$keyParts = explode( ClaimGuid::SEPARATOR, $serialization );

--- a/src/Claim/ClaimList.php
+++ b/src/Claim/ClaimList.php
@@ -35,7 +35,7 @@ class ClaimList implements \IteratorAggregate {
 		}
 
 		if ( !is_array( $claims ) ) {
-			throw new InvalidArgumentException( '$claims should be an array' );
+			throw new InvalidArgumentException( '$claims must be an array; got ' . gettype( $claims ) );
 		}
 
 		$this->claims = $claims;

--- a/src/Claim/Claims.php
+++ b/src/Claim/Claims.php
@@ -38,7 +38,7 @@ class Claims extends ArrayObject implements ClaimListAccess, Hashable, Comparabl
 
 		if ( $input !== null ) {
 			if ( !is_array( $input ) && !( $input instanceof Traversable ) ) {
-				throw new InvalidArgumentException( '$input must be traversable' );
+				throw new InvalidArgumentException( '$input must be an array or an instance of Traversable' );
 			}
 
 			foreach ( $input as $claim ) {
@@ -55,7 +55,7 @@ class Claims extends ArrayObject implements ClaimListAccess, Hashable, Comparabl
 	 */
 	private function getGuidKey( $guid ) {
 		if ( !is_string( $guid ) ) {
-			throw new InvalidArgumentException( 'Expected a GUID string' );
+			throw new InvalidArgumentException( '$guid must be a string; got ' . gettype( $guid ) );
 		}
 
 		$key = strtoupper( $guid );
@@ -93,7 +93,7 @@ class Claims extends ArrayObject implements ClaimListAccess, Hashable, Comparabl
 	 */
 	public function addClaim( Claim $claim, $index = null ) {
 		if ( !is_null( $index ) && !is_integer( $index ) ) {
-			throw new InvalidArgumentException( 'Index needs to be null or an integer value' );
+			throw new InvalidArgumentException( '$index must be an integer or null; got ' . gettype( $index ) );
 		} else if ( is_null( $index ) || $index >= count( $this ) ) {
 			$this[] = $claim;
 		} else {
@@ -269,7 +269,7 @@ class Claims extends ArrayObject implements ClaimListAccess, Hashable, Comparabl
 	 */
 	public function offsetSet( $guid, $claim ) {
 		if ( !( $claim instanceof Claim ) ) {
-			throw new InvalidArgumentException( 'Expected a Claim instance' );
+			throw new InvalidArgumentException( '$claim must be an instance of Claim' );
 		}
 
 		$claimKey = $this->getClaimKey( $claim );

--- a/src/Entity/Diff/ItemDiffer.php
+++ b/src/Entity/Diff/ItemDiffer.php
@@ -58,7 +58,7 @@ class ItemDiffer implements EntityDifferStrategy {
 
 	private function assertIsItem( EntityDocument $item ) {
 		if ( !( $item instanceof Item ) ) {
-			throw new InvalidArgumentException( 'All entities need to be items' );
+			throw new InvalidArgumentException( '$item must be an instance of Item' );
 		}
 	}
 

--- a/src/Entity/Diff/ItemPatcher.php
+++ b/src/Entity/Diff/ItemPatcher.php
@@ -60,7 +60,7 @@ class ItemPatcher implements EntityPatcherStrategy {
 
 	private function assertIsItem( EntityDocument $item ) {
 		if ( !( $item instanceof Item ) ) {
-			throw new InvalidArgumentException( 'All entities need to be items' );
+			throw new InvalidArgumentException( '$item must be an instance of Item' );
 		}
 	}
 

--- a/src/Entity/Diff/PropertyDiffer.php
+++ b/src/Entity/Diff/PropertyDiffer.php
@@ -57,7 +57,7 @@ class PropertyDiffer implements EntityDifferStrategy {
 
 	private function assertIsProperty( EntityDocument $item ) {
 		if ( !( $item instanceof Property ) ) {
-			throw new InvalidArgumentException( 'All entities need to be properties' );
+			throw new InvalidArgumentException( '$item must be an instance of Property' );
 		}
 	}
 

--- a/src/Entity/Diff/PropertyPatcher.php
+++ b/src/Entity/Diff/PropertyPatcher.php
@@ -54,7 +54,7 @@ class PropertyPatcher implements EntityPatcherStrategy {
 
 	private function assertIsProperty( EntityDocument $property ) {
 		if ( !( $property instanceof Property ) ) {
-			throw new InvalidArgumentException( 'All entities need to be properties' );
+			throw new InvalidArgumentException( '$property must be an instance of Property' );
 		}
 	}
 

--- a/src/Entity/DispatchingEntityIdParser.php
+++ b/src/Entity/DispatchingEntityIdParser.php
@@ -55,7 +55,7 @@ class DispatchingEntityIdParser implements EntityIdParser {
 	 */
 	private function assertIdIsString( $idSerialization ) {
 		if ( !is_string( $idSerialization ) ) {
-			throw new EntityIdParsingException( 'Entity id serializations need to be strings' );
+			throw new EntityIdParsingException( '$idSerialization must be a string; got ' . gettype( $idSerialization ) );
 		}
 	}
 

--- a/src/Entity/EntityIdValue.php
+++ b/src/Entity/EntityIdValue.php
@@ -140,7 +140,7 @@ class EntityIdValue extends DataValueObject {
 	 */
 	public static function newFromArray( $data ) {
 		if ( !is_array( $data ) ) {
-			throw new IllegalValueException( "array expected" );
+			throw new IllegalValueException( '$data must be an array; got ' . gettype( $data ) );
 		}
 
 		if ( !array_key_exists( 'entity-type', $data ) ) {

--- a/src/Entity/InMemoryDataTypeLookup.php
+++ b/src/Entity/InMemoryDataTypeLookup.php
@@ -53,7 +53,7 @@ class InMemoryDataTypeLookup implements PropertyDataTypeLookup {
 
 	private function verifyDataTypeIdType( $dataTypeId ) {
 		if ( !is_string( $dataTypeId ) ) {
-			throw new InvalidArgumentException( '$dataTypeId needs to be a string' );
+			throw new InvalidArgumentException( '$dataTypeId must be a string; got ' . gettype( $dataTypeId ) );
 		}
 	}
 

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -69,7 +69,7 @@ class Item extends Entity implements StatementListProvider {
 			$this->id = ItemId::newFromNumber( $id );
 		}
 		else {
-			throw new InvalidArgumentException( __METHOD__ . ' only accepts ItemId, integer and null' );
+			throw new InvalidArgumentException( '$id must be an instance of ItemId, an integer, or null' );
 		}
 	}
 
@@ -246,7 +246,7 @@ class Item extends Entity implements StatementListProvider {
 	 */
 	public function addClaim( Claim $statement ) {
 		if ( !( $statement instanceof Statement ) ) {
-			throw new InvalidArgumentException( 'Claims are not supported any more, use Statements.' );
+			throw new InvalidArgumentException( '$statement must be an instance of Statement' );
 		} elseif ( $statement->getGuid() === null ) {
 			throw new InvalidArgumentException( 'Can\'t add a Claim without a GUID.' );
 		}

--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -26,11 +26,11 @@ class ItemId extends EntityId {
 
 	private function assertValidIdFormat( $idSerialization ) {
 		if ( !is_string( $idSerialization ) ) {
-			throw new InvalidArgumentException( 'The id serialization needs to be a string.' );
+			throw new InvalidArgumentException( '$idSerialization must be a string; got ' . gettype( $idSerialization ) );
 		}
 
 		if ( !preg_match( self::PATTERN, $idSerialization ) ) {
-			throw new InvalidArgumentException( 'Invalid ItemId serialization provided.' );
+			throw new InvalidArgumentException( '$idSerialization must match ' . self::PATTERN );
 		}
 	}
 
@@ -80,7 +80,7 @@ class ItemId extends EntityId {
 	 */
 	public static function newFromNumber( $numericId ) {
 		if ( !is_numeric( $numericId ) ) {
-			throw new InvalidArgumentException( '$number needs to be numeric.' );
+			throw new InvalidArgumentException( '$numericId must be numeric' );
 		}
 
 		return new self( 'Q' . $numericId );

--- a/src/Entity/ItemIdSet.php
+++ b/src/Entity/ItemIdSet.php
@@ -31,7 +31,7 @@ class ItemIdSet implements IteratorAggregate, Countable, Comparable {
 	public function __construct( array $ids = array() ) {
 		foreach ( $ids as $id ) {
 			if ( !( $id instanceof ItemId ) ) {
-				throw new InvalidArgumentException( 'ItemIdSet can only contain instances of ItemId' );
+				throw new InvalidArgumentException( 'Every element in $ids must be an instance of ItemId' );
 			}
 
 			$this->ids[$id->getNumericId()] = $id;

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -62,7 +62,7 @@ class Property extends Entity implements StatementListProvider {
 			$this->id = PropertyId::newFromNumber( $id );
 		}
 		else {
-			throw new InvalidArgumentException( __METHOD__ . ' only accepts PropertyId, integer and null' );
+			throw new InvalidArgumentException( '$id must be an instance of PropertyId, an integer, or null' );
 		}
 	}
 
@@ -84,7 +84,7 @@ class Property extends Entity implements StatementListProvider {
 	 */
 	public function setDataTypeId( $dataTypeId ) {
 		if ( !is_string( $dataTypeId ) ) {
-			throw new InvalidArgumentException( '$dataTypeId needs to be a string' );
+			throw new InvalidArgumentException( '$dataTypeId must be a string; got ' . gettype( $dataTypeId ) );
 		}
 
 		$this->dataTypeId = $dataTypeId;

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -26,11 +26,11 @@ class PropertyId extends EntityId {
 
 	private function assertValidIdFormat( $idSerialization ) {
 		if ( !is_string( $idSerialization ) ) {
-			throw new InvalidArgumentException( 'The id serialization needs to be a string.' );
+			throw new InvalidArgumentException( '$idSerialization must be a string; got ' . gettype( $idSerialization ) );
 		}
 
 		if ( !preg_match( self::PATTERN, $idSerialization ) ) {
-			throw new InvalidArgumentException( 'Invalid PropertyId serialization provided.' );
+			throw new InvalidArgumentException( '$idSerialization must match ' . self::PATTERN );
 		}
 	}
 
@@ -80,7 +80,7 @@ class PropertyId extends EntityId {
 	 */
 	public static function newFromNumber( $numericId ) {
 		if ( !is_numeric( $numericId ) ) {
-			throw new InvalidArgumentException( '$number needs to be numeric.' );
+			throw new InvalidArgumentException( '$numericId must be numeric' );
 		}
 
 		return new self( 'P' . $numericId );

--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -414,10 +414,7 @@ abstract class HashArray extends \ArrayObject implements \Hashable, \Comparable 
 		if ( !$this->hasValidType( $value ) ) {
 			$type = is_object( $value ) ? get_class( $value ) : gettype( $value );
 
-			throw new InvalidArgumentException(
-				'Can only add ' . $this->getObjectType() . ' implementing objects to ' . get_called_class() . ', ' .
-				'but got a ' . $type . ' instead'
-			);
+			throw new InvalidArgumentException( '$value must be an instance of ' . $this->getObjectType() . '; got ' . $type );
 		}
 
 		if ( is_null( $index ) ) {

--- a/src/Internal/MapValueHasher.php
+++ b/src/Internal/MapValueHasher.php
@@ -34,7 +34,7 @@ class MapValueHasher implements MapHasher {
 	 */
 	public function hash( $map ) {
 		if ( !is_array( $map ) && !( $map instanceof Traversable ) ) {
-			throw new InvalidArgumentException( 'MapHasher::hash only accepts Traversable objects (including arrays)' );
+			throw new InvalidArgumentException( '$map must be an array or an instance of Traversable' );
 		}
 
 		$hashes = array();

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -40,7 +40,7 @@ class Reference implements \Hashable, \Comparable, \Immutable, \Countable {
 			$this->snaks = new SnakList( $snaks );
 		}
 		else {
-			throw new InvalidArgumentException();
+			throw new InvalidArgumentException( '$snaks must be an instance of Snaks, an array of instances of Snak, or null' );
 		}
 	}
 

--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -36,7 +36,7 @@ class ReferenceList extends HashableObjectStorage {
 	 */
 	public function addReference( Reference $reference, $index = null ) {
 		if( !is_null( $index ) && !is_integer( $index ) ) {
-			throw new InvalidArgumentException( 'Index needs to be an integer value' );
+			throw new InvalidArgumentException( '$index must be an integer or null; got ' . gettype( $index ) );
 		} else if ( is_null( $index ) || $index >= count( $this ) ) {
 			// Append object to the end of the reference list.
 			$this->attach( $reference );

--- a/src/SiteLink.php
+++ b/src/SiteLink.php
@@ -38,11 +38,11 @@ class SiteLink implements Comparable {
 	 */
 	public function __construct( $siteId, $pageName, $badges = null ) {
 		if ( !is_string( $siteId ) ) {
-			throw new InvalidArgumentException( '$siteId needs to be a string' );
+			throw new InvalidArgumentException( '$siteId must be a string; got ' . gettype( $siteId ) );
 		}
 
 		if ( !is_string( $pageName ) ) {
-			throw new InvalidArgumentException( '$pageName needs to be a string' );
+			throw new InvalidArgumentException( '$pageName must be a string; got ' . gettype( $pageName ) );
 		}
 
 		$this->siteId = $siteId;
@@ -56,7 +56,7 @@ class SiteLink implements Comparable {
 		} elseif ( is_array( $badges ) ) {
 			$badges = new ItemIdSet( $badges );
 		} elseif ( !( $badges instanceof ItemIdSet ) ) {
-			throw new InvalidArgumentException( '$badges needs to be ItemIdSet, ItemId[] or null' );
+			throw new InvalidArgumentException( '$badges must be an instance of ItemIdSet, an array of instances of ItemId, or null' );
 		}
 
 		$this->badges = $badges;

--- a/src/SiteLinkList.php
+++ b/src/SiteLinkList.php
@@ -33,7 +33,7 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	public function __construct( array $siteLinks = array() ) {
 		foreach ( $siteLinks as $siteLink ) {
 			if ( !( $siteLink instanceof SiteLink ) ) {
-				throw new InvalidArgumentException( 'SiteLinkList only accepts SiteLink objects' );
+				throw new InvalidArgumentException( 'Every element of $siteLinks must be an instance of SiteLink' );
 			}
 
 			$this->addSiteLink( $siteLink );
@@ -98,7 +98,7 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	 */
 	public function getBySiteId( $siteId ) {
 		if ( !$this->hasLinkWithSiteId( $siteId ) ) {
-			throw new OutOfBoundsException( 'No SiteLink with site id: ' . $siteId  );
+			throw new OutOfBoundsException( 'SiteLink with siteId "' . $siteId . '" not found'  );
 		}
 
 		return $this->siteLinks[$siteId];
@@ -114,7 +114,7 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	 */
 	public function hasLinkWithSiteId( $siteId ) {
 		if ( !is_string( $siteId ) ) {
-			throw new InvalidArgumentException( '$siteId should be a string' );
+			throw new InvalidArgumentException( '$siteId must be a string; got ' . gettype( $siteId ) );
 		}
 
 		return array_key_exists( $siteId, $this->siteLinks );
@@ -154,7 +154,7 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	 */
 	public function removeLinkWithSiteId( $siteId ) {
 		if ( !is_string( $siteId ) ) {
-			throw new InvalidArgumentException( '$siteId should be a string' );
+			throw new InvalidArgumentException( '$siteId must be a string; got ' . gettype( $siteId ) );
 		}
 
 		unset( $this->siteLinks[$siteId] );

--- a/src/Snak/SnakObject.php
+++ b/src/Snak/SnakObject.php
@@ -41,11 +41,11 @@ abstract class SnakObject implements Snak {
 		}
 
 		if ( !$propertyId instanceof EntityId ) {
-			throw new InvalidArgumentException( '$propertyId should be a PropertyId' );
+			throw new InvalidArgumentException( '$propertyId must be an instance of EntityId' );
 		}
 
 		if ( $propertyId->getEntityType() !== Property::ENTITY_TYPE ) {
-			throw new InvalidArgumentException( 'The $propertyId of a property snak can only be an ID of a Property object' );
+			throw new InvalidArgumentException( '$propertyId must have an entityType of ' . Property::ENTITY_TYPE );
 		}
 
 		if ( !( $propertyId instanceof PropertyId ) ) {

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -51,12 +51,12 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 
 	private function assertAreStatements( $statements ) {
 		if ( !is_array( $statements ) && !( $statements instanceof Traversable ) ) {
-			throw new InvalidArgumentException( '$statements should be an array or a Traversable' );
+			throw new InvalidArgumentException( '$statements must be an array or an instance of Traversable' );
 		}
 
 		foreach ( $statements as $statement ) {
 			if ( !( $statement instanceof Statement ) ) {
-				throw new InvalidArgumentException( 'All elements need to be of type Statement' );
+				throw new InvalidArgumentException( 'Every element in $statements must be an instance of Statement' );
 			}
 		}
 	}

--- a/src/Term/AliasGroup.php
+++ b/src/Term/AliasGroup.php
@@ -34,7 +34,7 @@ class AliasGroup implements Comparable, Countable {
 
 	private function setLanguageCode( $languageCode ) {
 		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode needs to be a string' );
+			throw new InvalidArgumentException( '$languageCode must be a string; got ' . gettype( $languageCode ) );
 		}
 
 		$this->languageCode = $languageCode;
@@ -43,7 +43,7 @@ class AliasGroup implements Comparable, Countable {
 	private function setAliases( array $aliases ) {
 		foreach ( $aliases as $alias ) {
 			if ( !is_string( $alias ) ) {
-				throw new InvalidArgumentException( 'All elements in $aliases need to be strings' );
+				throw new InvalidArgumentException( 'Every element in $aliases must be a string; found ' . gettype( $alias ) );
 			}
 		}
 

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -34,7 +34,7 @@ class AliasGroupList implements Countable, IteratorAggregate {
 	public function __construct( array $aliasGroups = array() ) {
 		foreach ( $aliasGroups as $aliasGroup ) {
 			if ( !( $aliasGroup instanceof AliasGroup ) ) {
-				throw new InvalidArgumentException( 'AliasGroupList can only contain AliasGroup instances' );
+				throw new InvalidArgumentException( 'Every element in $aliasGroups must be an instance of AliasGroup' );
 			}
 
 			$this->setGroup( $aliasGroup );
@@ -68,9 +68,7 @@ class AliasGroupList implements Countable, IteratorAggregate {
 		$this->assertIsLanguageCode( $languageCode );
 
 		if ( !array_key_exists( $languageCode, $this->groups ) ) {
-			throw new OutOfBoundsException(
-				'There is no AliasGroup with language code "' . $languageCode . '" in the list'
-			);
+			throw new OutOfBoundsException( 'AliasGroup with languageCode "' . $languageCode . '" not found' );
 		}
 
 		return $this->groups[$languageCode];
@@ -87,7 +85,7 @@ class AliasGroupList implements Countable, IteratorAggregate {
 
 	private function assertIsLanguageCode( $languageCode ) {
 		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode should be a string' );
+			throw new InvalidArgumentException( '$languageCode must be a string; got ' . gettype( $languageCode ) );
 		}
 	}
 

--- a/src/Term/Term.php
+++ b/src/Term/Term.php
@@ -26,11 +26,11 @@ class Term implements Comparable {
 	 */
 	public function __construct( $languageCode, $text ) {
 		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode should be a string' );
+			throw new InvalidArgumentException( '$languageCode must be a string; got ' . gettype( $languageCode ) );
 		}
 
 		if ( !is_string( $text ) ) {
-			throw new InvalidArgumentException( '$text should be a string' );
+			throw new InvalidArgumentException( '$text must be a string; got ' . gettype( $text ) );
 		}
 
 		$this->languageCode = $languageCode;

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -32,7 +32,7 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 	public function __construct( array $terms = array() ) {
 		foreach ( $terms as $term ) {
 			if ( !( $term instanceof Term ) ) {
-				throw new InvalidArgumentException( 'TermList can only contain instances of Term' );
+				throw new InvalidArgumentException( 'Every element in $terms must be an instance of Term' );
 			}
 
 			$this->terms[$term->getLanguageCode()] = $term;
@@ -81,9 +81,7 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 		$this->assertIsLanguageCode( $languageCode );
 
 		if ( !array_key_exists( $languageCode, $this->terms ) ) {
-			throw new OutOfBoundsException(
-				'There is no Term with language code "' . $languageCode . '" in the list'
-			);
+			throw new OutOfBoundsException( 'Term with languageCode "' . $languageCode . '" not found' );
 		}
 
 		return $this->terms[$languageCode];
@@ -101,7 +99,7 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 
 	private function assertIsLanguageCode( $languageCode ) {
 		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode should be a string' );
+			throw new InvalidArgumentException( '$languageCode must be a string; got ' . gettype( $languageCode ) );
 		}
 	}
 


### PR DESCRIPTION
I audited the exception error messages and discovered that different throws often reported the same error differently. I've gone through and made the text more uniform (and hopefully clearer and more helpful for a debugger) for the most common of cases.

I've left the following cases as-is:

```
ByPropertyIdArray.php:88:           throw new RuntimeException( 'Index not build, call buildIndex first' );
ByPropertyIdArray.php:220:          throw new OutOfBoundsException( 'Object cannot be moved to ' . $toIndex );
ByPropertyIdArray.php:387:          throw new OutOfBoundsException( 'Object not present in array' );
ByPropertyIdArray.php:389:          throw new OutOfBoundsException( 'Specified index is out of bounds' );
ByPropertyIdArray.php:465:          throw new OutOfBoundsException( 'No objects featuring the object\'s property exist' );
Statement/Statement.php:100:            throw new InvalidArgumentException( 'Invalid rank specified for statement: ' . var_export( $rank, true ) );
LegacyIdInterpreter.php:38:     throw new InvalidArgumentException( 'Invalid entityType ' . $entityType );
SiteLinkList.php:52:            throw new InvalidArgumentException( 'Duplicate site id: ' . $link->getSiteId() );
Claim/Claims.php:77:            throw new InvalidArgumentException( 'Can\'t handle claims with no GUID set!' );
Claim/ClaimGuidParser.php:41:           throw new ClaimGuidParsingException( '$serialization does not have the correct number of parts' );
Entity/Diff/EntityPatcher.php:50:       throw new RuntimeException( 'Patching the provided types of entities is not supported' );
Entity/Diff/EntityDiffer.php:47:            throw new InvalidArgumentException( 'Can only diff two entities of the same type' );
Entity/Diff/EntityDiffer.php:58:        throw new RuntimeException( 'Diffing the provided types of entities is not supported' );
Entity/Item.php:251:            throw new InvalidArgumentException( 'Can\'t add a Claim without a GUID.' );
Entity/InMemoryDataTypeLookup.php:50:           throw new PropertyNotFoundException( $propertyId, "The DataType for property '$numericId' is not set" );
Entity/Entity.php:367:      throw new RuntimeException( 'Claims on entities are not supported any more.' );
Entity/EntityIdValue.php:67:            throw new IllegalValueException( 'Invalid EntityIdValue serialization.' );
Entity/EntityIdValue.php:147:           throw new IllegalValueException( "'entity-type' field required" );
Entity/EntityIdValue.php:151:           throw new IllegalValueException( "'numeric-id' field required" );
Entity/EntityIdValue.php:161:           throw new IllegalValueException( $ex->getMessage(), 0, $ex );
Entity/DispatchingEntityIdParser.php:48:        throw $this->newInvalidIdException( $idSerialization );
Entity/DispatchingEntityIdParser.php:74:            throw $this->newInvalidIdException( $idSerialization );
```

These could also be made more uniform, but there weren't enough instances for me to determine the best format of the message.

In addition, in doing this, I discovered a few places where code could be optimized or where typos could be fixed, but I did not change them.

I also discovered that some exceptions that were essentially the same were actually called as different exceptions. (For example, treating a type error as an InvalidArgumentException in one place but a RuntimeException in another place.) I also did not touch these, as I didn't want to touch any actual workflow with these changes.

There were also a number of instances where exception messages could benefit from a global function that outputs either the class of an object or the type of a primitive. The code that would power this function is actually already in `src/HashArray.php`.
