### PR TITLE
Make all Item constructor parameters optional

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,8 +12,9 @@
 * Added `ItemLookup` and `PropertyLookup` interfaces
 * Added `ItemNotFoundException`
 * Empty strings are now detected as invalid language codes in the term classes
-* `Item` constructor parameters for site links and statements are optional now
+* Made the `Item` constructor parameters optional
 * Made the `Fingerprint` constructor parameters optional
+* Deprecated `Item::newEmpty` in favour of `new Item()`
 * The `StatementList` constructor now accepts `Statement` objects in variable-lenght argument list format
 
 ## Version 2.4.1 (2014-11-26)

--- a/src/Entity/Diff/ItemDiffer.php
+++ b/src/Entity/Diff/ItemDiffer.php
@@ -113,7 +113,7 @@ class ItemDiffer implements EntityDifferStrategy {
 	 */
 	public function getConstructionDiff( EntityDocument $entity ) {
 		$this->assertIsItem( $entity );
-		return $this->diffEntities( Item::newEmpty(), $entity );
+		return $this->diffEntities( new Item(), $entity );
 	}
 
 	/**
@@ -124,7 +124,7 @@ class ItemDiffer implements EntityDifferStrategy {
 	 */
 	public function getDestructionDiff( EntityDocument $entity ) {
 		$this->assertIsItem( $entity );
-		return $this->diffEntities( $entity, Item::newEmpty() );
+		return $this->diffEntities( $entity, new Item() );
 	}
 
 }

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -41,18 +41,18 @@ class Item extends Entity implements StatementListProvider {
 	 * @since 1.0
 	 *
 	 * @param ItemId|null $id
-	 * @param Fingerprint $fingerprint
+	 * @param Fingerprint|null $fingerprint
 	 * @param SiteLinkList|null $siteLinks
 	 * @param StatementList|null $statements
 	 */
 	public function __construct(
 		ItemId $id = null,
-		Fingerprint $fingerprint,
+		Fingerprint $fingerprint = null,
 		SiteLinkList $siteLinks = null,
 		StatementList $statements = null
 	) {
 		$this->id = $id;
-		$this->fingerprint = $fingerprint;
+		$this->fingerprint = $fingerprint ?: new Fingerprint();
 		$this->siteLinks = $siteLinks ?: new SiteLinkList();
 		$this->statements = $statements ?: new StatementList();
 	}
@@ -181,12 +181,12 @@ class Item extends Entity implements StatementListProvider {
 	}
 
 	/**
-	 * @since 0.1
+	 * @deprecated since 2.5, use new Item() instead.
 	 *
 	 * @return Item
 	 */
 	public static function newEmpty() {
-		return new self( null, Fingerprint::newEmpty() );
+		return new self();
 	}
 
 	/**

--- a/tests/unit/Entity/Diff/EntityDiffOldTest.php
+++ b/tests/unit/Entity/Diff/EntityDiffOldTest.php
@@ -19,19 +19,15 @@ use Wikibase\DataModel\Entity\Property;
  */
 abstract class EntityDiffOldTest extends \PHPUnit_Framework_TestCase {
 
-	private static function newEntity ( $entityType ) {
+	private static function newEntity( $entityType ) {
 		switch ( $entityType ) {
 			case Item::ENTITY_TYPE:
-				$entity = Item::newEmpty();
-				break;
+				return new Item();
 			case Property::ENTITY_TYPE:
-				$entity = Property::newFromType( 'string' );
-				break;
+				return Property::newFromType( 'string' );
 			default:
 				throw new \RuntimeException( "unknown entity type: $entityType" );
 		}
-
-		return $entity;
 	}
 
 	public static function generateApplyData( $entityType ) {

--- a/tests/unit/Entity/Diff/EntityDifferTest.php
+++ b/tests/unit/Entity/Diff/EntityDifferTest.php
@@ -26,13 +26,13 @@ class EntityDifferTest extends \PHPUnit_Framework_TestCase {
 		$differ = new EntityDiffer();
 
 		$this->setExpectedException( 'InvalidArgumentException' );
-		$differ->diffEntities( Item::newEmpty(), Property::newFromType( 'string' ) );
+		$differ->diffEntities( new Item(), Property::newFromType( 'string' ) );
 	}
 
 	public function testGivenTwoEmptyItems_emptyItemDiffIsReturned() {
 		$differ = new EntityDiffer();
 
-		$diff = $differ->diffEntities( Item::newEmpty(), Item::newEmpty() );
+		$diff = $differ->diffEntities( new Item(), new Item() );
 
 		$this->assertInstanceOf( 'Wikibase\DataModel\Entity\Diff\ItemDiff', $diff );
 		$this->assertTrue( $diff->isEmpty() );

--- a/tests/unit/Entity/Diff/EntityPatcherTest.php
+++ b/tests/unit/Entity/Diff/EntityPatcherTest.php
@@ -32,10 +32,10 @@ class EntityPatcherTest extends \PHPUnit_Framework_TestCase {
 	public function itemProvider() {
 		$argLists = array();
 
-		$nonEmptyItem = Item::newEmpty();
+		$nonEmptyItem = new Item();
 		$nonEmptyItem->setId( 2 );
 
-		$argLists[] = array( Item::newEmpty() );
+		$argLists[] = array( new Item() );
 		$argLists[] = array( $nonEmptyItem );
 
 		return $argLists;

--- a/tests/unit/Entity/Diff/ItemDiffTest.php
+++ b/tests/unit/Entity/Diff/ItemDiffTest.php
@@ -37,7 +37,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 		 */
 
 		// add link ------------------------------
-		$a = Item::newEmpty();
+		$a = new Item();
 		$a->getSiteLinkList()->addSiteLink(
 			new SiteLink(
 				'enwiki',
@@ -63,7 +63,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 		$tests[] = array( $a, $b );
 
 		// add badges
-		$a = Item::newEmpty();
+		$a = new Item();
 		$a->getSiteLinkList()->addSiteLink(
 			new SiteLink(
 				'enwiki',
@@ -74,7 +74,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 			)
 		);
 
-		$b = Item::newEmpty();
+		$b = new Item();
 		$b->getSiteLinkList()->addSiteLink(
 			new SiteLink(
 				'enwiki',
@@ -89,7 +89,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 		$tests[] = array( $a, $b );
 
 		// remove badges
-		$a = Item::newEmpty();
+		$a = new Item();
 		$a->getSiteLinkList()->addSiteLink(
 			new SiteLink(
 				'enwiki',
@@ -101,7 +101,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 			)
 		);
 
-		$b = Item::newEmpty();
+		$b = new Item();
 		$b->getSiteLinkList()->addSiteLink(
 			new SiteLink(
 				'enwiki',
@@ -113,7 +113,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 		);
 
 		// modify badges
-		$a = Item::newEmpty();
+		$a = new Item();
 		$a->getSiteLinkList()->addSiteLink(
 			new SiteLink(
 				'enwiki',
@@ -125,7 +125,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 			)
 		);
 
-		$b = Item::newEmpty();
+		$b = new Item();
 		$b->getSiteLinkList()->addSiteLink(
 			new SiteLink(
 				'enwiki',
@@ -140,7 +140,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 		$tests[] = array( $a, $b );
 
 		// remove link
-		$a = Item::newEmpty();
+		$a = new Item();
 		$a->getSiteLinkList()->addSiteLink(
 			new SiteLink(
 				'enwiki',
@@ -166,7 +166,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 		$tests[] = array( $a, $b );
 
 		// change link
-		$a = Item::newEmpty();
+		$a = new Item();
 		$a->getSiteLinkList()->addSiteLink(
 			new SiteLink(
 				'enwiki',
@@ -178,7 +178,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 			)
 		);
 
-		$b = Item::newEmpty();
+		$b = new Item();
 		$b->getSiteLinkList()->addSiteLink(
 			new SiteLink(
 				'enwiki',

--- a/tests/unit/Entity/Diff/ItemDifferTest.php
+++ b/tests/unit/Entity/Diff/ItemDifferTest.php
@@ -22,18 +22,18 @@ class ItemDifferTest extends \PHPUnit_Framework_TestCase {
 	public function testGivenTwoEmptyItems_emptyItemDiffIsReturned() {
 		$differ = new ItemDiffer();
 
-		$diff = $differ->diffEntities( Item::newEmpty(), Item::newEmpty() );
+		$diff = $differ->diffEntities( new Item(), new Item() );
 
 		$this->assertInstanceOf( 'Wikibase\DataModel\Entity\Diff\ItemDiff', $diff );
 		$this->assertTrue( $diff->isEmpty() );
 	}
 
 	public function testFingerprintIsDiffed() {
-		$firstItem = Item::newEmpty();
+		$firstItem = new Item();
 		$firstItem->getFingerprint()->setLabel( 'en', 'kittens' );
 		$firstItem->getFingerprint()->setAliasGroup( 'en', array( 'cats' ) );
 
-		$secondItem = Item::newEmpty();
+		$secondItem = new Item();
 		$secondItem->getFingerprint()->setLabel( 'en', 'nyan' );
 		$secondItem->getFingerprint()->setDescription( 'en', 'foo bar baz' );
 
@@ -57,9 +57,9 @@ class ItemDifferTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testClaimsAreDiffed() {
-		$firstItem = Item::newEmpty();
+		$firstItem = new Item();
 
-		$secondItem = Item::newEmpty();
+		$secondItem = new Item();
 		$secondItem->getStatements()->addNewStatement( new PropertySomeValueSnak( 42 ), null, null, 'guid' );
 
 		$differ = new ItemDiffer();
@@ -70,16 +70,16 @@ class ItemDifferTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGivenEmptyItem_constructionDiffIsEmpty() {
 		$differ = new ItemDiffer();
-		$this->assertTrue( $differ->getConstructionDiff( Item::newEmpty() )->isEmpty() );
+		$this->assertTrue( $differ->getConstructionDiff( new Item() )->isEmpty() );
 	}
 
 	public function testGivenEmptyItem_destructionDiffIsEmpty() {
 		$differ = new ItemDiffer();
-		$this->assertTrue( $differ->getDestructionDiff( Item::newEmpty() )->isEmpty() );
+		$this->assertTrue( $differ->getDestructionDiff( new Item() )->isEmpty() );
 	}
 
 	public function testConstructionDiffContainsAddOperations() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->getFingerprint()->setLabel( 'en', 'foo' );
 		$item->getSiteLinkList()->addNewSiteLink( 'bar', 'baz' );
 

--- a/tests/unit/Entity/Diff/ItemPatcherTest.php
+++ b/tests/unit/Entity/Diff/ItemPatcherTest.php
@@ -19,7 +19,7 @@ use Wikibase\DataModel\Entity\Property;
 class ItemPatcherTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGivenEmptyDiff_itemIsReturnedAsIs() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->getFingerprint()->setLabel( 'en', 'foo' );
 		$item->getSiteLinkList()->addNewSiteLink( 'enwiki', 'bar' );
 
@@ -54,7 +54,7 @@ class ItemPatcherTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testPatchesLabels() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->getFingerprint()->setLabel( 'en', 'foo' );
 		$item->getFingerprint()->setLabel( 'de', 'bar' );
 

--- a/tests/unit/Entity/Diff/PropertyPatcherTest.php
+++ b/tests/unit/Entity/Diff/PropertyPatcherTest.php
@@ -53,7 +53,7 @@ class PropertyPatcherTest extends \PHPUnit_Framework_TestCase {
 		$patcher = new PropertyPatcher();
 
 		$this->setExpectedException( 'InvalidArgumentException' );
-		$patcher->patchEntity( Item::newEmpty(), new EntityDiff() );
+		$patcher->patchEntity( new Item(), new EntityDiff() );
 	}
 
 	public function testStatementsArePatched() {

--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -10,7 +10,6 @@ use Wikibase\DataModel\Entity\Diff\EntityDiff;
 use Wikibase\DataModel\Entity\Entity;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Reference;
-use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;
@@ -388,7 +387,7 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCopyRetainsLabels() {
-		$item = Item::newEmpty();
+		$item = new Item();
 
 		$item->getFingerprint()->setLabel( 'en', 'foo' );
 		$item->getFingerprint()->setLabel( 'de', 'bar' );

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -24,7 +24,6 @@ use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Snak\SnakList;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
-use Wikibase\DataModel\Term\Fingerprint;
 
 /**
  * @covers Wikibase\DataModel\Entity\Item
@@ -112,7 +111,7 @@ class ItemTest extends EntityTest {
 	 * @return Item
 	 */
 	protected function getNewEmpty() {
-		return Item::newEmpty();
+		return new Item();
 	}
 
 	public function testGetId() {
@@ -134,13 +133,13 @@ class ItemTest extends EntityTest {
 	public function itemProvider() {
 		$items = array();
 
-		$items[] = Item::newEmpty();
+		$items[] = new Item();
 
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->setDescription( 'en', 'foo' );
 		$items[] = $item;
 
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->setDescription( 'en', 'foo' );
 		$item->setDescription( 'de', 'foo' );
 		$item->setLabel( 'en', 'foo' );
@@ -440,7 +439,7 @@ class ItemTest extends EntityTest {
 	}
 
 	public function testGetSiteLinkWithNonSetSiteId() {
-		$item = Item::newEmpty();
+		$item = new Item();
 
 		$this->setExpectedException( 'OutOfBoundsException' );
 		$item->getSiteLinkList()->getBySiteId( 'enwiki' );
@@ -450,7 +449,7 @@ class ItemTest extends EntityTest {
 	 * @dataProvider simpleSiteLinkProvider
 	 */
 	public function testAddSiteLink( SiteLink $siteLink ) {
-		$item = Item::newEmpty();
+		$item = new Item();
 
 		$item->getSiteLinkList()->addSiteLink( $siteLink );
 
@@ -507,7 +506,7 @@ class ItemTest extends EntityTest {
 	 */
 	public function testGetSiteLinks() {
 		$siteLinks = func_get_args();
-		$item = Item::newEmpty();
+		$item = new Item();
 
 		foreach ( $siteLinks as $siteLink ) {
 			$item->getSiteLinkList()->addSiteLink( $siteLink );
@@ -539,7 +538,7 @@ class ItemTest extends EntityTest {
 	}
 
 	public function testHasLinkToSiteForFalse() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->getSiteLinkList()->addSiteLink( new SiteLink( 'ENWIKI', 'Wikidata', array( new ItemId( 'Q42' ) ) ) );
 
 		$this->assertFalse( $item->getSiteLinkList()->hasLinkWithSiteId( 'enwiki' ) );
@@ -548,7 +547,7 @@ class ItemTest extends EntityTest {
 	}
 
 	public function testHasLinkToSiteForTrue() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->getSiteLinkList()->addSiteLink( new SiteLink( 'enwiki', 'Wikidata', array( new ItemId( 'Q42' ) ) ) );
 		$item->getSiteLinkList()->addSiteLink( new SiteLink( 'dewiki', 'Wikidata' ) );
 		$item->getSiteLinkList()->addSiteLink( new SiteLink( 'foo bar', 'Wikidata' ) );
@@ -562,7 +561,7 @@ class ItemTest extends EntityTest {
 		/** @var Snak $snak */
 		$snak = $this->getMock( 'Wikibase\DataModel\Snak\Snak' );
 
-		$item = Item::newEmpty();
+		$item = new Item();
 		$statement = $item->newClaim( $snak );
 
 		$this->assertInstanceOf( 'Wikibase\DataModel\Statement\Statement', $statement );
@@ -570,7 +569,7 @@ class ItemTest extends EntityTest {
 	}
 
 	public function testSetClaims() {
-		$item = Item::newEmpty();
+		$item = new Item();
 
 		$statement0 = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
 		$statement0->setGuid( 'TEST$NVS42' );
@@ -589,11 +588,12 @@ class ItemTest extends EntityTest {
 
 
 	public function testEmptyItemReturnsEmptySiteLinkList() {
-		$this->assertTrue( Item::newEmpty()->getSiteLinkList()->isEmpty() );
+		$item = new Item();
+		$this->assertTrue( $item->getSiteLinkList()->isEmpty() );
 	}
 
 	public function testAddSiteLinkOverridesOldLinks() {
-		$item = Item::newEmpty();
+		$item = new Item();
 
 		$item->getSiteLinkList()->addSiteLink( new SiteLink( 'kittens', 'foo' ) );
 
@@ -604,37 +604,38 @@ class ItemTest extends EntityTest {
 	}
 
 	public function testEmptyItemIsEmpty() {
-		$this->assertTrue( Item::newEmpty()->isEmpty() );
+		$item = new Item();
+		$this->assertTrue( $item->isEmpty() );
 	}
 
 	public function testItemWithIdIsEmpty() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->setId( 1337 );
 		$this->assertTrue( $item->isEmpty() );
 	}
 
 	public function testItemWithStuffIsNotEmpty() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->getFingerprint()->setAliasGroup( 'en', array( 'foo' ) );
 		$this->assertFalse( $item->isEmpty() );
 
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->getSiteLinkList()->addNewSiteLink( 'en', 'o_O' );
 		$this->assertFalse( $item->isEmpty() );
 
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->addClaim( $this->newStatement() );
 		$this->assertFalse( $item->isEmpty() );
 	}
 
 	public function testItemWithSitelinksHasSitelinks() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->getSiteLinkList()->addNewSiteLink( 'en', 'foo' );
 		$this->assertFalse( $item->getSiteLinkList()->isEmpty() );
 	}
 
 	public function testItemWithoutSitelinksHasNoSitelinks() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$this->assertTrue( $item->getSiteLinkList()->isEmpty() );
 	}
 
@@ -645,7 +646,7 @@ class ItemTest extends EntityTest {
 	}
 
 	public function testClearRemovesAllButId() {
-		$item = Item::newEmpty();
+		$item = new Item();
 
 		$item->setId( 42 );
 		$item->getFingerprint()->setLabel( 'en', 'foo' );
@@ -660,18 +661,22 @@ class ItemTest extends EntityTest {
 		$this->assertTrue( $item->getStatements()->isEmpty() );
 	}
 
+	public function testEmptyConstructor() {
+		$item = new Item();
+
+		$this->assertNull( $item->getId() );
+		$this->assertTrue( $item->getFingerprint()->isEmpty() );
+		$this->assertTrue( $item->getSiteLinkList()->isEmpty() );
+		$this->assertTrue( $item->getStatements()->isEmpty() );
+	}
+
 	public function testCanConstructWithStatementList() {
 		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
 		$statement->setGuid( 'meh' );
 
 		$statements = new StatementList( array( $statement ) );
 
-		$item = new Item(
-			null,
-			new Fingerprint(),
-			null,
-			$statements
-		);
+		$item = new Item( null, null, null, $statements );
 
 		$this->assertEquals(
 			$statements,
@@ -680,7 +685,7 @@ class ItemTest extends EntityTest {
 	}
 
 	public function testSetStatements() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
 
 		$item->setStatements( new StatementList() );
@@ -688,17 +693,17 @@ class ItemTest extends EntityTest {
 	}
 
 	public function testGetStatementsReturnsCorrectTypeAfterClear() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->clear();
 
 		$this->assertTrue( $item->getStatements()->isEmpty() );
 	}
 
 	public function equalsProvider() {
-		$firstItem = Item::newEmpty();
+		$firstItem = new Item();
 		$firstItem->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
 
-		$secondItem = Item::newEmpty();
+		$secondItem = new Item();
 		$secondItem->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
 
 		$secondItemWithId = unserialize( serialize( $secondItem ) );
@@ -708,7 +713,7 @@ class ItemTest extends EntityTest {
 		$differentId->setId( 43 );
 
 		return array(
-			array( Item::newEmpty(), Item::newEmpty() ),
+			array( new Item(), new Item() ),
 			array( $firstItem, $secondItem ),
 			array( $secondItem, $secondItemWithId ),
 			array( $secondItemWithId, $differentId ),
@@ -724,7 +729,7 @@ class ItemTest extends EntityTest {
 	}
 
 	private function getBaseItem() {
-		$item = Item::newEmpty();
+		$item = new Item();
 
 		$item->setId( 42 );
 		$item->getFingerprint()->setLabel( 'en', 'Same' );
@@ -757,7 +762,7 @@ class ItemTest extends EntityTest {
 		$item = $this->getBaseItem();
 
 		return array(
-			'empty' => array( $item, Item::newEmpty() ),
+			'empty' => array( $item, new Item() ),
 			'label' => array( $item, $differentLabel ),
 			'description' => array( $item, $differentDescription ),
 			'alias' => array( $item, $differentAlias ),

--- a/tests/unit/Entity/TestItems.php
+++ b/tests/unit/Entity/TestItems.php
@@ -20,27 +20,27 @@ final class TestItems {
 	public static function getItems() {
 		$items = array();
 
-		$items[] = Item::newEmpty();
+		$items[] = new Item();
 
-		$item = Item::newEmpty();
+		$item = new Item();
 
 		$item->setDescription( 'en', 'foo' );
 		$item->setLabel( 'en', 'bar' );
 
 		$items[] = $item;
 
-		$item = Item::newEmpty();
+		$item = new Item();
 
 		$item->addAliases( 'en', array( 'foobar', 'baz' ) );
 
 		$items[] = $item;
 
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->getSiteLinkList()->addSiteLink( new SiteLink( 'enwiki', 'spam' ) );
 
 		$items[] = $item;
 
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->getSiteLinkList()->addSiteLink( new SiteLink( 'enwiki', 'spamz' ) );
 		$item->getSiteLinkList()->addSiteLink( new SiteLink( 'dewiki', 'foobar' ) );
 


### PR DESCRIPTION
Main reason to touch this was the `Item` constructor. The first parameter can be null but the others can not? This doesn't make much sense. Why not simply make them all optional?