### PR TITLE
More robust Snak::equals

### DIFF
--- a/src/Snak/SnakObject.php
+++ b/src/Snak/SnakObject.php
@@ -89,7 +89,8 @@ abstract class SnakObject implements Snak {
 			return true;
 		}
 
-		return $target instanceof self
+		return is_object( $target )
+			&& get_called_class() === get_class( $target )
 			&& $this->getHash() === $target->getHash();
 	}
 

--- a/tests/unit/Snak/PropertyNoValueSnakTest.php
+++ b/tests/unit/Snak/PropertyNoValueSnakTest.php
@@ -4,6 +4,7 @@ namespace Wikibase\Test\Snak;
 
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
+use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 
 /**
  * @covers Wikibase\DataModel\Snak\PropertyNoValueSnak
@@ -26,6 +27,14 @@ class PropertyNoValueSnakTest extends SnakObjectTest {
 
 	public function getClass() {
 		return 'Wikibase\DataModel\Snak\PropertyNoValueSnak';
+	}
+
+	public function testEquals_givenOtherSnakImplementation_isNotEqual() {
+		$propertyId = new PropertyId( 'P1' );
+		$noValue = new PropertyNoValueSnak( $propertyId );
+		$someValue = new PropertySomeValueSnak( $propertyId );
+
+		$this->assertFalse( $noValue->equals( $someValue ) );
 	}
 
 	/**

--- a/tests/unit/Snak/PropertySomeValueSnakTest.php
+++ b/tests/unit/Snak/PropertySomeValueSnakTest.php
@@ -3,6 +3,7 @@
 namespace Wikibase\Test\Snak;
 
 use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 
 /**
@@ -26,6 +27,14 @@ class PropertySomeValueSnakTest extends SnakObjectTest {
 
 	public function getClass() {
 		return 'Wikibase\DataModel\Snak\PropertySomeValueSnak';
+	}
+
+	public function testEquals_givenOtherSnakImplementation_isNotEqual() {
+		$propertyId = new PropertyId( 'P1' );
+		$someValue = new PropertySomeValueSnak( $propertyId );
+		$noValue = new PropertyNoValueSnak( $propertyId );
+
+		$this->assertFalse( $someValue->equals( $noValue ) );
 	}
 
 	/**


### PR DESCRIPTION
Comparing with `self` is dangerous in an abstract base class because this compares the base class, not the sub classes. It's not a problem in this case because `getHash` contains the sub class name and is guaranteed to be different. But if we ever change `serialize` (as already discussed) `equals` may fail. Adding tests to make sure this never happens.

https://github.com/DataValues/DataValues/pull/12 does the same for the abstract `DataValueObject::equals`.