### PR TITLE
Remove misleading return doc

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,7 @@
 ## Version 2.6.0 (dev)
 
 * Empty strings are now detected as invalid in the `SiteLink` constructor
+* Fixed `EntityIdValue::unserialize` accidentally returning itself
 
 ## Version 2.5.0 (2014-01-20)
 

--- a/src/Entity/EntityIdValue.php
+++ b/src/Entity/EntityIdValue.php
@@ -56,7 +56,6 @@ class EntityIdValue extends DataValueObject {
 	 * @param string $value
 	 *
 	 * @throws IllegalValueException
-	 * @return EntityIdValue
 	 */
 	public function unserialize( $value ) {
 		list( $entityType, $numericId ) = json_decode( $value );
@@ -67,7 +66,7 @@ class EntityIdValue extends DataValueObject {
 			throw new IllegalValueException( 'Invalid EntityIdValue serialization.' );
 		}
 
-		return $this->__construct( $entityId );
+		$this->__construct( $entityId );
 	}
 
 	/**


### PR DESCRIPTION
`Serializable::unserialize` isn't supposed to `@return` anything. Warning, this is a possible breaking change (in contrast to all other `unserialize` implementations in all other components, they never returned anything, but this one did).