### PR TITLE
Make Term::equals robust against subclasses

### DIFF
--- a/src/Term/AliasGroup.php
+++ b/src/Term/AliasGroup.php
@@ -92,7 +92,8 @@ class AliasGroup implements Comparable, Countable {
 			return true;
 		}
 
-		return $target instanceof self
+		return is_object( $target )
+			&& get_called_class() === get_class( $target )
 			&& $this->languageCode === $target->languageCode
 			&& $this->aliases == $target->aliases;
 	}

--- a/src/Term/Term.php
+++ b/src/Term/Term.php
@@ -70,7 +70,8 @@ class Term implements Comparable {
 			return true;
 		}
 
-		return $target instanceof self
+		return is_object( $target )
+			&& get_called_class() === get_class( $target )
 			&& $this->languageCode === $target->languageCode
 			&& $this->text === $target->text;
 	}

--- a/tests/unit/Term/AliasGroupTest.php
+++ b/tests/unit/Term/AliasGroupTest.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel\Tests\Term;
 
 use InvalidArgumentException;
 use Wikibase\DataModel\Term\AliasGroup;
+use Wikibase\DataModel\Term\AliasGroupFallback;
 
 /**
  * @covers Wikibase\DataModel\Term\AliasGroup
@@ -57,6 +58,12 @@ class AliasGroupTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertFalse( $group->equals( new AliasGroup( 'en', array( 'foo', 'baz', 'bar' ) ) ) );
 		$this->assertFalse( $group->equals( new AliasGroup( 'en', array( 'baz', 'bar', 'foo' ) ) ) );
+	}
+
+	public function testGivenSimilarFallbackObject_equalsReturnsFalse() {
+		$aliasGroup = new AliasGroup( 'de' );
+		$aliasGroupFallback = new AliasGroupFallback( 'de', array(), 'en', null );
+		$this->assertFalse( $aliasGroup->equals( $aliasGroupFallback ) );
 	}
 
 	public function testDuplicatesAreRemoved() {

--- a/tests/unit/Term/TermTest.php
+++ b/tests/unit/Term/TermTest.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel\Tests\Term;
 
 use InvalidArgumentException;
 use Wikibase\DataModel\Term\Term;
+use Wikibase\DataModel\Term\TermFallback;
 
 /**
  * @covers Wikibase\DataModel\Term\Term
@@ -61,6 +62,12 @@ class TermTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $term->equals( new Term( 'foo', 'spam' ) ) );
 		$this->assertFalse( $term->equals( new Term( 'spam', 'bar' ) ) );
 		$this->assertFalse( $term->equals( new Term( 'spam', 'spam' ) ) );
+	}
+
+	public function testGivenSimilarFallbackObject_equalsReturnsFalse() {
+		$term = new Term( 'de', 'foo' );
+		$termFallback = new TermFallback( 'de', 'foo', 'en', null );
+		$this->assertFalse( $term->equals( $termFallback ) );
 	}
 
 }


### PR DESCRIPTION
Classes that do have subclasses need a slightly more complex equals implementation.

We *could* rework all equals methods like that but I do not think this is necessary or helpful. A straight instanceof is way more readable and sufficient in almost all cases.