### PR TITLE
Optional Item constructor parameters

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,7 @@
 * Added `ItemLoookup` and `PropertyLookup` interfaces
 * Added `ItemNotFoundException`
 * Empty strings are now detected as invalid language codes in the term classes
+* `Item` constructor parameters for site links and statements are optional now
 
 ## Version 2.4.1 (2014-11-26)
 

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -42,14 +42,19 @@ class Item extends Entity implements StatementListProvider {
 	 *
 	 * @param ItemId|null $id
 	 * @param Fingerprint $fingerprint
-	 * @param SiteLinkList $links
-	 * @param StatementList $statements
+	 * @param SiteLinkList|null $siteLinks
+	 * @param StatementList|null $statements
 	 */
-	public function __construct( ItemId $id = null, Fingerprint $fingerprint, SiteLinkList $links, StatementList $statements ) {
+	public function __construct(
+		ItemId $id = null,
+		Fingerprint $fingerprint,
+		SiteLinkList $siteLinks = null,
+		StatementList $statements = null
+	) {
 		$this->id = $id;
 		$this->fingerprint = $fingerprint;
-		$this->siteLinks = $links;
-		$this->statements = $statements;
+		$this->siteLinks = $siteLinks ?: new SiteLinkList();
+		$this->statements = $statements ?: new StatementList();
 	}
 
 	/**
@@ -181,12 +186,7 @@ class Item extends Entity implements StatementListProvider {
 	 * @return Item
 	 */
 	public static function newEmpty() {
-		return new self(
-			null,
-			Fingerprint::newEmpty(),
-			new SiteLinkList(),
-			new StatementList()
-		);
+		return new self( null, Fingerprint::newEmpty() );
 	}
 
 	/**

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -17,7 +17,6 @@ use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\ReferenceList;
 use Wikibase\DataModel\SiteLink;
-use Wikibase\DataModel\SiteLinkList;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
@@ -667,12 +666,7 @@ class ItemTest extends EntityTest {
 
 		$statements = new StatementList( array( $statement ) );
 
-		$item = new Item(
-			null,
-			Fingerprint::newEmpty(),
-			new SiteLinkList(),
-			$statements
-		);
+		$item = new Item( null, Fingerprint::newEmpty(), null, $statements );
 
 		$this->assertEquals(
 			$statements,


### PR DESCRIPTION
This is a part of #290. I hope we can at least agree on that. The two parameters made optional by this patch are:
* `$statements` are already optional in `Property`, but not in `Item`, which is just a bit inconsistent.
* `$siteLinks` are specific for `Item`s.