### PR TITLE
Fix HashArray accepting anything

### DIFF
--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -70,11 +70,17 @@ abstract class HashArray extends \ArrayObject implements \Hashable, \Comparable 
 	 * @param array|Traversable|null $input
 	 * @param int $flags
 	 * @param string $iterator_class
+	 *
+	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $input = null, $flags = 0, $iterator_class = 'ArrayIterator' ) {
 		parent::__construct( array(), $flags, $iterator_class );
 
 		if ( $input !== null ) {
+			if ( !is_array( $input ) && !( $input instanceof Traversable ) ) {
+				throw new InvalidArgumentException( '$input must be an array or Traversable' );
+			}
+
 			foreach ( $input as $offset => $value ) {
 				$this->offsetSet( $offset, $value );
 			}

--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -117,7 +117,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 		$instance = clone $baseInstance;
 
 		$instance->setReferences( new ReferenceList( array(
-			new Reference( new SnakList(
+			new Reference( array(
 				new PropertyValueSnak( new PropertyId( 'P1' ), new StringValue( 'a' ) )
 			) )
 		) ) );
@@ -145,14 +145,13 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testSetReferences( Statement $statement ) {
 		$references = new ReferenceList( array(
-			new Reference( new SnakList(
+			new Reference( array(
 				new PropertyValueSnak(
 					new PropertyId( 'P1' ),
 					new StringValue( 'a' )
 				)
 			) )
 		) );
-
 
 		$statement->setReferences( $references );
 


### PR DESCRIPTION
Calling `new SnakList( $snak )` with a single snak object created an empty snak list. I added a specific test and immediately found that mistake in StatementTest. Whoops.