### PR TITLE
Fix misleading Property release note

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,22 +2,22 @@
 
 ## Version 2.5.0 (2014-01-20)
 
-* Added `TermList::getWithLanguages`
-* Added `AliasGroupList::getWithLanguages`
-* Added `AliasGroupList::toTextArray`
-* Added `SiteLinkList::toArray`
-* Added `SiteLinkList::setSiteLink`
-* Added `SiteLinkList::setNewSiteLink`
-* Added `ItemIdSet::getSerializations`
 * Added `ItemLookup` and `PropertyLookup` interfaces
 * Added `ItemNotFoundException`
+* Added `AliasGroupList::getWithLanguages`
+* Added `AliasGroupList::toTextArray`
+* Added `ItemIdSet::getSerializations`
+* Added `SiteLinkList::setNewSiteLink`
+* Added `SiteLinkList::setSiteLink`
+* Added `SiteLinkList::toArray`
+* Added `TermList::getWithLanguages`
 * Empty strings are now detected as invalid language codes in the term classes
-* Made the `Item` constructor parameters optional
-* Made the `Fingerprint` constructor parameters optional
-* Made the `Property` constructors fingerprint parameter optional
-* Deprecated `Item::newEmpty` in favour of `new Item()`
-* Deprecated `Fingerprint::newEmpty` in favour of `new Fingerprint()`
+* Made all `Fingerprint` constructor parameters optional
+* Made all `Item` constructor parameters optional
+* Made the `Property` constructor's fingerprint parameter nullable
 * The `StatementList` constructor now accepts `Statement` objects in variable-length argument list format
+* Deprecated `Fingerprint::newEmpty` in favour of `new Fingerprint()`
+* Deprecated `Item::newEmpty` in favour of `new Item()`
 * Added PHPCS support
 
 ## Version 2.4.1 (2014-11-26)


### PR DESCRIPTION
* Main change is the `Property` line. The parameter is not "optional", it's required, but it can be `null` now.
* Changed two "the" to "all".
* All other lines are only re-orderd, but not changed.