### PR TITLE
Clarify contracts of toArray methods

### DIFF
--- a/src/Claim/ClaimList.php
+++ b/src/Claim/ClaimList.php
@@ -27,6 +27,7 @@ class ClaimList implements \IteratorAggregate {
 
 	/**
 	 * @param Claim[]|Traversable $claims
+	 *
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $claims = array() ) {
@@ -99,6 +100,8 @@ class ClaimList implements \IteratorAggregate {
 	}
 
 	/**
+	 * FIXME: This does not reindex sparse arrays!
+	 *
 	 * @return Claim[]
 	 */
 	public function toArray() {

--- a/src/SiteLinkList.php
+++ b/src/SiteLinkList.php
@@ -175,7 +175,7 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	/**
 	 * @since 2.5
 	 *
-	 * @return SiteLink[]
+	 * @return SiteLink[] Array indexed by site id.
 	 */
 	public function toArray() {
 		return $this->siteLinks;

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -222,7 +222,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	/**
-	 * @return Statement[]
+	 * @return Statement[] Numerically indexed (non-sparse) array.
 	 */
 	public function toArray() {
 		return $this->statements;

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -62,7 +62,7 @@ class AliasGroupList implements Countable, IteratorAggregate {
 	 *
 	 * @since 2.3
 	 *
-	 * @return AliasGroup[]
+	 * @return AliasGroup[] Array indexed by language code.
 	 */
 	public function toArray() {
 		return $this->groups;


### PR DESCRIPTION
As requested in https://github.com/wmde/WikibaseDataModel/pull/311#issuecomment-64713212.

Please note that `StatementList` always reindexed the array. It stopped doing this with #285 (released with 2.4.0).

I think this must be the responsibility of the `StatementList` class (as well as `ClaimList`, see the TODO) and not the calling code.