### PR TITLE
Make AliasGroup constructor parameter optional

### DIFF
--- a/src/Term/AliasGroup.php
+++ b/src/Term/AliasGroup.php
@@ -27,7 +27,7 @@ class AliasGroup implements Comparable, Countable {
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function __construct( $languageCode, array $aliases ) {
+	public function __construct( $languageCode, array $aliases = array() ) {
 		$this->setLanguageCode( $languageCode );
 		$this->setAliases( $aliases );
 	}

--- a/tests/unit/Term/AliasGroupListTest.php
+++ b/tests/unit/Term/AliasGroupListTest.php
@@ -87,9 +87,9 @@ class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
 		$enGroup = new AliasGroup( 'en', array( 'foo' ) );
 
 		$list = new AliasGroupList( array(
-			new AliasGroup( 'de', array() ),
+			new AliasGroup( 'de' ),
 			$enGroup,
-			new AliasGroup( 'nl', array() ),
+			new AliasGroup( 'nl' ),
 		) );
 
 		$this->assertEquals( $enGroup, $list->getByLanguage( 'en' ) );
@@ -153,14 +153,14 @@ class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
 		$enGroup = new AliasGroup( 'en', array( 'foo' ) );
 
 		$list = new AliasGroupList( array(
-			new AliasGroup( 'de', array() ),
+			new AliasGroup( 'de' ),
 			$enGroup,
-			new AliasGroup( 'en', array() ),
-			new AliasGroup( 'nl', array() ),
+			new AliasGroup( 'en' ),
+			new AliasGroup( 'nl' ),
 		) );
 
 		$expectedList = new AliasGroupList( array(
-			new AliasGroup( 'en', array() ),
+			new AliasGroup( 'en' ),
 		) );
 
 		$this->assertEquals( $expectedList, $list );
@@ -173,8 +173,8 @@ class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
 
 		$expectedList = new AliasGroupList( array() );
 
-		$list->setGroup( new AliasGroup( 'en', array() ) );
-		$list->setGroup( new AliasGroup( 'de', array() ) );
+		$list->setGroup( new AliasGroup( 'en' ) );
+		$list->setGroup( new AliasGroup( 'de' ) );
 
 		$this->assertEquals( $expectedList, $list );
 	}

--- a/tests/unit/Term/AliasGroupTest.php
+++ b/tests/unit/Term/AliasGroupTest.php
@@ -23,7 +23,7 @@ class AliasGroupTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testIsEmpty() {
-		$emptyGroup = new AliasGroup( 'en', array() );
+		$emptyGroup = new AliasGroup( 'en' );
 		$this->assertTrue( $emptyGroup->isEmpty() );
 
 		$filledGroup = new AliasGroup( 'en', array( 'foo' ) );
@@ -48,7 +48,7 @@ class AliasGroupTest extends \PHPUnit_Framework_TestCase {
 		$group = new AliasGroup( 'en', array( 'foo', 'bar' ) );
 
 		$this->assertFalse( $group->equals( new AliasGroup( 'de', array( 'foo', 'bar' ) ) ) );
-		$this->assertFalse( $group->equals( new AliasGroup( 'de', array() ) ) );
+		$this->assertFalse( $group->equals( new AliasGroup( 'de' ) ) );
 	}
 
 	public function testGroupDoesNotEqualWhenOrderIsDifferent() {
@@ -67,7 +67,7 @@ class AliasGroupTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testIsCountable() {
-		$this->assertCount( 0, new AliasGroup( 'en', array() ) );
+		$this->assertCount( 0, new AliasGroup( 'en' ) );
 		$this->assertCount( 1, new AliasGroup( 'en', array( 'foo' ) ) );
 		$this->assertCount( 2, new AliasGroup( 'en', array( 'foo', 'bar' ) ) );
 	}


### PR DESCRIPTION
Either that or throw an exception if the array is empty. I think we discussed this some time ago and decided the later should be done. Therefor the [DNM].
