### PR TITLE
Fix border condition bug in BestStatementsFinder

### DIFF
--- a/src/Statement/BestStatementsFinder.php
+++ b/src/Statement/BestStatementsFinder.php
@@ -60,14 +60,12 @@ class BestStatementsFinder {
 	 *
 	 * @param PropertyId $propertyId
 	 * @return Statement[]
-	 * @throws OutOfBoundsException
 	 */
 	public function getBestStatementsForProperty( PropertyId $propertyId ) {
 		$bestRank = Statement::RANK_NORMAL;
 		$statements = array();
 
-		/** @var Statement $statement */
-		foreach ( $this->byPropertyIdGrouper->getByPropertyId( $propertyId ) as $statement ) {
+		foreach ( $this->getStatementsBy( $propertyId ) as $statement ) {
 			$rank = $statement->getRank();
 			if ( $rank > $bestRank ) {
 				// clear statements if we found a better one
@@ -80,6 +78,19 @@ class BestStatementsFinder {
 		}
 
 		return $statements;
+	}
+
+	/**
+	 * @param PropertyId $propertyId
+	 *
+	 * @return Statement[]
+	 */
+	private function getStatementsBy( PropertyId $propertyId ) {
+		if ( $this->byPropertyIdGrouper->hasPropertyId( $propertyId ) ) {
+			return $this->byPropertyIdGrouper->getByPropertyId( $propertyId );
+		}
+
+		return array();
 	}
 
 }

--- a/tests/unit/Statement/BestStatementsFinderTest.php
+++ b/tests/unit/Statement/BestStatementsFinderTest.php
@@ -164,4 +164,13 @@ class BestStatementsFinderTest extends \PHPUnit_Framework_TestCase {
 		return $statement;
 	}
 
+	public function testGetBestStatementsForPropertyReturnsEmptyArrayWhenNoSuchProperty() {
+		$bestStatementFinder = new BestStatementsFinder( array() );
+
+		$this->assertSame(
+			array(),
+			$bestStatementFinder->getBestStatementsForProperty( new PropertyId( 'P1' ) )
+		);
+	}
+
 }


### PR DESCRIPTION
@Benestar This is why it's important to test border conditions. Typically what you want to do is have a single test for a "main case", and then one per border condition. (Having a whole pile for different main cases is likely a waste of time.)
