### PR TITLE
More descriptive Term/AliasGroup docs

### DIFF
--- a/src/Term/AliasGroup.php
+++ b/src/Term/AliasGroup.php
@@ -19,7 +19,7 @@ use InvalidArgumentException;
 class AliasGroup implements Comparable, Countable {
 
 	/**
-	 * @var string
+	 * @var string Usually the requested and/or actual language of the aliases.
 	 */
 	private $languageCode;
 
@@ -29,7 +29,7 @@ class AliasGroup implements Comparable, Countable {
 	private $aliases;
 
 	/**
-	 * @param string $languageCode
+	 * @param string $languageCode Usually the requested and/or actual language of the aliases.
 	 * @param string[] $aliases
 	 *
 	 * @throws InvalidArgumentException

--- a/src/Term/Term.php
+++ b/src/Term/Term.php
@@ -16,7 +16,7 @@ use InvalidArgumentException;
 class Term implements Comparable {
 
 	/**
-	 * @var string
+	 * @var string Usually the requested and/or actual language of the text.
 	 */
 	private $languageCode;
 
@@ -26,7 +26,7 @@ class Term implements Comparable {
 	private $text;
 
 	/**
-	 * @param string $languageCode
+	 * @param string $languageCode Usually the requested and/or actual language of the text.
 	 * @param string $text
 	 *
 	 * @throws InvalidArgumentException


### PR DESCRIPTION
* Main reason for this patch is the inline documentation. Note that the sub classes are changing the meaning of the `$languageCode` field in the parent class!
* ~~Inlined some trivial private setters. Some where already inlined, some not. This makes the code look more equal in the 4 classes.~~
* ~~Removed some `gettype`. They are not worth the additional complexity in my opinion.~~
* ~~"need" -> "must".~~
* ~~Avoid calling getters if not necesarry.~~
* ~~Avoid `is_null`, it's barely used in DataModel.~~

(Almost everything was re-submitted and merged in #335.)