### PR TITLE
Optional fingerprint constructor parameter in Property

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,6 +14,7 @@
 * Empty strings are now detected as invalid language codes in the term classes
 * Made the `Item` constructor parameters optional
 * Made the `Fingerprint` constructor parameters optional
+* Made the `Property` constructor parameter for fingerprint nullable
 * Deprecated `Item::newEmpty` in favour of `new Item()`
 * The `StatementList` constructor now accepts `Statement` objects in variable-lenght argument list format
 

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -38,18 +38,18 @@ class Property extends Entity implements StatementListProvider {
 	 * @since 1.0
 	 *
 	 * @param PropertyId|null $id
-	 * @param Fingerprint $fingerprint
+	 * @param Fingerprint|null $fingerprint
 	 * @param string $dataTypeId
 	 * @param StatementList|null $statements Since 1.1
 	 */
 	public function __construct(
 		PropertyId $id = null,
-		Fingerprint $fingerprint,
+		Fingerprint $fingerprint = null,
 		$dataTypeId,
 		StatementList $statements = null
 	) {
 		$this->id = $id;
-		$this->fingerprint = $fingerprint;
+		$this->fingerprint = $fingerprint ?: new Fingerprint();
 		$this->setDataTypeId( $dataTypeId );
 		$this->statements = $statements ?: new StatementList();
 	}
@@ -127,11 +127,7 @@ class Property extends Entity implements StatementListProvider {
 	 * @return Property
 	 */
 	public static function newFromType( $dataTypeId ) {
-		return new self(
-			null,
-			new Fingerprint(),
-			$dataTypeId
-		);
+		return new self( null, null, $dataTypeId );
 	}
 
 	/**

--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -9,7 +9,6 @@ use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Entity\Diff\EntityDiff;
 use Wikibase\DataModel\Entity\Entity;
 use Wikibase\DataModel\Entity\Item;
-use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -2,14 +2,16 @@
 
 namespace Wikibase\DataModel\Tests\Entity;
 
+use InvalidArgumentException;
 use Wikibase\DataModel\Claim\Claim;
+use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\Property;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
-use Wikibase\DataModel\Statement\StatementList;
-use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
-use Wikibase\DataModel\Claim\Claims;
+use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Statement\StatementList;
+use Wikibase\DataModel\Term\Fingerprint;
 
 /**
  * @covers Wikibase\DataModel\Entity\Property
@@ -43,6 +45,36 @@ class PropertyTest extends EntityTest {
 	 */
 	protected function getNewEmpty() {
 		return Property::newFromType( 'string' );
+	}
+
+	public function testConstructorWithAllParameters() {
+		$property = new Property(
+			new PropertyId( 'P42' ),
+			new Fingerprint(),
+			'string',
+			new StatementList()
+		);
+		$this->assertInstanceOf( 'Wikibase\DataModel\Entity\Property', $property );
+		$this->assertEquals( new PropertyId( 'P42' ), $property->getId() );
+		$this->assertEquals( new Fingerprint(), $property->getFingerprint() );
+		$this->assertEquals( 'string', $property->getDataTypeId() );
+		$this->assertEquals( new StatementList(), $property->getStatements() );
+	}
+
+	public function testConstructorWithMinimalParameters() {
+		$property = new Property( null, null, '' );
+		$this->assertInstanceOf( 'Wikibase\DataModel\Entity\Property', $property );
+		$this->assertNull( $property->getId() );
+		$this->assertEquals( new Fingerprint(), $property->getFingerprint() );
+		$this->assertEquals( '', $property->getDataTypeId() );
+		$this->assertEquals( new StatementList(), $property->getStatements() );
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidType_ConstructorThrowsException() {
+		new Property( null, null, null );
 	}
 
 	public function testNewFromType() {
@@ -211,7 +243,6 @@ class PropertyTest extends EntityTest {
 	}
 
 	public function testNewClaimReturnsStatementWithProvidedMainSnak() {
-		/** @var Snak $snak */
 		$snak = $this->getMock( 'Wikibase\DataModel\Snak\Snak' );
 
 		$property = Property::newFromType( 'string' );


### PR DESCRIPTION
Since the `Fingerprint` constructor parameter is now optional in `Item`, it should be optional in `Property` too.

This also adds tests for the `Property` constructor which was not tested at all, from what I can see.