### PR TITLE
Replace static with self

### DIFF
--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -347,7 +347,7 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 *
 	 * @since 0.1
 	 *
-	 * @return static
+	 * @return self
 	 */
 	public function copy() {
 		return unserialize( serialize( $this ) );


### PR DESCRIPTION
At least PHPStorm does not like the `static` keyword, gets confused and does not know the actual return type any more. Which leads to "unknown method called" and other warnings. `self` does not have this problem.