### PR TITLE
Add setId to EntityDocument

### DIFF
--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -49,8 +49,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 		return $this->id;
 	}
 
-	public abstract function setId( $id );
-
 	/**
 	 * Sets the value for the label in a certain value.
 	 *

--- a/src/Entity/EntityDocument.php
+++ b/src/Entity/EntityDocument.php
@@ -6,7 +6,7 @@ namespace Wikibase\DataModel\Entity;
  * Minimal interface for all objects that represent an entity.
  * All entities have an EntityId and an entity type.
  *
- * @since 0.8.2
+ * @since 0.8.2, modified in 3.0
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
@@ -30,5 +30,18 @@ interface EntityDocument {
 	 * @return string
 	 */
 	public function getType();
+
+	/**
+	 * Sets the id of the entity. If the id is not of the correct type,
+	 * an exception will be thrown. A specific derivative of EntityId is
+	 * always supported.
+	 *
+	 * @since 3.0
+	 *
+	 * @param EntityId $id
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	public function setId( $id );
 
 }

--- a/tests/fixtures/EntityOfUnknownType.php
+++ b/tests/fixtures/EntityOfUnknownType.php
@@ -18,4 +18,7 @@ class EntityOfUnknownType implements EntityDocument {
 		return 'unknown-entity-type';
 	}
 
+	public function setId( $id ) {
+	}
+
 }


### PR DESCRIPTION
Pull request into 3.0.x-dev, not into master.

This fixes https://github.com/wmde/WikibaseDataModel/issues/310 and is the approach that came out of the discussion there. (We decided to not go with https://github.com/wmde/WikibaseDataModel/pull/312)

Note how we cannot use `EntityId` as PHP type hint, since then derivatives would not be able to do things such as accept an integer. This is needed since we support `$item->setId( 42 )`.

Also note that if we would just (doc) type hint against `EntityId`, we'd have a LSP violation. This is why the doc outlines a more detailed contract. (I'd rather avoid this situation here, since it can be avoided by not having the method, which is part of why I favoured the approach of deprecation. We have to do something though, and this approach seems benign enough to me.)

Both these points apply to the existing `setId` method in `Entity`, so in a way, we are just keeping what is already there.