### PR TITLE
Empty string isn't a language code

### DIFF
--- a/src/Term/AliasGroup.php
+++ b/src/Term/AliasGroup.php
@@ -35,36 +35,26 @@ class AliasGroup implements Comparable, Countable {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $languageCode, array $aliases = array() ) {
-		$this->setLanguageCode( $languageCode );
-		$this->setAliases( $aliases );
-	}
-
-	private function setLanguageCode( $languageCode ) {
 		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode must be a string; got ' . gettype( $languageCode ) );
+			throw new InvalidArgumentException( '$languageCode must be a string' );
 		}
 
 		$this->languageCode = $languageCode;
-	}
-
-	private function setAliases( array $aliases ) {
-		foreach ( $aliases as $alias ) {
-			if ( !is_string( $alias ) ) {
-				throw new InvalidArgumentException( 'Every element in $aliases must be a string; found ' . gettype( $alias ) );
-			}
-		}
-
 		$this->aliases = array_values(
-			array_filter(
-				array_unique(
-					array_map(
-						'trim',
-						$aliases
+			array_unique(
+				array_map(
+					'trim',
+					array_filter(
+						$aliases,
+						function( $alias ) {
+							if ( !is_string( $alias ) ) {
+								throw new InvalidArgumentException( '$aliases must be an array of strings' );
+							}
+
+							return trim( $alias ) !== '';
+						}
 					)
-				),
-				function( $string ) {
-					return $string !== '';
-				}
+				)
 			)
 		);
 	}
@@ -109,6 +99,7 @@ class AliasGroup implements Comparable, Countable {
 
 	/**
 	 * @see Countable::count
+	 *
 	 * @return int
 	 */
 	public function count() {

--- a/src/Term/AliasGroup.php
+++ b/src/Term/AliasGroup.php
@@ -35,8 +35,8 @@ class AliasGroup implements Comparable, Countable {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $languageCode, array $aliases = array() ) {
-		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode must be a string' );
+		if ( !is_string( $languageCode ) || $languageCode === '' ) {
+			throw new InvalidArgumentException( '$languageCode must be a non-empty string' );
 		}
 
 		$this->languageCode = $languageCode;

--- a/src/Term/AliasGroupFallback.php
+++ b/src/Term/AliasGroupFallback.php
@@ -39,12 +39,14 @@ class AliasGroupFallback extends AliasGroup {
 	public function __construct( $requestedLanguageCode, array $aliases, $actualLanguageCode, $sourceLanguageCode ) {
 		parent::__construct( $requestedLanguageCode, $aliases );
 
-		if ( !is_string( $actualLanguageCode ) ) {
-			throw new InvalidArgumentException( '$actualLanguageCode must be a string' );
+		if ( !is_string( $actualLanguageCode ) || $actualLanguageCode === '' ) {
+			throw new InvalidArgumentException( '$actualLanguageCode must be a non-empty string' );
 		}
 
-		if ( $sourceLanguageCode !== null && !is_string( $sourceLanguageCode ) ) {
-			throw new InvalidArgumentException( '$sourceLanguageCode must be a string or null' );
+		if ( !( $sourceLanguageCode === null
+			|| ( is_string( $sourceLanguageCode ) && $sourceLanguageCode !== '' )
+		) ) {
+			throw new InvalidArgumentException( '$sourceLanguageCode must be a non-empty string or null' );
 		}
 
 		$this->actualLanguageCode = $actualLanguageCode;

--- a/src/Term/AliasGroupFallback.php
+++ b/src/Term/AliasGroupFallback.php
@@ -17,39 +17,39 @@ use InvalidArgumentException;
  */
 class AliasGroupFallback extends AliasGroup {
 
+	/**
+	 * @var string Actual language of the aliases.
+	 */
 	private $actualLanguageCode;
+
+	/**
+	 * @var string|null Source language if the aliases are transliterations.
+	 */
 	private $sourceLanguageCode;
 
 	/**
-	 * @param string $languageCode
+	 * @param string $requestedLanguageCode Requested language, not necessarily the language of the
+	 * aliases.
 	 * @param string[] $aliases
-	 * @param string $actualLanguageCode fallen back to
-	 * @param string|null $sourceLanguageCode for transliteration
+	 * @param string $actualLanguageCode Actual language of the aliases.
+	 * @param string|null $sourceLanguageCode Source language if the aliases are transliterations.
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function __construct( $languageCode, array $aliases, $actualLanguageCode, $sourceLanguageCode ) {
-		parent::__construct( $languageCode, $aliases );
-		$this->setActualLanguageCode( $actualLanguageCode );
-		$this->setSourceLanguageCode( $sourceLanguageCode );
-	}
+	public function __construct( $requestedLanguageCode, array $aliases, $actualLanguageCode, $sourceLanguageCode ) {
+		parent::__construct( $requestedLanguageCode, $aliases );
 
-	private function setActualLanguageCode( $actualLanguageCode ) {
 		if ( !is_string( $actualLanguageCode ) ) {
-			throw new InvalidArgumentException( '$actualLanguageCode needs to be a string.' );
+			throw new InvalidArgumentException( '$actualLanguageCode must be a string' );
+		}
+
+		if ( $sourceLanguageCode !== null && !is_string( $sourceLanguageCode ) ) {
+			throw new InvalidArgumentException( '$sourceLanguageCode must be a string or null' );
 		}
 
 		$this->actualLanguageCode = $actualLanguageCode;
-	}
-
-	private function setSourceLanguageCode( $sourceLanguageCode ) {
-		if ( !is_null( $sourceLanguageCode ) && !is_string( $sourceLanguageCode ) ) {
-			throw new InvalidArgumentException( '$sourceLanguageCode needs to be null or a string.' );
-		}
-
 		$this->sourceLanguageCode = $sourceLanguageCode;
 	}
-
 
 	/**
 	 * @return string
@@ -73,10 +73,14 @@ class AliasGroupFallback extends AliasGroup {
 	 * @return bool
 	 */
 	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
 		return $target instanceof self
 			&& parent::equals( $target )
-			&& $this->actualLanguageCode === $target->getActualLanguageCode()
-			&& $this->sourceLanguageCode === $target->getSourceLanguageCode();
+			&& $this->actualLanguageCode === $target->actualLanguageCode
+			&& $this->sourceLanguageCode === $target->sourceLanguageCode;
 	}
 
 }

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -106,8 +106,8 @@ class AliasGroupList implements Countable, IteratorAggregate {
 	}
 
 	private function assertIsLanguageCode( $languageCode ) {
-		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode must be a string' );
+		if ( !is_string( $languageCode ) || $languageCode === '' ) {
+			throw new InvalidArgumentException( '$languageCode must be a non-empty string' );
 		}
 	}
 

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -107,7 +107,7 @@ class AliasGroupList implements Countable, IteratorAggregate {
 
 	private function assertIsLanguageCode( $languageCode ) {
 		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode must be a string; got ' . gettype( $languageCode ) );
+			throw new InvalidArgumentException( '$languageCode must be a string' );
 		}
 	}
 

--- a/src/Term/Term.php
+++ b/src/Term/Term.php
@@ -32,8 +32,8 @@ class Term implements Comparable {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $languageCode, $text ) {
-		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode must be a string' );
+		if ( !is_string( $languageCode ) || $languageCode === '' ) {
+			throw new InvalidArgumentException( '$languageCode must be a non-empty string' );
 		}
 
 		if ( !is_string( $text ) ) {

--- a/src/Term/Term.php
+++ b/src/Term/Term.php
@@ -15,7 +15,14 @@ use InvalidArgumentException;
  */
 class Term implements Comparable {
 
+	/**
+	 * @var string
+	 */
 	private $languageCode;
+
+	/**
+	 * @var string
+	 */
 	private $text;
 
 	/**
@@ -26,11 +33,11 @@ class Term implements Comparable {
 	 */
 	public function __construct( $languageCode, $text ) {
 		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode must be a string; got ' . gettype( $languageCode ) );
+			throw new InvalidArgumentException( '$languageCode must be a string' );
 		}
 
 		if ( !is_string( $text ) ) {
-			throw new InvalidArgumentException( '$text must be a string; got ' . gettype( $text ) );
+			throw new InvalidArgumentException( '$text must be a string' );
 		}
 
 		$this->languageCode = $languageCode;
@@ -64,8 +71,8 @@ class Term implements Comparable {
 		}
 
 		return $target instanceof self
-			&& $this->languageCode === $target->getLanguageCode()
-			&& $this->text === $target->getText();
+			&& $this->languageCode === $target->languageCode
+			&& $this->text === $target->text;
 	}
 
 }

--- a/src/Term/TermFallback.php
+++ b/src/Term/TermFallback.php
@@ -36,12 +36,14 @@ class TermFallback extends Term {
 	public function __construct( $requestedLanguageCode, $text, $actualLanguageCode, $sourceLanguageCode ) {
 		parent::__construct( $requestedLanguageCode, $text );
 
-		if ( !is_string( $actualLanguageCode ) ) {
-			throw new InvalidArgumentException( '$actualLanguageCode must be a string' );
+		if ( !is_string( $actualLanguageCode ) || $actualLanguageCode === '' ) {
+			throw new InvalidArgumentException( '$actualLanguageCode must be a non-empty string' );
 		}
 
-		if ( $sourceLanguageCode !== null && !is_string( $sourceLanguageCode ) ) {
-			throw new InvalidArgumentException( '$sourceLanguageCode must be a string or null' );
+		if ( !( $sourceLanguageCode === null
+			|| ( is_string( $sourceLanguageCode ) && $sourceLanguageCode !== '' )
+		) ) {
+			throw new InvalidArgumentException( '$sourceLanguageCode must be a non-empty string or null' );
 		}
 
 		$this->actualLanguageCode = $actualLanguageCode;

--- a/src/Term/TermFallback.php
+++ b/src/Term/TermFallback.php
@@ -14,25 +14,34 @@ use InvalidArgumentException;
  */
 class TermFallback extends Term {
 
+	/**
+	 * @var string Actual language of the text.
+	 */
 	private $actualLanguageCode;
+
+	/**
+	 * @var string|null Source language if the text is a transliteration.
+	 */
 	private $sourceLanguageCode;
 
 	/**
-	 * @param string $languageCode
+	 * @param string $requestedLanguageCode Requested language, not necessarily the language of the
+	 * text.
 	 * @param string $text
-	 * @param string $actualLanguageCode fallen back to
-	 * @param string|null $sourceLanguageCode for transliteration
+	 * @param string $actualLanguageCode Actual language of the text.
+	 * @param string|null $sourceLanguageCode Source language if the text is a transliteration.
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function __construct( $languageCode, $text, $actualLanguageCode, $sourceLanguageCode ) {
-		parent::__construct( $languageCode, $text );
+	public function __construct( $requestedLanguageCode, $text, $actualLanguageCode, $sourceLanguageCode ) {
+		parent::__construct( $requestedLanguageCode, $text );
+
 		if ( !is_string( $actualLanguageCode ) ) {
-			throw new InvalidArgumentException( '$actualLanguageCode should be a string' );
+			throw new InvalidArgumentException( '$actualLanguageCode must be a string' );
 		}
 
-		if ( !is_null( $sourceLanguageCode ) && !is_string( $sourceLanguageCode ) ) {
-			throw new InvalidArgumentException( '$sourceLanguageCode should be a string or null' );
+		if ( $sourceLanguageCode !== null && !is_string( $sourceLanguageCode ) ) {
+			throw new InvalidArgumentException( '$sourceLanguageCode must be a string or null' );
 		}
 
 		$this->actualLanguageCode = $actualLanguageCode;
@@ -61,10 +70,14 @@ class TermFallback extends Term {
 	 * @return bool
 	 */
 	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
 		return $target instanceof self
 			&& parent::equals( $target )
-			&& $this->actualLanguageCode === $target->getActualLanguageCode()
-			&& $this->sourceLanguageCode === $target->getSourceLanguageCode();
+			&& $this->actualLanguageCode === $target->actualLanguageCode
+			&& $this->sourceLanguageCode === $target->sourceLanguageCode;
 	}
 
 }

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -109,8 +109,8 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 	}
 
 	private function assertIsLanguageCode( $languageCode ) {
-		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode must be a string' );
+		if ( !is_string( $languageCode ) || $languageCode === '' ) {
+			throw new InvalidArgumentException( '$languageCode must be a non-empty string' );
 		}
 	}
 

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -110,7 +110,7 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 
 	private function assertIsLanguageCode( $languageCode ) {
 		if ( !is_string( $languageCode ) ) {
-			throw new InvalidArgumentException( '$languageCode must be a string; got ' . gettype( $languageCode ) );
+			throw new InvalidArgumentException( '$languageCode must be a string' );
 		}
 	}
 

--- a/tests/unit/Term/AliasGroupFallbackTest.php
+++ b/tests/unit/Term/AliasGroupFallbackTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Term\Test;
 
+use InvalidArgumentException;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupFallback;
 
@@ -38,24 +39,35 @@ class AliasGroupFallbackTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( $source, $group->getSourceLanguageCode() );
 	}
 
-	public function testGivenInvalidActualLanguageCode_constructorThrowsException() {
-		$language = 'en-real';
-		$aliases = array();
-		$actual = null;
-		$source = 'en-source';
-
-		$this->setExpectedException( 'InvalidArgumentException' );
-		$group = new AliasGroupFallback( $language, $aliases, $actual, $source );
+	/**
+	 * @dataProvider invalidLanguageCodeProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidActualLanguageCode_constructorThrowsException( $languageCode ) {
+		new AliasGroupFallback( 'en-real', array(), $languageCode, 'en-source' );
 	}
 
-	public function testGivenInvalidSourceLanguageCode_constructorThrowsException() {
-		$language = 'en-real';
-		$aliases = array();
-		$actual = 'en-actual';
-		$source = 21;
+	public function invalidLanguageCodeProvider() {
+		return array(
+			array( null ),
+			array( 21 ),
+			array( '' ),
+		);
+	}
 
-		$this->setExpectedException( 'InvalidArgumentException' );
-		$group = new AliasGroupFallback( $language, $aliases, $actual, $source );
+	/**
+	 * @dataProvider invalidSourceLanguageCodeProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidSourceLanguageCode_constructorThrowsException( $languageCode ) {
+		new AliasGroupFallback( 'en-real', array(), 'en-actual', $languageCode );
+	}
+
+	public function invalidSourceLanguageCodeProvider() {
+		return array(
+			array( 21 ),
+			array( '' ),
+		);
 	}
 
 	public function testGroupEqualsItself() {

--- a/tests/unit/Term/AliasGroupListTest.php
+++ b/tests/unit/Term/AliasGroupListTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Term\Test;
 
+use InvalidArgumentException;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;
 
@@ -103,11 +104,13 @@ class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( $enGroup, $list->getByLanguage( 'en' ) );
 	}
 
-	public function testGivenNonString_getByLanguageThrowsException() {
+	/**
+	 * @dataProvider invalidLanguageCodeProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidLanguageCode_getByLanguageThrowsException( $languageCode ) {
 		$list = new AliasGroupList();
-
-		$this->setExpectedException( 'InvalidArgumentException' );
-		$list->getByLanguage( null );
+		$list->getByLanguage( $languageCode );
 	}
 
 	public function testGivenNonSetLanguageCode_getByLanguageThrowsException() {
@@ -155,6 +158,15 @@ class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
 		$list->removeByLanguage( 'en' );
 
 		$this->assertEquals( new AliasGroupList(), $list );
+	}
+
+	/**
+	 * @dataProvider invalidLanguageCodeProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidLanguageCode_removeByLanguageThrowsException( $languageCode ) {
+		$list = new AliasGroupList();
+		$list->removeByLanguage( $languageCode );
 	}
 
 	public function testGivenEmptyGroups_constructorRemovesThem() {
@@ -252,6 +264,38 @@ class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
 	public function testGivenMatchingGroup_hasAliasGroupReturnsTrue() {
 		$list = new AliasGroupList( array( new AliasGroup( 'en', array( 'kittens' ) ) ) );
 		$this->assertTrue( $list->hasAliasGroup( new AliasGroup( 'en', array( 'kittens' ) ) ) );
+	}
+
+	public function testGivenNonSetLanguageGroup_hasGroupForLanguageReturnsFalse() {
+		$list = new AliasGroupList();
+		$this->assertFalse( $list->hasGroupForLanguage( 'en' ) );
+	}
+
+	/**
+	 * @dataProvider invalidLanguageCodeProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidLanguageCode_hasGroupForLanguageThrowsException( $languageCode ) {
+		$list = new AliasGroupList();
+		$list->hasGroupForLanguage( $languageCode );
+	}
+
+	public function invalidLanguageCodeProvider() {
+		return array(
+			array( null ),
+			array( 21 ),
+			array( '' ),
+		);
+	}
+
+	public function testGivenMismatchingGroup_hasGroupForLanguageReturnsFalse() {
+		$list = new AliasGroupList( array( new AliasGroup( 'en', array( 'cats' ) ) ) );
+		$this->assertFalse( $list->hasGroupForLanguage( 'de' ) );
+	}
+
+	public function testGivenMatchingGroup_hasGroupForLanguageReturnsTrue() {
+		$list = new AliasGroupList( array( new AliasGroup( 'en', array( 'kittens' ) ) ) );
+		$this->assertTrue( $list->hasGroupForLanguage( 'en' ) );
 	}
 
 	public function testGivenAliasGroupArgs_setGroupTextsSetsAliasGroup() {

--- a/tests/unit/Term/AliasGroupTest.php
+++ b/tests/unit/Term/AliasGroupTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Term\Test;
 
+use InvalidArgumentException;
 use Wikibase\DataModel\Term\AliasGroup;
 
 /**
@@ -88,13 +89,26 @@ class AliasGroupTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( $expectedGroup, $group );
 	}
 
-	public function testGivenInvalidLanguageCode_constructorThrowsException() {
-		$this->setExpectedException( 'InvalidArgumentException' );
-		new AliasGroup( null, array( 'foo' ) );
+	/**
+	 * @dataProvider invalidLanguageCodeProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidLanguageCode_constructorThrowsException( $languageCode ) {
+		new AliasGroup( $languageCode, array( 'foo' ) );
 	}
 
+	public function invalidLanguageCodeProvider() {
+		return array(
+			array( null ),
+			array( 21 ),
+			array( '' ),
+		);
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
 	public function testGivenInvalidAlias_constructorThrowsException() {
-		$this->setExpectedException( 'InvalidArgumentException' );
 		new AliasGroup( 'en', array( 21 ) );
 	}
 

--- a/tests/unit/Term/TermFallbackTest.php
+++ b/tests/unit/Term/TermFallbackTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Term\Test;
 
+use InvalidArgumentException;
 use Wikibase\DataModel\Term\Term;
 use Wikibase\DataModel\Term\TermFallback;
 
@@ -26,14 +27,35 @@ class TermFallbackTest extends \PHPUnit_Framework_TestCase {
 		$this->assertNull( $term->getSourceLanguageCode() );
 	}
 
-	public function testGivenNonStringActualLanguageCode_constructorThrowsException() {
-		$this->setExpectedException( 'InvalidArgumentException' );
-		new TermFallback( 'foor', 'bar', null, 'foos' );
+	/**
+	 * @dataProvider invalidLanguageCodeProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidActualLanguageCode_constructorThrowsException( $languageCode ) {
+		new TermFallback( 'foor', 'bar', $languageCode, 'foos' );
 	}
 
-	public function testGivenNonStringSourceLanguageCode_constructorThrowsException() {
-		$this->setExpectedException( 'InvalidArgumentException' );
-		new TermFallback( 'foor', 'bar', 'fooa', 21 );
+	public function invalidLanguageCodeProvider() {
+		return array(
+			array( null ),
+			array( 21 ),
+			array( '' ),
+		);
+	}
+
+	/**
+	 * @dataProvider invalidSourceLanguageCodeProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidSourceLanguageCode_constructorThrowsException( $languageCode ) {
+		new TermFallback( 'foor', 'bar', 'fooa', $languageCode );
+	}
+
+	public function invalidSourceLanguageCodeProvider() {
+		return array(
+			array( 21 ),
+			array( '' ),
+		);
 	}
 
 	public function testEquality() {

--- a/tests/unit/Term/TermListTest.php
+++ b/tests/unit/Term/TermListTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Term\Test;
 
+use InvalidArgumentException;
 use Wikibase\DataModel\Term\Term;
 use Wikibase\DataModel\Term\TermList;
 
@@ -115,11 +116,13 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( $enTerm, $list->getByLanguage( 'en' ) );
 	}
 
-	public function testGivenNonString_getByLanguageThrowsException() {
+	/**
+	 * @dataProvider invalidLanguageCodeProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidLanguageCode_getByLanguageThrowsException( $languageCode ) {
 		$list = new TermList();
-
-		$this->setExpectedException( 'InvalidArgumentException' );
-		$list->getByLanguage( null );
+		$list->getByLanguage( $languageCode );
 	}
 
 	public function testGivenNonSetLanguageCode_getByLanguageThrowsException() {
@@ -143,6 +146,23 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertFalse( $list->hasTermForLanguage( 'EN' ) );
 		$this->assertFalse( $list->hasTermForLanguage( ' de ' ) );
+	}
+
+	/**
+	 * @dataProvider invalidLanguageCodeProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidLanguageCode_hasTermForLanguageThrowsException( $languageCode ) {
+		$list = new TermList();
+		$list->hasTermForLanguage( $languageCode );
+	}
+
+	public function invalidLanguageCodeProvider() {
+		return array(
+			array( null ),
+			array( 21 ),
+			array( '' ),
+		);
 	}
 
 	public function testGivenNotSetLanguageCode_removeByLanguageDoesNoOp() {
@@ -170,6 +190,15 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 			array( 'de' => $deTerm ),
 			iterator_to_array( $list )
 		);
+	}
+
+	/**
+	 * @dataProvider invalidLanguageCodeProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidLanguageCode_removeByLanguageThrowsException( $languageCode ) {
+		$list = new TermList();
+		$list->removeByLanguage( $languageCode );
 	}
 
 	public function testGivenTermForNewLanguage_setTermAddsTerm() {

--- a/tests/unit/Term/TermTest.php
+++ b/tests/unit/Term/TermTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Term\Test;
 
+use InvalidArgumentException;
 use Wikibase\DataModel\Term\Term;
 
 /**
@@ -19,11 +20,19 @@ class TermTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider nonStringProvider
+	 * @dataProvider invalidLanguageCodeProvider
+	 * @expectedException InvalidArgumentException
 	 */
-	public function testGivenNonStringLanguageCode_constructorThrowsException( $nonString ) {
-		$this->setExpectedException( 'InvalidArgumentException' );
-		new Term( $nonString, 'bar' );
+	public function testGivenInvalidLanguageCode_constructorThrowsException( $languageCode ) {
+		new Term( $languageCode, 'bar' );
+	}
+
+	public function invalidLanguageCodeProvider() {
+		return array(
+			array( null ),
+			array( 21 ),
+			array( '' ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
This depends on #335 (1st commit), please review the 2nd commit only.

Changes:
* All language codes are validated to be _non-empty_ strings now.
* Most of these exceptions had no test before.
* `AliasGroupList::hasGroupForLanguage` had no tests at all.