### PR TITLE
Drop static keywords from data providers

### DIFF
--- a/tests/unit/Entity/Diff/EntityDiffOldTest.php
+++ b/tests/unit/Entity/Diff/EntityDiffOldTest.php
@@ -138,7 +138,7 @@ abstract class EntityDiffOldTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $a->getFingerprint()->equals( $b->getFingerprint() ) );
 	}
 
-	public static function provideConflictDetection() {
+	public function provideConflictDetection() {
 		$cases = array();
 
 		// #0: adding a label where there was none before

--- a/tests/unit/Entity/Diff/ItemDiffTest.php
+++ b/tests/unit/Entity/Diff/ItemDiffTest.php
@@ -27,7 +27,7 @@ use Wikibase\DataModel\SiteLink;
  */
 class ItemDiffTest extends EntityDiffOldTest {
 
-	public static function provideApplyData() {
+	public function provideApplyData() {
 		$originalTests = parent::generateApplyData( Item::ENTITY_TYPE );
 		$tests = array();
 


### PR DESCRIPTION
I'm not sure if this was required in an older PHPUnit version. But I'm sure it's not needed with our current PHPUnit version(s).