### PR TITLE
Normalize namespaces of all tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,7 @@ if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 
 $autoLoader = require_once __DIR__ . '/../vendor/autoload.php';
 
-$autoLoader->addPsr4( 'Wikibase\\Test\\', __DIR__ . '/unit/' );
-$autoLoader->addPsr4( 'Wikibase\\Test\\DataModel\\Fixtures\\', __DIR__ . '/fixtures/' );
+$autoLoader->addPsr4( 'Wikibase\\DataModel\\Tests\\', __DIR__ . '/unit/' );
+$autoLoader->addPsr4( 'Wikibase\\DataModel\\Fixtures\\', __DIR__ . '/fixtures/' );
 
 unset( $autoLoader );

--- a/tests/component/AutoloadingAliasesTest.php
+++ b/tests/component/AutoloadingAliasesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wikibase\DataModel;
+namespace Wikibase\DataModel\Tests;
 
 /**
  * @licence GNU GPL v2+

--- a/tests/fixtures/EntityOfUnknownType.php
+++ b/tests/fixtures/EntityOfUnknownType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\DataModel\Fixtures;
+namespace Wikibase\DataModel\Fixtures;
 
 use Wikibase\DataModel\Entity\EntityDocument;
 

--- a/tests/fixtures/HashArrayElement.php
+++ b/tests/fixtures/HashArrayElement.php
@@ -1,12 +1,14 @@
 <?php
 
-namespace Wikibase\Test\DataModel\Fixtures;
+namespace Wikibase\DataModel\Fixtures;
+
+use Hashable;
 
 /**
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class HashArrayElement implements \Hashable {
+class HashArrayElement implements Hashable {
 
 	public $text = '';
 

--- a/tests/fixtures/HashArrayWithDuplicates.php
+++ b/tests/fixtures/HashArrayWithDuplicates.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\DataModel\Fixtures;
+namespace Wikibase\DataModel\Fixtures;
 
 use Wikibase\DataModel\HashArray;
 

--- a/tests/fixtures/HashArrayWithoutDuplicates.php
+++ b/tests/fixtures/HashArrayWithoutDuplicates.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\DataModel\Fixtures;
+namespace Wikibase\DataModel\Fixtures;
 
 use Wikibase\DataModel\HashArray;
 

--- a/tests/fixtures/HashableObject.php
+++ b/tests/fixtures/HashableObject.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\DataModel\Fixtures;
+namespace Wikibase\DataModel\Fixtures;
 
 /**
  * @licence GNU GPL v2+

--- a/tests/fixtures/MutableHashable.php
+++ b/tests/fixtures/MutableHashable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\DataModel\Fixtures;
+namespace Wikibase\DataModel\Fixtures;
 
 use Hashable;
 

--- a/tests/unit/ByPropertyIdArrayTest.php
+++ b/tests/unit/ByPropertyIdArrayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests;
 
 use DataValues\StringValue;
 use ReflectionClass;

--- a/tests/unit/ByPropertyIdGrouperTest.php
+++ b/tests/unit/ByPropertyIdGrouperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Test;
+namespace Wikibase\DataModel\Tests;
 
 use OutOfBoundsException;
 use Wikibase\DataModel\ByPropertyIdGrouper;

--- a/tests/unit/Claim/ClaimGuidParserTest.php
+++ b/tests/unit/Claim/ClaimGuidParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Claim;
 
 use Wikibase\DataModel\Claim\ClaimGuid;
 use Wikibase\DataModel\Claim\ClaimGuidParser;

--- a/tests/unit/Claim/ClaimGuidTest.php
+++ b/tests/unit/Claim/ClaimGuidTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Claim;
 
 use Exception;
 use Wikibase\DataModel\Claim\ClaimGuid;

--- a/tests/unit/Claim/ClaimListAccessTest.php
+++ b/tests/unit/Claim/ClaimListAccessTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Claim;
 
 use DataValues\StringValue;
 use Wikibase\DataModel\Claim\Claim;

--- a/tests/unit/Claim/ClaimListTest.php
+++ b/tests/unit/Claim/ClaimListTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Claim;
 
 use DataValues\StringValue;
 use Wikibase\DataModel\Claim\Claim;

--- a/tests/unit/Claim/ClaimStandaloneTest.php
+++ b/tests/unit/Claim/ClaimStandaloneTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Claim;
 
 use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;

--- a/tests/unit/Claim/ClaimTest.php
+++ b/tests/unit/Claim/ClaimTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Claim;
 
 use DataValues\StringValue;
 use Wikibase\DataModel\Claim\Claim;

--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Claim;
 
 use InvalidArgumentException;
 use ReflectionClass;

--- a/tests/unit/Entity/BasicEntityIdParserTest.php
+++ b/tests/unit/Entity/BasicEntityIdParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Wikibase\DataModel\Entity\BasicEntityIdParser;
 use Wikibase\DataModel\Entity\EntityId;

--- a/tests/unit/Entity/Diff/EntityDiffOldTest.php
+++ b/tests/unit/Entity/Diff/EntityDiffOldTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity\Diff;
+namespace Wikibase\DataModel\Tests\Entity\Diff;
 
 use Wikibase\DataModel\Entity\Entity;
 use Wikibase\DataModel\Entity\Item;

--- a/tests/unit/Entity/Diff/EntityDiffTest.php
+++ b/tests/unit/Entity/Diff/EntityDiffTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity\Diff;
+namespace Wikibase\DataModel\Tests\Entity\Diff;
 
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
@@ -115,7 +115,7 @@ class EntityDiffTest extends \PHPUnit_Framework_TestCase {
 	public function testGetClaimsDiff( EntityDiff $entityDiff ) {
 		$diff = $entityDiff->getClaimsDiff();
 
-		$this->assertInstanceOf( '\Diff\Diff', $diff );
+		$this->assertInstanceOf( 'Diff\Diff', $diff );
 		$this->assertTrue( $diff->isAssociative() );
 
 		foreach ( $diff as $diffOp ) {
@@ -132,7 +132,7 @@ class EntityDiffTest extends \PHPUnit_Framework_TestCase {
 	public function testGetDescriptionsDiff( EntityDiff $entityDiff ) {
 		$diff = $entityDiff->getDescriptionsDiff();
 
-		$this->assertInstanceOf( '\Diff\Diff', $diff );
+		$this->assertInstanceOf( 'Diff\Diff', $diff );
 		$this->assertTrue( $diff->isAssociative() );
 	}
 
@@ -142,7 +142,7 @@ class EntityDiffTest extends \PHPUnit_Framework_TestCase {
 	public function testGetLabelsDiff( EntityDiff $entityDiff ) {
 		$diff = $entityDiff->getLabelsDiff();
 
-		$this->assertInstanceOf( '\Diff\Diff', $diff );
+		$this->assertInstanceOf( 'Diff\Diff', $diff );
 		$this->assertTrue( $diff->isAssociative() );
 	}
 
@@ -152,7 +152,7 @@ class EntityDiffTest extends \PHPUnit_Framework_TestCase {
 	public function testGetAliasesDiff( EntityDiff $entityDiff ) {
 		$diff = $entityDiff->getAliasesDiff();
 
-		$this->assertInstanceOf( '\Diff\Diff', $diff );
+		$this->assertInstanceOf( 'Diff\Diff', $diff );
 		$this->assertTrue( $diff->isAssociative() );
 	}
 

--- a/tests/unit/Entity/Diff/EntityDifferTest.php
+++ b/tests/unit/Entity/Diff/EntityDifferTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Wikibase\Test\Entity\Diff;
+namespace Wikibase\DataModel\Tests\Entity\Diff;
 
 use Wikibase\DataModel\Entity\Diff\EntityDiffer;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\Property;
-use Wikibase\Test\DataModel\Fixtures\EntityOfUnknownType;
+use Wikibase\DataModel\Fixtures\EntityOfUnknownType;
 
 /**
  * @covers Wikibase\DataModel\Entity\Diff\EntityDiffer
@@ -53,4 +53,3 @@ class EntityDifferTest extends \PHPUnit_Framework_TestCase {
 	}
 
 }
-

--- a/tests/unit/Entity/Diff/EntityPatcherTest.php
+++ b/tests/unit/Entity/Diff/EntityPatcherTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Wikibase\Test\Entity\Diff;
+namespace Wikibase\DataModel\Tests\Entity\Diff;
 
 use Wikibase\DataModel\Entity\Diff\EntityDiff;
 use Wikibase\DataModel\Entity\Diff\EntityPatcher;
 use Wikibase\DataModel\Entity\Diff\ItemDiff;
 use Wikibase\DataModel\Entity\Item;
-use Wikibase\Test\DataModel\Fixtures\EntityOfUnknownType;
+use Wikibase\DataModel\Fixtures\EntityOfUnknownType;
 
 /**
  * @covers Wikibase\DataModel\Entity\Diff\EntityPatcher
@@ -49,4 +49,3 @@ class EntityPatcherTest extends \PHPUnit_Framework_TestCase {
 	}
 
 }
-

--- a/tests/unit/Entity/Diff/FingerprintPatcherTest.php
+++ b/tests/unit/Entity/Diff/FingerprintPatcherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity\Diff;
+namespace Wikibase\DataModel\Tests\Entity\Diff;
 
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
@@ -96,4 +96,3 @@ class FingerprintPatcherTest extends \PHPUnit_Framework_TestCase {
 	}
 
 }
-

--- a/tests/unit/Entity/Diff/ItemDiffTest.php
+++ b/tests/unit/Entity/Diff/ItemDiffTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity\Diff;
+namespace Wikibase\DataModel\Tests\Entity\Diff;
 
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;

--- a/tests/unit/Entity/Diff/ItemDifferTest.php
+++ b/tests/unit/Entity/Diff/ItemDifferTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity\Diff;
+namespace Wikibase\DataModel\Tests\Entity\Diff;
 
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
@@ -98,4 +98,3 @@ class ItemDifferTest extends \PHPUnit_Framework_TestCase {
 	}
 
 }
-

--- a/tests/unit/Entity/Diff/ItemPatcherTest.php
+++ b/tests/unit/Entity/Diff/ItemPatcherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity\Diff;
+namespace Wikibase\DataModel\Tests\Entity\Diff;
 
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
@@ -78,4 +78,3 @@ class ItemPatcherTest extends \PHPUnit_Framework_TestCase {
 	}
 
 }
-

--- a/tests/unit/Entity/Diff/PropertyDifferTest.php
+++ b/tests/unit/Entity/Diff/PropertyDifferTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity\Diff;
+namespace Wikibase\DataModel\Tests\Entity\Diff;
 
 use Wikibase\DataModel\Entity\Diff\PropertyDiffer;
 use Wikibase\DataModel\Entity\Property;
@@ -37,4 +37,3 @@ class PropertyDifferTest extends \PHPUnit_Framework_TestCase {
 	}
 
 }
-

--- a/tests/unit/Entity/Diff/PropertyPatcherTest.php
+++ b/tests/unit/Entity/Diff/PropertyPatcherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity\Diff;
+namespace Wikibase\DataModel\Tests\Entity\Diff;
 
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
@@ -89,4 +89,3 @@ class PropertyPatcherTest extends \PHPUnit_Framework_TestCase {
 	}
 
 }
-

--- a/tests/unit/Entity/Diff/SiteLinkListPatcherTest.php
+++ b/tests/unit/Entity/Diff/SiteLinkListPatcherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity\Diff;
+namespace Wikibase\DataModel\Tests\Entity\Diff;
 
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;

--- a/tests/unit/Entity/EntityIdParserTest.php
+++ b/tests/unit/Entity/EntityIdParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Wikibase\DataModel\Entity\BasicEntityIdParser;
 use Wikibase\DataModel\Entity\DispatchingEntityIdParser;

--- a/tests/unit/Entity/EntityIdTest.php
+++ b/tests/unit/Entity/EntityIdTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\ItemId;

--- a/tests/unit/Entity/EntityIdValueTest.php
+++ b/tests/unit/Entity/EntityIdValueTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Wikibase\DataModel\Entity\EntityIdValue;
 use Wikibase\DataModel\Entity\ItemId;

--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;

--- a/tests/unit/Entity/InMemoryDataTypeLookupTest.php
+++ b/tests/unit/Entity/InMemoryDataTypeLookupTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Wikibase\DataModel\Entity\InMemoryDataTypeLookup;
 use Wikibase\DataModel\Entity\PropertyId;

--- a/tests/unit/Entity/ItemIdSetTest.php
+++ b/tests/unit/Entity/ItemIdSetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\ItemIdSet;

--- a/tests/unit/Entity/ItemIdTest.php
+++ b/tests/unit/Entity/ItemIdTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Wikibase\DataModel\Entity\ItemId;
 

--- a/tests/unit/Entity/ItemNotFoundExceptionTest.php
+++ b/tests/unit/Entity/ItemNotFoundExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\ItemNotFoundException;

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use DataValues\StringValue;
 use Diff\DiffOp\Diff\Diff;

--- a/tests/unit/Entity/PropertyIdTest.php
+++ b/tests/unit/Entity/PropertyIdTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Wikibase\DataModel\Entity\PropertyId;
 

--- a/tests/unit/Entity/PropertyNotFoundExceptionTest.php
+++ b/tests/unit/Entity/PropertyNotFoundExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Entity\PropertyNotFoundException;

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Entity\Property;

--- a/tests/unit/Entity/TestItems.php
+++ b/tests/unit/Entity/TestItems.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Entity;
+namespace Wikibase\DataModel\Tests\Entity;
 
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\SiteLink;

--- a/tests/unit/HashArray/HashArrayTest.php
+++ b/tests/unit/HashArray/HashArrayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\HashArray;
+namespace Wikibase\DataModel\Tests\HashArray;
 
 use Hashable;
 use Wikibase\DataModel\HashArray;

--- a/tests/unit/HashArray/HashArrayWithDuplicatesTest.php
+++ b/tests/unit/HashArray/HashArrayWithDuplicatesTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Wikibase\Test\HashArray;
+namespace Wikibase\DataModel\Tests\HashArray;
 
 use Hashable;
+use Wikibase\DataModel\Fixtures\HashArrayElement;
+use Wikibase\DataModel\Fixtures\MutableHashable;
 use Wikibase\DataModel\HashArray;
-use Wikibase\Test\DataModel\Fixtures\HashArrayElement;
-use Wikibase\Test\DataModel\Fixtures\MutableHashable;
 
 /**
  * @covers Wikibase\DataModel\HashArray
@@ -29,7 +29,7 @@ class HashArrayWithDuplicatesTest extends HashArrayTest {
 	}
 
 	public function getInstanceClass() {
-		return 'Wikibase\Test\DataModel\Fixtures\HashArrayWithDuplicates';
+		return 'Wikibase\DataModel\Fixtures\HashArrayWithDuplicates';
 	}
 
 	public function elementInstancesProvider() {
@@ -141,4 +141,3 @@ class HashArrayWithDuplicatesTest extends HashArrayTest {
 	}
 
 }
-

--- a/tests/unit/HashArray/HashArrayWithoutDuplicatesTest.php
+++ b/tests/unit/HashArray/HashArrayWithoutDuplicatesTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Wikibase\Test\HashArray;
+namespace Wikibase\DataModel\Tests\HashArray;
 
+use Wikibase\DataModel\Fixtures\HashArrayElement;
+use Wikibase\DataModel\Fixtures\MutableHashable;
 use Wikibase\DataModel\HashArray;
-use Wikibase\Test\DataModel\Fixtures\HashArrayElement;
-use Wikibase\Test\DataModel\Fixtures\MutableHashable;
 
 /**
  * @covers Wikibase\DataModel\HashArray
@@ -28,7 +28,7 @@ class HashArrayWithoutDuplicatesTest extends HashArrayTest {
 	}
 
 	public function getInstanceClass() {
-		return 'Wikibase\Test\DataModel\Fixtures\HashArrayWithoutDuplicates';
+		return 'Wikibase\DataModel\Fixtures\HashArrayWithoutDuplicates';
 	}
 
 	public function elementInstancesProvider() {

--- a/tests/unit/HashableObjectStorageTest.php
+++ b/tests/unit/HashableObjectStorageTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests;
 
+use Wikibase\DataModel\Fixtures\HashableObject;
 use Wikibase\DataModel\HashableObjectStorage;
-use Wikibase\Test\DataModel\Fixtures\HashableObject;
 
 /**
  * @covers Wikibase\DataModel\HashableObjectStorage
@@ -130,5 +130,3 @@ class HashableObjectStorageTest extends \PHPUnit_Framework_TestCase {
 	}
 
 }
-
-

--- a/tests/unit/Internal/MapValueHasherTest.php
+++ b/tests/unit/Internal/MapValueHasherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Internal;
 
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Internal\MapValueHasher;

--- a/tests/unit/LegacyIdInterpreterTest.php
+++ b/tests/unit/LegacyIdInterpreterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests;
 
 use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\ItemId;

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests;
 
 use Hashable;
 use Wikibase\DataModel\Reference;

--- a/tests/unit/ReferenceTest.php
+++ b/tests/unit/ReferenceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests;
 
 use DataValues\StringValue;
 use Wikibase\DataModel\Entity\PropertyId;

--- a/tests/unit/SiteLinkListTest.php
+++ b/tests/unit/SiteLinkListTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Test;
+namespace Wikibase\DataModel\Tests;
 
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\ItemIdSet;

--- a/tests/unit/SiteLinkTest.php
+++ b/tests/unit/SiteLinkTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Test;
+namespace Wikibase\DataModel\Tests;
 
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\ItemIdSet;

--- a/tests/unit/Snak/PropertyNoValueSnakTest.php
+++ b/tests/unit/Snak/PropertyNoValueSnakTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Snak;
+namespace Wikibase\DataModel\Tests\Snak;
 
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;

--- a/tests/unit/Snak/PropertySomeValueSnakTest.php
+++ b/tests/unit/Snak/PropertySomeValueSnakTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Snak;
+namespace Wikibase\DataModel\Tests\Snak;
 
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;

--- a/tests/unit/Snak/PropertyValueSnakTest.php
+++ b/tests/unit/Snak/PropertyValueSnakTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Snak;
+namespace Wikibase\DataModel\Tests\Snak;
 
 use DataValues\StringValue;
 use Wikibase\DataModel\Entity\PropertyId;

--- a/tests/unit/Snak/SnakListTest.php
+++ b/tests/unit/Snak/SnakListTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Snak;
+namespace Wikibase\DataModel\Tests\Snak;
 
 use DataValues\StringValue;
 use Wikibase\DataModel\Entity\PropertyId;
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Snak\SnakList;
-use Wikibase\Test\HashArray\HashArrayTest;
+use Wikibase\DataModel\Tests\HashArray\HashArrayTest;
 
 /**
  * @covers Wikibase\DataModel\Snak\SnakList

--- a/tests/unit/Snak/SnakObjectTest.php
+++ b/tests/unit/Snak/SnakObjectTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test\Snak;
+namespace Wikibase\DataModel\Tests\Snak;
 
 use Exception;
 use ReflectionClass;

--- a/tests/unit/Snak/SnakTest.php
+++ b/tests/unit/Snak/SnakTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Snak;
 
 use DataValues\NumberValue;
 use DataValues\StringValue;

--- a/tests/unit/Snak/TypedSnakTest.php
+++ b/tests/unit/Snak/TypedSnakTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Snak\Test;
+namespace Wikibase\DataModel\Tests\Snak;
 
 use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Snak\TypedSnak;

--- a/tests/unit/Statement/BestStatementsFinderTest.php
+++ b/tests/unit/Statement/BestStatementsFinderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Statement;
 
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Statement\BestStatementsFinder;

--- a/tests/unit/Statement/StatementListDifferTest.php
+++ b/tests/unit/Statement/StatementListDifferTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Statement;
 
 use DataValues\StringValue;
 use Diff\DiffOp\Diff\Diff;

--- a/tests/unit/Statement/StatementListPatcherTest.php
+++ b/tests/unit/Statement/StatementListPatcherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Statement;
 
 use DataValues\StringValue;
 use Diff\DiffOp\Diff\Diff;

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Statement;
 
 use DataValues\StringValue;
 use Wikibase\DataModel\Claim\Claim;

--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\Test;
+namespace Wikibase\DataModel\Tests\Statement;
 
 use DataValues\StringValue;
 use Wikibase\DataModel\Claim\Claim;

--- a/tests/unit/Term/AliasGroupFallbackTest.php
+++ b/tests/unit/Term/AliasGroupFallbackTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Term\Test;
+namespace Wikibase\DataModel\Tests\Term;
 
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupFallback;

--- a/tests/unit/Term/AliasGroupListTest.php
+++ b/tests/unit/Term/AliasGroupListTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Term\Test;
+namespace Wikibase\DataModel\Tests\Term;
 
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;

--- a/tests/unit/Term/AliasGroupTest.php
+++ b/tests/unit/Term/AliasGroupTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Term\Test;
+namespace Wikibase\DataModel\Tests\Term;
 
 use Wikibase\DataModel\Term\AliasGroup;
 

--- a/tests/unit/Term/FingerprintTest.php
+++ b/tests/unit/Term/FingerprintTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Term\Test;
+namespace Wikibase\DataModel\Tests\Term;
 
 use OutOfBoundsException;
 use Wikibase\DataModel\Term\AliasGroup;

--- a/tests/unit/Term/TermFallbackTest.php
+++ b/tests/unit/Term/TermFallbackTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Term\Test;
+namespace Wikibase\DataModel\Tests\Term;
 
 use Wikibase\DataModel\Term\Term;
 use Wikibase\DataModel\Term\TermFallback;
@@ -63,4 +63,5 @@ class TermFallbackTest extends \PHPUnit_Framework_TestCase {
 			'instance Term' => array( new Term( 'foor', 'bar' ) ),
 		);
 	}
+
 }

--- a/tests/unit/Term/TermListTest.php
+++ b/tests/unit/Term/TermListTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Term\Test;
+namespace Wikibase\DataModel\Tests\Term;
 
 use Wikibase\DataModel\Term\Term;
 use Wikibase\DataModel\Term\TermList;

--- a/tests/unit/Term/TermTest.php
+++ b/tests/unit/Term/TermTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Term\Test;
+namespace Wikibase\DataModel\Tests\Term;
 
 use Wikibase\DataModel\Term\Term;
 


### PR DESCRIPTION
Fixes #252.

Please note that I picked a naming scheme that was not used in this component before, but it is already in use in the Wikibase Client/Lib/Repo tests.