### PR TITLE
Disallow empty strings in SiteLink

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel release notes
 
+## Version 3.0.0 (dev)
+
+* Empty strings are now detected as invalid in the `SiteLink` constructor
+
 ## Version 2.5.0 (2014-01-20)
 
 * Added `ItemLookup` and `PropertyLookup` interfaces

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 # Wikibase DataModel release notes
 
-## Version 3.0.0 (dev)
+## Version 2.6.0 (dev)
 
 * Empty strings are now detected as invalid in the `SiteLink` constructor
 

--- a/src/Claim/Claim.php
+++ b/src/Claim/Claim.php
@@ -164,7 +164,7 @@ class Claim implements Hashable, Comparable, PropertyIdProvider {
 	 */
 	public function setGuid( $guid ) {
 		if ( !is_string( $guid ) && $guid !== null ) {
-			throw new InvalidArgumentException( '$guid must be a string or null; got ' . gettype( $guid ) );
+			throw new InvalidArgumentException( '$guid must be a string or null' );
 		}
 
 		$this->guid = $guid;

--- a/src/Claim/ClaimGuid.php
+++ b/src/Claim/ClaimGuid.php
@@ -29,11 +29,11 @@ class ClaimGuid implements Comparable {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $entityId, $guid ) {
-		if( !$entityId instanceof EntityId ){
+		if ( !$entityId instanceof EntityId ) {
 			throw new InvalidArgumentException( '$entityId must be an instance of EntityId' );
 		}
-		if( !is_string( $guid ) ){
-			throw new InvalidArgumentException( '$guid must be a string; got ' . gettype( $guid ) );
+		if ( !is_string( $guid ) ) {
+			throw new InvalidArgumentException( '$guid must be a string' );
 		}
 
 		$this->serialization = $entityId->getSerialization() . self::SEPARATOR . $guid;

--- a/src/SiteLink.php
+++ b/src/SiteLink.php
@@ -45,12 +45,12 @@ class SiteLink implements Comparable {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $siteId, $pageName, $badges = null ) {
-		if ( !is_string( $siteId ) ) {
-			throw new InvalidArgumentException( '$siteId must be a string; got ' . gettype( $siteId ) );
+		if ( !is_string( $siteId ) || $siteId === '' ) {
+			throw new InvalidArgumentException( '$siteId must be a non-empty string' );
 		}
 
-		if ( !is_string( $pageName ) ) {
-			throw new InvalidArgumentException( '$pageName must be a string; got ' . gettype( $pageName ) );
+		if ( !is_string( $pageName ) || $pageName === '' ) {
+			throw new InvalidArgumentException( '$pageName must be a non-empty string' );
 		}
 
 		$this->siteId = $siteId;

--- a/tests/unit/SiteLinkTest.php
+++ b/tests/unit/SiteLinkTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Tests;
 
+use InvalidArgumentException;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\ItemIdSet;
 use Wikibase\DataModel\Entity\PropertyId;
@@ -16,6 +17,7 @@ use Wikibase\DataModel\SiteLink;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Michał Łazowik
+ * @author Thiemo Mättig
  */
 class SiteLinkTest extends \PHPUnit_Framework_TestCase {
 
@@ -43,22 +45,21 @@ class SiteLinkTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider stuffThatIsNotStringProvider
+	 * @dataProvider invalidStringIdentifierProvider
+	 * @expectedException InvalidArgumentException
 	 */
 	public function testCannotConstructWithNonStringSiteId( $invalidSiteId ) {
-		$this->setExpectedException( 'InvalidArgumentException' );
 		new SiteLink( $invalidSiteId, 'Wikidata' );
 	}
 
-	public function stuffThatIsNotStringProvider() {
-		$argLists = array();
-
-		$argLists[] = array( 42 );
-		$argLists[] = array( true );
-		$argLists[] = array( array() );
-		$argLists[] = array( null );
-
-		return $argLists;
+	public function invalidStringIdentifierProvider() {
+		return array(
+			array( null ),
+			array( true ),
+			array( 42 ),
+			array( '' ),
+			array( array() ),
+		);
 	}
 
 	/**
@@ -80,10 +81,10 @@ class SiteLinkTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider stuffThatIsNotStringProvider
+	 * @dataProvider invalidStringIdentifierProvider
+	 * @expectedException InvalidArgumentException
 	 */
 	public function testCannotConstructWithNonStringPageName( $invalidPageName ) {
-		$this->setExpectedException( 'InvalidArgumentException' );
 		new SiteLink( 'enwiki', $invalidPageName );
 	}
 
@@ -131,58 +132,30 @@ class SiteLinkTest extends \PHPUnit_Framework_TestCase {
 
 		$argLists[] = array( $badges, $expected );
 
-
-		return $argLists;
-	}
-
-	/**
-	 * @dataProvider stuffThatIsNotArrayProvider
-	 */
-	public function testCannotConstructWithNonArrayBadges( $invalidBadges ) {
-		$this->setExpectedException( 'InvalidArgumentException' );
-		new SiteLink( 'enwiki', 'Wikidata', $invalidBadges );
-	}
-
-	public function stuffThatIsNotArrayProvider() {
-		$argLists = array();
-
-		$argLists[] = array( 42 );
-		$argLists[] = array( true );
-		$argLists[] = array( 'nyan nyan' );
-
 		return $argLists;
 	}
 
 	/**
 	 * @dataProvider invalidBadgesProvider
+	 * @expectedException InvalidArgumentException
 	 */
 	public function testCannotConstructWithInvalidBadges( $invalidBadges ) {
-		$this->setExpectedException( 'InvalidArgumentException' );
 		new SiteLink( 'enwiki', 'Wikidata', $invalidBadges );
 	}
 
 	public function invalidBadgesProvider() {
-		$argLists = array();
-
-		// non ItemIds
-		$argLists[] = array( array(
-			'nyan',
-			42
-		) );
-		$argLists[] = array( array(
-			'nyan',
-			array()
-		) );
-		$argLists[] = array( array(
-			new PropertyId( 'P2' ),
-			new ItemId( 'Q149' )
-		) );
-		$argLists[] = array( array(
-			new PropertyId( 'P2' ),
-			new PropertyId( 'P3' )
-		) );
-
-		return $argLists;
+		return array(
+			// Stuff that's not an array
+			array( true ),
+			array( 42 ),
+			array( 'nyan nyan' ),
+			// Arrays with stuff that's not even an object
+			array( array( 'nyan', 42 ) ),
+			array( array( 'nyan', array() ) ),
+			// Arrays with Entities that aren't Items
+			array( array( new PropertyId( 'P2' ), new ItemId( 'Q149' ) ) ),
+			array( array( new PropertyId( 'P2' ), new PropertyId( 'P3' ) ) ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
This also removes some of the `gettype` calls as reasoned in #335.