### PR TITLE
Allow constructing empty Fingerprint

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,6 +15,7 @@
 * Made the `Item` constructor parameters optional
 * Made the `Fingerprint` constructor parameters optional
 * Deprecated `Item::newEmpty` in favour of `new Item()`
+* Deprecated `Fingerprint::newEmpty` in favour of `new Fingerprint()`
 * The `StatementList` constructor now accepts `Statement` objects in variable-lenght argument list format
 
 ## Version 2.4.1 (2014-11-26)

--- a/src/Term/Fingerprint.php
+++ b/src/Term/Fingerprint.php
@@ -15,6 +15,8 @@ use InvalidArgumentException;
 class Fingerprint implements Comparable {
 
 	/**
+	 * @deprecated since 2.5, use new Fingerprint() instead.
+	 *
 	 * @return Fingerprint
 	 */
 	public static function newEmpty() {


### PR DESCRIPTION
This is split from #290. I hope we all agree that the concept of an empty Fingerprint is in the scope of the DataModel.