### PR TITLE
More descriptive Term/AliasGroupFallback docs

### DIFF
--- a/src/Term/AliasGroup.php
+++ b/src/Term/AliasGroup.php
@@ -35,36 +35,26 @@ class AliasGroup implements Comparable, Countable {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $languageCode, array $aliases = array() ) {
-		$this->setLanguageCode( $languageCode );
-		$this->setAliases( $aliases );
-	}
-
-	private function setLanguageCode( $languageCode ) {
 		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode must be a string; got ' . gettype( $languageCode ) );
+			throw new InvalidArgumentException( '$languageCode must be a string' );
 		}
 
 		$this->languageCode = $languageCode;
-	}
-
-	private function setAliases( array $aliases ) {
-		foreach ( $aliases as $alias ) {
-			if ( !is_string( $alias ) ) {
-				throw new InvalidArgumentException( 'Every element in $aliases must be a string; found ' . gettype( $alias ) );
-			}
-		}
-
 		$this->aliases = array_values(
-			array_filter(
-				array_unique(
-					array_map(
-						'trim',
-						$aliases
+			array_unique(
+				array_map(
+					'trim',
+					array_filter(
+						$aliases,
+						function( $alias ) {
+							if ( !is_string( $alias ) ) {
+								throw new InvalidArgumentException( '$aliases must be an array of strings' );
+							}
+
+							return trim( $alias ) !== '';
+						}
 					)
-				),
-				function( $string ) {
-					return $string !== '';
-				}
+				)
 			)
 		);
 	}
@@ -109,6 +99,7 @@ class AliasGroup implements Comparable, Countable {
 
 	/**
 	 * @see Countable::count
+	 *
 	 * @return int
 	 */
 	public function count() {

--- a/src/Term/AliasGroupFallback.php
+++ b/src/Term/AliasGroupFallback.php
@@ -17,39 +17,39 @@ use InvalidArgumentException;
  */
 class AliasGroupFallback extends AliasGroup {
 
+	/**
+	 * @var string Actual language of the aliases.
+	 */
 	private $actualLanguageCode;
+
+	/**
+	 * @var string|null Source language if the aliases are transliterations.
+	 */
 	private $sourceLanguageCode;
 
 	/**
-	 * @param string $languageCode
+	 * @param string $requestedLanguageCode Requested language, not necessarily the language of the
+	 * aliases.
 	 * @param string[] $aliases
-	 * @param string $actualLanguageCode fallen back to
-	 * @param string|null $sourceLanguageCode for transliteration
+	 * @param string $actualLanguageCode Actual language of the aliases.
+	 * @param string|null $sourceLanguageCode Source language if the aliases are transliterations.
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function __construct( $languageCode, array $aliases, $actualLanguageCode, $sourceLanguageCode ) {
-		parent::__construct( $languageCode, $aliases );
-		$this->setActualLanguageCode( $actualLanguageCode );
-		$this->setSourceLanguageCode( $sourceLanguageCode );
-	}
+	public function __construct( $requestedLanguageCode, array $aliases, $actualLanguageCode, $sourceLanguageCode ) {
+		parent::__construct( $requestedLanguageCode, $aliases );
 
-	private function setActualLanguageCode( $actualLanguageCode ) {
 		if ( !is_string( $actualLanguageCode ) ) {
-			throw new InvalidArgumentException( '$actualLanguageCode needs to be a string.' );
+			throw new InvalidArgumentException( '$actualLanguageCode must be a string' );
+		}
+
+		if ( $sourceLanguageCode !== null && !is_string( $sourceLanguageCode ) ) {
+			throw new InvalidArgumentException( '$sourceLanguageCode must be a string or null' );
 		}
 
 		$this->actualLanguageCode = $actualLanguageCode;
-	}
-
-	private function setSourceLanguageCode( $sourceLanguageCode ) {
-		if ( !is_null( $sourceLanguageCode ) && !is_string( $sourceLanguageCode ) ) {
-			throw new InvalidArgumentException( '$sourceLanguageCode needs to be null or a string.' );
-		}
-
 		$this->sourceLanguageCode = $sourceLanguageCode;
 	}
-
 
 	/**
 	 * @return string
@@ -73,10 +73,14 @@ class AliasGroupFallback extends AliasGroup {
 	 * @return bool
 	 */
 	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
 		return $target instanceof self
 			&& parent::equals( $target )
-			&& $this->actualLanguageCode === $target->getActualLanguageCode()
-			&& $this->sourceLanguageCode === $target->getSourceLanguageCode();
+			&& $this->actualLanguageCode === $target->actualLanguageCode
+			&& $this->sourceLanguageCode === $target->sourceLanguageCode;
 	}
 
 }

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -107,7 +107,7 @@ class AliasGroupList implements Countable, IteratorAggregate {
 
 	private function assertIsLanguageCode( $languageCode ) {
 		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode must be a string; got ' . gettype( $languageCode ) );
+			throw new InvalidArgumentException( '$languageCode must be a string' );
 		}
 	}
 

--- a/src/Term/Term.php
+++ b/src/Term/Term.php
@@ -15,7 +15,14 @@ use InvalidArgumentException;
  */
 class Term implements Comparable {
 
+	/**
+	 * @var string
+	 */
 	private $languageCode;
+
+	/**
+	 * @var string
+	 */
 	private $text;
 
 	/**
@@ -26,11 +33,11 @@ class Term implements Comparable {
 	 */
 	public function __construct( $languageCode, $text ) {
 		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode must be a string; got ' . gettype( $languageCode ) );
+			throw new InvalidArgumentException( '$languageCode must be a string' );
 		}
 
 		if ( !is_string( $text ) ) {
-			throw new InvalidArgumentException( '$text must be a string; got ' . gettype( $text ) );
+			throw new InvalidArgumentException( '$text must be a string' );
 		}
 
 		$this->languageCode = $languageCode;
@@ -64,8 +71,8 @@ class Term implements Comparable {
 		}
 
 		return $target instanceof self
-			&& $this->languageCode === $target->getLanguageCode()
-			&& $this->text === $target->getText();
+			&& $this->languageCode === $target->languageCode
+			&& $this->text === $target->text;
 	}
 
 }

--- a/src/Term/TermFallback.php
+++ b/src/Term/TermFallback.php
@@ -14,25 +14,34 @@ use InvalidArgumentException;
  */
 class TermFallback extends Term {
 
+	/**
+	 * @var string Actual language of the text.
+	 */
 	private $actualLanguageCode;
+
+	/**
+	 * @var string|null Source language if the text is a transliteration.
+	 */
 	private $sourceLanguageCode;
 
 	/**
-	 * @param string $languageCode
+	 * @param string $requestedLanguageCode Requested language, not necessarily the language of the
+	 * text.
 	 * @param string $text
-	 * @param string $actualLanguageCode fallen back to
-	 * @param string|null $sourceLanguageCode for transliteration
+	 * @param string $actualLanguageCode Actual language of the text.
+	 * @param string|null $sourceLanguageCode Source language if the text is a transliteration.
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function __construct( $languageCode, $text, $actualLanguageCode, $sourceLanguageCode ) {
-		parent::__construct( $languageCode, $text );
+	public function __construct( $requestedLanguageCode, $text, $actualLanguageCode, $sourceLanguageCode ) {
+		parent::__construct( $requestedLanguageCode, $text );
+
 		if ( !is_string( $actualLanguageCode ) ) {
-			throw new InvalidArgumentException( '$actualLanguageCode should be a string' );
+			throw new InvalidArgumentException( '$actualLanguageCode must be a string' );
 		}
 
-		if ( !is_null( $sourceLanguageCode ) && !is_string( $sourceLanguageCode ) ) {
-			throw new InvalidArgumentException( '$sourceLanguageCode should be a string or null' );
+		if ( $sourceLanguageCode !== null && !is_string( $sourceLanguageCode ) ) {
+			throw new InvalidArgumentException( '$sourceLanguageCode must be a string or null' );
 		}
 
 		$this->actualLanguageCode = $actualLanguageCode;
@@ -61,10 +70,14 @@ class TermFallback extends Term {
 	 * @return bool
 	 */
 	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
 		return $target instanceof self
 			&& parent::equals( $target )
-			&& $this->actualLanguageCode === $target->getActualLanguageCode()
-			&& $this->sourceLanguageCode === $target->getSourceLanguageCode();
+			&& $this->actualLanguageCode === $target->actualLanguageCode
+			&& $this->sourceLanguageCode === $target->sourceLanguageCode;
 	}
 
 }

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -110,7 +110,7 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 
 	private function assertIsLanguageCode( $languageCode ) {
 		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode must be a string; got ' . gettype( $languageCode ) );
+			throw new InvalidArgumentException( '$languageCode must be a string' );
 		}
 	}
 


### PR DESCRIPTION
This is a re-submit of #334 since, apparently, having no documentation is better than having any.

Additional changes:
* Rearranged the setAliases code to avoid iterating the array twice.
* Inlined a few more trivial private setters.
* Dropped all `gettype` (introduced in #276) from the `Term` namespace since I find the added code complexity not worth it.