### PR TITLE
Remove misleading type from EntityDocument

### DIFF
--- a/src/Entity/EntityDocument.php
+++ b/src/Entity/EntityDocument.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
  * Minimal interface for all objects that represent an entity.
  * All entities have an EntityId and an entity type.
  *
- * @since 0.8.2
+ * @since 0.8.2, modified in 3.0
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/src/Entity/EntityDocument.php
+++ b/src/Entity/EntityDocument.php
@@ -2,11 +2,13 @@
 
 namespace Wikibase\DataModel\Entity;
 
+use InvalidArgumentException;
+
 /**
  * Minimal interface for all objects that represent an entity.
  * All entities have an EntityId and an entity type.
  *
- * @since 0.8.2, modified in 3.0
+ * @since 0.8.2
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
@@ -32,15 +34,11 @@ interface EntityDocument {
 	public function getType();
 
 	/**
-	 * Sets the id of the entity. If the id is not of the correct type,
-	 * an exception will be thrown. A specific derivative of EntityId is
-	 * always supported.
+	 * Sets the id of the entity. A specific derivative of EntityId is always supported.
 	 *
 	 * @since 3.0
 	 *
-	 * @param EntityId $id
-	 *
-	 * @throws \InvalidArgumentException
+	 * @throws InvalidArgumentException if the id is not of the correct type.
 	 */
 	public function setId( $id );
 


### PR DESCRIPTION
Main change here is: Remove the `@param` line. Note that the original `Entity` class did not had that either. It's misleading (subclasses don't fulfill this contract and aren't supposed to) and better described in text.