### PR TITLE
Drop odd Entity test

### DIFF
--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -428,31 +428,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( count( $entity->getClaims() ) !== 0, $has );
 	}
 
-	/**
-	 * Tests Entity::newClaim
-	 *
-	 * @dataProvider instanceProvider
-	 *
-	 * @param Entity $entity
-	 */
-	public function testNewClaim( Entity $entity ) {
-		if ( $entity->getId() === null ) {
-			$entity->setId( 50 );
-		}
-
-		$snak = new PropertyNoValueSnak( 42 );
-		$claim = new Statement( new Claim( $snak ) );
-		$claim->setGuid( 'q42$foobarbaz' );
-
-		$this->assertInstanceOf( 'Wikibase\DataModel\Claim\Claim', $claim );
-
-		$this->assertTrue( $snak->equals( $claim->getMainSnak() ) );
-
-		$guid = $claim->getGuid();
-
-		$this->assertInternalType( 'string', $guid );
-	}
-
 	public function diffProvider() {
 		$argLists = array();
 

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -149,9 +149,9 @@ class ItemTest extends EntityTest {
 		$items[] = $item;
 
 		$item = $item->copy();
-		$item->getStatements()->addStatement( new Statement(
-			new Claim( new PropertyNoValueSnak( new PropertyId( 'P42' ) ) )
-		) );
+		$item->getStatements()->addNewStatement(
+			new PropertyNoValueSnak( new PropertyId( 'P42' ) )
+		);
 		$items[] = $item;
 
 		$argLists = array();


### PR DESCRIPTION
This test does not test what it says it tests. It talks about `newClaim` in the comment and the function name but `newClaim` is deprecated and does not appear in the implementation of this test any more. Since June 2013: https://gerrit.wikimedia.org/r/#/c/68400.
