### PR TITLE
Reworked all equals methods

### DIFF
--- a/src/Claim/Claim.php
+++ b/src/Claim/Claim.php
@@ -209,10 +209,16 @@ class Claim implements Hashable, Comparable, PropertyIdProvider {
 	 *
 	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function equals( $target ) {
-		if ( !( $target instanceof self ) || $target instanceof Statement ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
+		if ( !( $target instanceof self )
+			|| $target instanceof Statement
+		) {
 			return false;
 		}
 

--- a/src/Claim/ClaimGuid.php
+++ b/src/Claim/ClaimGuid.php
@@ -60,6 +60,10 @@ class ClaimGuid implements Comparable {
 	 * @return bool
 	 */
 	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
 		return $target instanceof self
 			&& $target->serialization === $this->serialization;
 	}

--- a/src/Claim/Claims.php
+++ b/src/Claim/Claims.php
@@ -469,14 +469,16 @@ class Claims extends ArrayObject implements ClaimListAccess, Hashable, Comparabl
 	 *
 	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function equals( $target ) {
-		if ( !( $target instanceof self ) ) {
-			return false;
+		if ( $this === $target ) {
+			return true;
 		}
 
-		if ( $this->count() !== $target->count() ) {
+		if ( !( $target instanceof self )
+			|| $this->count() !== $target->count()
+		) {
 			return false;
 		}
 

--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -55,9 +55,13 @@ abstract class EntityId implements \Comparable, \Serializable {
 	 *
 	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
 		return $target instanceof self
 			&& $target->serialization === $this->serialization;
 	}

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -309,22 +309,19 @@ class Item extends Entity implements StatementListProvider {
 	 *
 	 * @since 0.1
 	 *
-	 * @param mixed $that
+	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
-	public function equals( $that ) {
-		if ( $this === $that ) {
+	public function equals( $target ) {
+		if ( $this === $target ) {
 			return true;
 		}
 
-		if ( !( $that instanceof self ) ) {
-			return false;
-		}
-
-		return $this->fingerprint->equals( $that->fingerprint )
-			&& $this->siteLinks->equals( $that->siteLinks )
-			&& $this->statements->equals( $that->statements );
+		return $target instanceof self
+			&& $this->fingerprint->equals( $target->fingerprint )
+			&& $this->siteLinks->equals( $target->siteLinks )
+			&& $this->statements->equals( $target->statements );
 	}
 
 }

--- a/src/Entity/ItemIdSet.php
+++ b/src/Entity/ItemIdSet.php
@@ -70,14 +70,15 @@ class ItemIdSet implements IteratorAggregate, Countable, Comparable {
 	 *
 	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function equals( $target ) {
-		if ( !( $target instanceof self ) ) {
-			return false;
+		if ( $this === $target ) {
+			return true;
 		}
 
-		return $this->ids == $target->ids;
+		return $target instanceof self
+			&& $this->ids == $target->ids;
 	}
 
 }

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -4,8 +4,8 @@ namespace Wikibase\DataModel\Entity;
 
 use InvalidArgumentException;
 use Wikibase\DataModel\Statement\StatementList;
-use Wikibase\DataModel\Term\Fingerprint;
 use Wikibase\DataModel\StatementListProvider;
+use Wikibase\DataModel\Term\Fingerprint;
 
 /**
  * Represents a single Wikibase property.
@@ -136,22 +136,19 @@ class Property extends Entity implements StatementListProvider {
 	 *
 	 * @since 0.1
 	 *
-	 * @param mixed $that
+	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
-	public function equals( $that ) {
-		if ( $this === $that ) {
+	public function equals( $target ) {
+		if ( $this === $target ) {
 			return true;
 		}
 
-		if ( !( $that instanceof self ) ) {
-			return false;
-		}
-
-		return $this->dataTypeId === $that->dataTypeId
-			&& $this->fingerprint->equals( $that->fingerprint )
-			&& $this->statements->equals( $that->statements );
+		return $target instanceof self
+			&& $this->dataTypeId === $target->dataTypeId
+			&& $this->fingerprint->equals( $target->fingerprint )
+			&& $this->statements->equals( $target->statements );
 	}
 
 	/**

--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -289,13 +289,17 @@ abstract class HashArray extends \ArrayObject implements \Hashable, \Comparable 
 	 *
 	 * @since 0.3
 	 *
-	 * @param mixed $mixed
+	 * @param mixed $target
 	 *
 	 * @return bool
 	 */
-	public function equals( $mixed ) {
-		return $mixed instanceof self
-			&& $this->getHash() === $mixed->getHash();
+	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
+		return $target instanceof self
+			&& $this->getHash() === $target->getHash();
 	}
 
 	/**

--- a/src/HashableObjectStorage.php
+++ b/src/HashableObjectStorage.php
@@ -75,13 +75,17 @@ class HashableObjectStorage extends \SplObjectStorage implements \Comparable {
 	 *
 	 * @since 0.3
 	 *
-	 * @param mixed $mixed
+	 * @param mixed $target
 	 *
 	 * @return bool
 	 */
-	public function equals( $mixed ) {
-		return $mixed instanceof self
-			&& $this->getValueHash() === $mixed->getValueHash();
+	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
+		return $target instanceof self
+			&& $this->getValueHash() === $target->getValueHash();
 	}
 
 }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -92,13 +92,17 @@ class Reference implements \Hashable, \Comparable, \Immutable, \Countable {
 	 *
 	 * @since 0.3
 	 *
-	 * @param mixed $mixed
+	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
-	public function equals( $mixed ) {
-		return $mixed instanceof self
-			&& $this->snaks->equals( $mixed->snaks );
+	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
+		return $target instanceof self
+			&& $this->snaks->equals( $target->snaks );
 	}
 
 }

--- a/src/SiteLink.php
+++ b/src/SiteLink.php
@@ -101,15 +101,12 @@ class SiteLink implements Comparable {
 	 * @return bool
 	 */
 	public function equals( $target ) {
-		if ( $target === $this ) {
+		if ( $this === $target ) {
 			return true;
 		}
 
-		if ( !( $target instanceof self ) ) {
-			return false;
-		}
-
-		return $this->siteId === $target->siteId
+		return $target instanceof self
+			&& $this->siteId === $target->siteId
 			&& $this->pageName === $target->pageName
 			&& $this->badges->equals( $target->badges );
 	}

--- a/src/SiteLinkList.php
+++ b/src/SiteLinkList.php
@@ -127,14 +127,15 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	 *
 	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function equals( $target ) {
-		if ( !( $target instanceof self ) ) {
-			return false;
+		if ( $this === $target ) {
+			return true;
 		}
 
-		return $this->siteLinks == $target->siteLinks;
+		return $target instanceof self
+			&& $this->siteLinks == $target->siteLinks;
 	}
 
 	/**

--- a/src/Snak/SnakObject.php
+++ b/src/Snak/SnakObject.php
@@ -85,15 +85,12 @@ abstract class SnakObject implements Snak {
 	 * @return bool
 	 */
 	public function equals( $target ) {
-		if ( $target === $this ) {
+		if ( $this === $target ) {
 			return true;
 		}
 
-		if ( !( $target instanceof Snak ) ) {
-			return false;
-		}
-
-		return $this->getHash() === $target->getHash();
+		return $target instanceof self
+			&& $this->getHash() === $target->getHash();
 	}
 
 	/**

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -160,14 +160,15 @@ class Statement extends Claim {
 	 *
 	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function equals( $target ) {
-		if ( !( $target instanceof self ) ) {
-			return false;
+		if ( $this === $target ) {
+			return true;
 		}
 
-		return $this->claimFieldsEqual( $target )
+		return $target instanceof self
+			&& $this->claimFieldsEqual( $target )
 			&& $this->rank === $target->getRank()
 			&& $this->references->equals( $target->references );
 	}

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -208,22 +208,22 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	/**
 	 * @see Comparable::equals
 	 *
-	 * @param mixed $statementList
+	 * @param mixed $target
 	 *
 	 * @return bool
 	 */
-	public function equals( $statementList ) {
-		if ( $this === $statementList ) {
+	public function equals( $target ) {
+		if ( $this === $target ) {
 			return true;
 		}
 
-		if ( !( $statementList instanceof self )
-			|| $this->count() !== $statementList->count()
+		if ( !( $target instanceof self )
+			|| $this->count() !== $target->count()
 		) {
 			return false;
 		}
 
-		return $this->statementsEqual( $statementList->statements );
+		return $this->statementsEqual( $target->statements );
 	}
 
 	private function statementsEqual( array $statements ) {

--- a/src/Term/AliasGroup.php
+++ b/src/Term/AliasGroup.php
@@ -91,6 +91,10 @@ class AliasGroup implements Comparable, Countable {
 	 * @return bool
 	 */
 	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
 		return $target instanceof self
 			&& $this->languageCode === $target->languageCode
 			&& $this->aliases == $target->aliases;

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -122,14 +122,16 @@ class AliasGroupList implements Countable, IteratorAggregate {
 	 *
 	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function equals( $target ) {
-		if ( !( $target instanceof self ) ) {
-			return false;
+		if ( $this === $target ) {
+			return true;
 		}
 
-		if ( $this->count() !== $target->count() ) {
+		if ( !( $target instanceof self )
+			|| $this->count() !== $target->count()
+		) {
 			return false;
 		}
 

--- a/src/Term/Fingerprint.php
+++ b/src/Term/Fingerprint.php
@@ -195,14 +195,15 @@ class Fingerprint implements Comparable {
 	 *
 	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function equals( $target ) {
-		if ( !( $target instanceof self ) ) {
-			return false;
+		if ( $this === $target ) {
+			return true;
 		}
 
-		return $this->descriptions->equals( $target->getDescriptions() )
+		return $target instanceof self
+			&& $this->descriptions->equals( $target->getDescriptions() )
 			&& $this->labels->equals( $target->getLabels() )
 			&& $this->aliasGroups->equals( $target->getAliasGroups() );
 	}

--- a/src/Term/Term.php
+++ b/src/Term/Term.php
@@ -59,9 +59,13 @@ class Term implements Comparable {
 	 * @return bool
 	 */
 	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
 		return $target instanceof self
-			&& $this->text === $target->getText()
-			&& $this->languageCode === $target->getLanguageCode();
+			&& $this->languageCode === $target->getLanguageCode()
+			&& $this->text === $target->getText();
 	}
 
 }

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -124,14 +124,16 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 	 *
 	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function equals( $target ) {
-		if ( !( $target instanceof self ) ) {
-			return false;
+		if ( $this === $target ) {
+			return true;
 		}
 
-		if ( $this->count() !== $target->count() ) {
+		if ( !( $target instanceof self )
+			|| $this->count() !== $target->count()
+		) {
 			return false;
 		}
 


### PR DESCRIPTION
Main change are the "shorten out if it's the same object" checks.

I avoided the variable name `$that` because it's to close to `$this` and I remember we already shot us in the foot because of that, see #169. ;-)

I'm not 100% sure if the coding style I'm using now is the absolute best. But at least it's the same in all classes now. Please note that I merged the `instanceof` check in the final `return` if possible. I find a straight `&&` combined list of checks easier to read compared to a separate `return false`.
