### PR TITLE
Make the test bootstrap work when included from another project

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,11 +14,17 @@ if ( PHP_SAPI !== 'cli' ) {
 error_reporting( E_ALL | E_STRICT );
 ini_set( 'display_errors', 1 );
 
-if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
+if ( is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
+	$classLoaderPath = __DIR__ . '/../vendor/autoload.php';
+}
+elseif ( is_readable( __DIR__ . '/../../../vendor/autoload.php' ) ) {
+	$classLoaderPath = __DIR__ . '/../../../vendor/autoload.php';
+}
+else {
 	die( 'You need to install this package with Composer before you can run the tests' );
 }
 
-$autoLoader = require_once( __DIR__ . '/../vendor/autoload.php' );
+$autoLoader = require_once( $classLoaderPath );
 
 $autoLoader->addPsr4( 'Wikibase\\Test\\', __DIR__ . '/unit/' );
 $autoLoader->addPsr4( 'Wikibase\\Test\\DataModel\\Fixtures\\', __DIR__ . '/fixtures/' );


### PR DESCRIPTION
This enables you to run the DM tests when having DM installed
in another component:

phpunit -c vendor/wikibase/data-model/
