### PR TITLE
Remove Claim from Statement constructor

### DIFF
--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -208,7 +208,7 @@ class Item extends Entity implements StatementListProvider {
 	 * @return Statement
 	 */
 	public function newClaim( Snak $mainSnak ) {
-		return new Statement( new Claim( $mainSnak ) );
+		return new Statement( $mainSnak );
 	}
 
 	/**

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -240,7 +240,7 @@ class Property extends Entity implements StatementListProvider {
 	 * @return Statement
 	 */
 	public function newClaim( Snak $mainSnak ) {
-		return new Statement( new Claim( $mainSnak ) );
+		return new Statement( $mainSnak );
 	}
 
 	/**

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -8,6 +8,7 @@ use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\ReferenceList;
 use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Snak\SnakList;
+use Wikibase\DataModel\Snak\Snaks;
 
 /**
  * Class representing a Wikibase statement.
@@ -43,13 +44,17 @@ class Statement extends Claim {
 	/**
 	 * @since 2.0
 	 *
-	 * @param Claim $claim
+	 * @param Snak $mainSnak
+	 * @param Snaks|null $qualifiers
 	 * @param ReferenceList|null $references
 	 */
-	public function __construct( Claim $claim, ReferenceList $references = null ) {
-		$this->mainSnak = $claim->getMainSnak();
-		$this->qualifiers = $claim->getQualifiers();
-		$this->guid = $claim->getGuid();
+	public function __construct(
+		Snak $mainSnak,
+		Snaks $qualifiers = null,
+		ReferenceList $references = null
+	) {
+		$this->mainSnak = $mainSnak;
+		$this->qualifiers = $qualifiers ?: new SnakList();
 		$this->references = $references ?: new ReferenceList();
 	}
 

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -101,7 +101,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 		$qualifiers = is_array( $qualifiers ) ? new SnakList( $qualifiers ) : $qualifiers;
 		$references = is_array( $references ) ? new ReferenceList( $references ) : $references;
 
-		$statement = new Statement( new Claim( $mainSnak, $qualifiers ), $references );
+		$statement = new Statement( $mainSnak, $qualifiers, $references );
 		$statement->setGuid( $guid );
 
 		$this->addStatement( $statement );

--- a/tests/unit/ByPropertyIdArrayTest.php
+++ b/tests/unit/ByPropertyIdArrayTest.php
@@ -80,7 +80,7 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 
 		$lists[] = array_map(
 			function( Snak $snak ) {
-				return new Statement( new Claim( $snak ) );
+				return new Statement( $snak );
 			},
 			$snaks
 		);

--- a/tests/unit/Claim/ClaimStandaloneTest.php
+++ b/tests/unit/Claim/ClaimStandaloneTest.php
@@ -81,7 +81,7 @@ class ClaimStandaloneTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGivenSimilarStatement_equalsReturnsFalse() {
 		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
-		$this->assertFalse( $claim->equals( new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) ) ) );
+		$this->assertFalse( $claim->equals( new Statement( new PropertyNoValueSnak( 42 ) ) ) );
 	}
 
 }

--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -47,7 +47,7 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 			$guid = 'TEST$statement-' . $this->guidCounter;
 		}
 
-		$claim = new Statement( new Claim( $mainSnak ) );
+		$claim = new Statement( $mainSnak );
 		$claim->setGuid( $guid );
 
 		return $claim;

--- a/tests/unit/Entity/Diff/EntityDiffTest.php
+++ b/tests/unit/Entity/Diff/EntityDiffTest.php
@@ -89,7 +89,7 @@ class EntityDiffTest extends \PHPUnit_Framework_TestCase {
 
 		$diffs[] = new EntityDiff( $diffOps );
 
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setGuid( 'EntityDiffTest$foo' );
 
 		$statementListDiffer = new StatementListDiffer();

--- a/tests/unit/Entity/Diff/EntityDiffTest.php
+++ b/tests/unit/Entity/Diff/EntityDiffTest.php
@@ -94,7 +94,7 @@ class EntityDiffTest extends \PHPUnit_Framework_TestCase {
 
 		$statementListDiffer = new StatementListDiffer();
 		$diffOps['claim'] = $statementListDiffer->getDiff(
-			new StatementList( array( $statement ) ),
+			new StatementList( $statement ),
 			new StatementList()
 		);
 

--- a/tests/unit/Entity/Diff/PropertyPatcherTest.php
+++ b/tests/unit/Entity/Diff/PropertyPatcherTest.php
@@ -57,13 +57,13 @@ class PropertyPatcherTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testStatementsArePatched() {
-		$s1337 = new Statement( new Claim( new PropertyNoValueSnak( 1337 ) ) );
+		$s1337 = new Statement( new PropertyNoValueSnak( 1337 ) );
 		$s1337->setGuid( 's1337' );
 
-		$s23 = new Statement( new Claim( new PropertyNoValueSnak( 23 ) ) );
+		$s23 = new Statement( new PropertyNoValueSnak( 23 ) );
 		$s23->setGuid( 's23' );
 
-		$s42 = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$s42 = new Statement( new PropertyNoValueSnak( 42 ) );
 		$s42->setGuid( 's42' );
 
 		$patch = new EntityDiff( array(

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -617,7 +617,7 @@ class ItemTest extends EntityTest {
 		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
 		$statement->setGuid( 'meh' );
 
-		$statements = new StatementList( array( $statement ) );
+		$statements = new StatementList( $statement );
 
 		$item = new Item( null, null, null, $statements );
 

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -514,10 +514,10 @@ class ItemTest extends EntityTest {
 	public function testSetClaims() {
 		$item = new Item();
 
-		$statement0 = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement0 = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement0->setGuid( 'TEST$NVS42' );
 
-		$statement1 = new Statement( new Claim( new PropertySomeValueSnak( 42 ) ) );
+		$statement1 = new Statement( new PropertySomeValueSnak( 42 ) );
 		$statement1->setGuid( 'TEST$SVS42' );
 
 		$statements = array( $statement0, $statement1 );
@@ -583,7 +583,7 @@ class ItemTest extends EntityTest {
 	}
 
 	private function newStatement() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setGuid( 'kittens' );
 		return $statement;
 	}
@@ -614,7 +614,7 @@ class ItemTest extends EntityTest {
 	}
 
 	public function testCanConstructWithStatementList() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setGuid( 'meh' );
 
 		$statements = new StatementList( $statement );

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -246,10 +246,10 @@ class PropertyTest extends EntityTest {
 	public function testSetClaims() {
 		$property = Property::newFromType( 'string' );
 
-		$statement0 = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement0 = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement0->setGuid( 'TEST$NVS42' );
 
-		$statement1 = new Statement( new Claim( new PropertySomeValueSnak( 42 ) ) );
+		$statement1 = new Statement( new PropertySomeValueSnak( 42 ) );
 		$statement1->setGuid( 'TEST$SVS42' );
 
 		$statements = array( $statement0, $statement1 );

--- a/tests/unit/Statement/StatementListDifferTest.php
+++ b/tests/unit/Statement/StatementListDifferTest.php
@@ -34,10 +34,10 @@ class StatementListDifferTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenTwoIdenticalLists_diffIsEmpty() {
-		$statements = new StatementList( array(
+		$statements = new StatementList(
 			$this->getNewStatement( 'zero', 'first' ),
-			$this->getNewStatement( 'one', 'second' ),
-		) );
+			$this->getNewStatement( 'one', 'second' )
+		);
 
 		$this->assertResultsInDiff( $statements, $statements, new Diff() );
 	}
@@ -49,16 +49,16 @@ class StatementListDifferTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenToListWithExtraStatement_additionOperationInDiff() {
-		$fromStatements = new StatementList( array(
+		$fromStatements = new StatementList(
 			$this->getNewStatement( 'zero', 'first' ),
-			$this->getNewStatement( 'one', 'second' ),
-		) );
+			$this->getNewStatement( 'one', 'second' )
+		);
 
-		$toStatements = new StatementList( array(
+		$toStatements = new StatementList(
 			$this->getNewStatement( 'zero', 'first' ),
 			$this->getNewStatement( 'two', 'third' ),
-			$this->getNewStatement( 'one', 'second' ),
-		) );
+			$this->getNewStatement( 'one', 'second' )
+		);
 
 		$diff = new Diff( array(
 			'two' => new DiffOpAdd( $this->getNewStatement( 'two', 'third' ) ),
@@ -68,15 +68,15 @@ class StatementListDifferTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenToListWithLessStatements_removalOperationsInDiff() {
-		$fromStatements = new StatementList( array(
+		$fromStatements = new StatementList(
 			$this->getNewStatement( 'zero', 'first' ),
 			$this->getNewStatement( 'one', 'second' ),
-			$this->getNewStatement( 'two', 'third' ),
-		) );
+			$this->getNewStatement( 'two', 'third' )
+		);
 
-		$toStatements = new StatementList( array(
-			$this->getNewStatement( 'one', 'second' ),
-		) );
+		$toStatements = new StatementList(
+			$this->getNewStatement( 'one', 'second' )
+		);
 
 		$diff = new Diff( array(
 			'zero' => new DiffOpRemove( $this->getNewStatement( 'zero', 'first' ) ),
@@ -87,17 +87,17 @@ class StatementListDifferTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenListWithChangedStatements_changeOperationsInDiff() {
-		$fromStatements = new StatementList( array(
+		$fromStatements = new StatementList(
 			$this->getNewStatement( 'zero', 'first' ),
 			$this->getNewStatement( 'one', 'second' ),
-			$this->getNewStatement( 'two', 'third' ),
-		) );
+			$this->getNewStatement( 'two', 'third' )
+		);
 
-		$toStatements = new StatementList( array(
+		$toStatements = new StatementList(
 			$this->getNewStatement( 'zero', 'FIRST' ),
 			$this->getNewStatement( 'one', 'second' ),
-			$this->getNewStatement( 'two', 'THIRD' ),
-		) );
+			$this->getNewStatement( 'two', 'THIRD' )
+		);
 
 		$diff = new Diff( array(
 			'zero' => new DiffOpChange(

--- a/tests/unit/Statement/StatementListDifferTest.php
+++ b/tests/unit/Statement/StatementListDifferTest.php
@@ -43,7 +43,7 @@ class StatementListDifferTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	private function getNewStatement( $guid, $hash ) {
-		$statement = new Statement( new Claim( new PropertyValueSnak( 1, new StringValue( $hash ) ) ) );
+		$statement = new Statement( new PropertyValueSnak( 1, new StringValue( $hash ) ) );
 		$statement->setGuid( $guid );
 		return $statement;
 	}

--- a/tests/unit/Statement/StatementListPatcherTest.php
+++ b/tests/unit/Statement/StatementListPatcherTest.php
@@ -34,16 +34,16 @@ class StatementListPatcherTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testFoo() {
-		$statement0 = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement0 = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement0->setGuid( 's0' );
 
-		$statement1 = new Statement( new Claim( new PropertySomeValueSnak( 42 ) ) );
+		$statement1 = new Statement( new PropertySomeValueSnak( 42 ) );
 		$statement1->setGuid( 's1' );
 
-		$statement2 = new Statement( new Claim( new PropertyValueSnak( 42, new StringValue( 'ohi' ) ) ) );
+		$statement2 = new Statement( new PropertyValueSnak( 42, new StringValue( 'ohi' ) ) );
 		$statement2->setGuid( 's2' );
 
-		$statement3 = new Statement( new Claim( new PropertyNoValueSnak( 1 ) ) );
+		$statement3 = new Statement( new PropertyNoValueSnak( 1 ) );
 		$statement3->setGuid( 's3' );
 
 		$patch = new Diff( array(

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -158,7 +158,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 
 	private function getStatementWithSnak( $propertyId, $stringValue ) {
 		$snak = $this->newSnak( $propertyId, $stringValue );
-		$statement = new Statement( new Claim( $snak ) );
+		$statement = new Statement( $snak );
 		$statement->setGuid( sha1( $snak->getHash() ) );
 		return $statement;
 	}
@@ -173,9 +173,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$list->addNewStatement( $this->newSnak( 42, 'foo' ) );
 
 		$this->assertEquals(
-			new StatementList(
-				new Statement( new Claim( $this->newSnak( 42, 'foo' ) ) )
-			),
+			new StatementList( new Statement( $this->newSnak( 42, 'foo' ) ) ),
 			$list
 		);
 	}
@@ -192,12 +190,12 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			new StatementList(
-				new Statement( new Claim(
+				new Statement(
 					$this->newSnak( 42, 'foo' ),
 					new SnakList( array(
 						$this->newSnak( 1, 'bar' )
 					) )
-				) )
+				)
 			),
 			$list
 		);
@@ -215,12 +213,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals(
-			new StatementList(
-				new Statement( new Claim(
-					$this->newSnak( 42, 'foo' ),
-					$snakList
-				) )
-			),
+			new StatementList( new Statement( $this->newSnak( 42, 'foo' ), $snakList ) ),
 			$list
 		);
 	}
@@ -235,10 +228,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 			'kittens'
 		);
 
-		$statement = new Statement( new Claim(
-			$this->newSnak( 42, 'foo' ),
-			null
-		) );
+		$statement = new Statement( $this->newSnak( 42, 'foo' ) );
 
 		$statement->setGuid( 'kittens' );
 
@@ -283,7 +273,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanConstructWithStatement() {
-		$statement = new Statement( new Claim( $this->newSnak( 42, 'foo' ) ) );
+		$statement = new Statement( $this->newSnak( 42, 'foo' ) );
 
 		$this->assertEquals(
 			new StatementList( array( $statement ) ),
@@ -292,9 +282,9 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanConstructWithStatementArgumentList() {
-		$statement0 = new Statement( new Claim( $this->newSnak( 42, 'foo' ) ) );
-		$statement1 = new Statement( new Claim( $this->newSnak( 42, 'bar' ) ) );
-		$statement2 = new Statement( new Claim( $this->newSnak( 42, 'baz' ) ) );
+		$statement0 = new Statement( $this->newSnak( 42, 'foo' ) );
+		$statement1 = new Statement( $this->newSnak( 42, 'bar' ) );
+		$statement2 = new Statement( $this->newSnak( 42, 'baz' ) );
 
 		$this->assertEquals(
 			new StatementList( array( $statement0, $statement1, $statement2 ) ),
@@ -303,9 +293,9 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenArgumentListWithNonStatement_constructorThrowsException() {
-		$statement0 = new Statement( new Claim( $this->newSnak( 42, 'foo' ) ) );
-		$statement1 = new Statement( new Claim( $this->newSnak( 42, 'bar' ) ) );
-		$statement2 = new Statement( new Claim( $this->newSnak( 42, 'baz' ) ) );
+		$statement0 = new Statement( $this->newSnak( 42, 'foo' ) );
+		$statement1 = new Statement( $this->newSnak( 42, 'bar' ) );
+		$statement2 = new Statement( $this->newSnak( 42, 'baz' ) );
 
 		$this->setExpectedException( 'InvalidArgumentException' );
 		new StatementList( $statement0, $statement1, array(), $statement2 );
@@ -482,13 +472,13 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenValidRank_getWithRankReturnsOnlyMatchingStatements() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setRank( Statement::RANK_PREFERRED );
 
-		$secondStatement = new Statement( new Claim( new PropertyNoValueSnak( 1337 ) ) );
+		$secondStatement = new Statement( new PropertyNoValueSnak( 1337 ) );
 		$secondStatement->setRank( Statement::RANK_NORMAL );
 
-		$thirdStatement = new Statement( new Claim( new PropertyNoValueSnak( 9001 ) ) );
+		$thirdStatement = new Statement( new PropertyNoValueSnak( 9001 ) );
 		$thirdStatement->setRank( Statement::RANK_DEPRECATED );
 
 		$list = new StatementList( $statement, $secondStatement, $thirdStatement );
@@ -510,10 +500,10 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testWhenOnlyDeprecatedStatements_getBestStatementsReturnsEmptyList() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setRank( Statement::RANK_DEPRECATED );
 
-		$secondStatement = new Statement( new Claim( new PropertyNoValueSnak( 9001 ) ) );
+		$secondStatement = new Statement( new PropertyNoValueSnak( 9001 ) );
 		$secondStatement->setRank( Statement::RANK_DEPRECATED );
 
 		$list = new StatementList( $statement, $secondStatement );
@@ -521,16 +511,16 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testWhenPreferredStatements_getBestStatementsReturnsOnlyThose() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setRank( Statement::RANK_PREFERRED );
 
-		$secondStatement = new Statement( new Claim( new PropertyNoValueSnak( 1337 ) ) );
+		$secondStatement = new Statement( new PropertyNoValueSnak( 1337 ) );
 		$secondStatement->setRank( Statement::RANK_NORMAL );
 
-		$thirdStatement = new Statement( new Claim( new PropertyNoValueSnak( 9001 ) ) );
+		$thirdStatement = new Statement( new PropertyNoValueSnak( 9001 ) );
 		$thirdStatement->setRank( Statement::RANK_DEPRECATED );
 
-		$fourthStatement = new Statement( new Claim( new PropertyNoValueSnak( 23 ) ) );
+		$fourthStatement = new Statement( new PropertyNoValueSnak( 23 ) );
 		$fourthStatement->setRank( Statement::RANK_PREFERRED );
 
 		$list = new StatementList( $statement, $secondStatement, $thirdStatement, $fourthStatement );
@@ -541,13 +531,13 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testWhenNoPreferredStatements_getBestStatementsReturnsOnlyNormalOnes() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setRank( Statement::RANK_NORMAL );
 
-		$secondStatement = new Statement( new Claim( new PropertyNoValueSnak( 1337 ) ) );
+		$secondStatement = new Statement( new PropertyNoValueSnak( 1337 ) );
 		$secondStatement->setRank( Statement::RANK_NORMAL );
 
-		$thirdStatement = new Statement( new Claim( new PropertyNoValueSnak( 9001 ) ) );
+		$thirdStatement = new Statement( new PropertyNoValueSnak( 9001 ) );
 		$thirdStatement->setRank( Statement::RANK_DEPRECATED );
 
 		$list = new StatementList( $statement, $secondStatement, $thirdStatement );

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -27,13 +27,13 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenStatements_getPropertyIdsReturnsArrayWithoutDuplicates() {
-		$list = new StatementList( array(
+		$list = new StatementList(
 			$this->getStatement( 1, 'kittens' ),
 			$this->getStatement( 3, 'foo' ),
 			$this->getStatement( 2, 'bar' ),
 			$this->getStatement( 2, 'baz' ),
-			$this->getStatement( 1, 'bah' ),
-		) );
+			$this->getStatement( 1, 'bah' )
+		);
 
 		$this->assertEquals(
 			array(
@@ -80,7 +80,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanIterate() {
 		$statement = $this->getStatement( 1, 'kittens' );
-		$list = new StatementList( array( $statement ) );
+		$list = new StatementList( $statement );
 
 		foreach ( $list as $statementFormList ) {
 			$this->assertEquals( $statement, $statementFormList );
@@ -88,7 +88,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetBestStatementPerProperty() {
-		$list = new StatementList( array(
+		$list = new StatementList(
 			$this->getStatement( 1, 'one', Statement::RANK_PREFERRED ),
 			$this->getStatement( 1, 'two', Statement::RANK_NORMAL ),
 			$this->getStatement( 1, 'three', Statement::RANK_PREFERRED ),
@@ -99,8 +99,8 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 			$this->getStatement( 3, 'six', Statement::RANK_NORMAL ),
 
 			$this->getStatement( 4, 'seven', Statement::RANK_PREFERRED ),
-			$this->getStatement( 4, 'eight', Claim::RANK_TRUTH ),
-		) );
+			$this->getStatement( 4, 'eight', Claim::RANK_TRUTH )
+		);
 
 		$this->assertEquals(
 			array(
@@ -116,13 +116,13 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetUniqueMainSnaksReturnsListWithoutDuplicates() {
-		$list = new StatementList( array(
+		$list = new StatementList(
 			$this->getStatementWithSnak( 1, 'foo' ),
 			$this->getStatementWithSnak( 2, 'foo' ),
 			$this->getStatementWithSnak( 1, 'foo' ),
 			$this->getStatementWithSnak( 2, 'bar' ),
-			$this->getStatementWithSnak( 1, 'bar' ),
-		) );
+			$this->getStatementWithSnak( 1, 'bar' )
+		);
 
 		$this->assertEquals(
 			array(
@@ -136,13 +136,13 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetAllSnaksReturnsAllSnaks() {
-		$list = new StatementList( array(
+		$list = new StatementList(
 			$this->getStatementWithSnak( 1, 'foo' ),
 			$this->getStatementWithSnak( 2, 'foo' ),
 			$this->getStatementWithSnak( 1, 'foo' ),
 			$this->getStatementWithSnak( 2, 'bar' ),
-			$this->getStatementWithSnak( 1, 'bar' ),
-		) );
+			$this->getStatementWithSnak( 1, 'bar' )
+		);
 
 		$this->assertEquals(
 			array(
@@ -173,9 +173,9 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$list->addNewStatement( $this->newSnak( 42, 'foo' ) );
 
 		$this->assertEquals(
-			new StatementList( array(
+			new StatementList(
 				new Statement( new Claim( $this->newSnak( 42, 'foo' ) ) )
-			) ),
+			),
 			$list
 		);
 	}
@@ -191,14 +191,14 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals(
-			new StatementList( array(
+			new StatementList(
 				new Statement( new Claim(
 					$this->newSnak( 42, 'foo' ),
 					new SnakList( array(
 						$this->newSnak( 1, 'bar' )
 					) )
 				) )
-			) ),
+			),
 			$list
 		);
 	}
@@ -215,12 +215,12 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals(
-			new StatementList( array(
+			new StatementList(
 				new Statement( new Claim(
 					$this->newSnak( 42, 'foo' ),
 					$snakList
 				) )
-			) ),
+			),
 			$list
 		);
 	}
@@ -242,10 +242,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 
 		$statement->setGuid( 'kittens' );
 
-		$this->assertEquals(
-			new StatementList( array( $statement ) ),
-			$list
-		);
+		$this->assertEquals( new StatementList( $statement ), $list );
 	}
 
 	public function testCanConstructWithClaimsObjectContainingOnlyStatements() {
@@ -321,10 +318,10 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCountForNonEmptyList() {
-		$list = new StatementList( array(
+		$list = new StatementList(
 			$this->getStatementWithSnak( 1, 'foo' ),
-			$this->getStatementWithSnak( 2, 'bar' ),
-		) );
+			$this->getStatementWithSnak( 2, 'bar' )
+		);
 
 		$this->assertSame( 2, $list->count() );
 	}
@@ -354,47 +351,47 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenDifferentLists_equalsReturnsFalse() {
-		$firstStatements = new StatementList( array(
+		$firstStatements = new StatementList(
 			$this->getStatementWithSnak( 1, 'foo' ),
-			$this->getStatementWithSnak( 2, 'bar' ),
-		) );
+			$this->getStatementWithSnak( 2, 'bar' )
+		);
 
-		$secondStatements = new StatementList( array(
+		$secondStatements = new StatementList(
 			$this->getStatementWithSnak( 1, 'foo' ),
-			$this->getStatementWithSnak( 2, 'SPAM' ),
-		) );
+			$this->getStatementWithSnak( 2, 'SPAM' )
+		);
 
 		$this->assertFalse( $firstStatements->equals( $secondStatements ) );
 	}
 
 	public function testGivenListsWithDifferentDuplicates_equalsReturnsFalse() {
-		$firstStatements = new StatementList( array(
+		$firstStatements = new StatementList(
 			$this->getStatementWithSnak( 1, 'foo' ),
 			$this->getStatementWithSnak( 1, 'foo' ),
-			$this->getStatementWithSnak( 2, 'bar' ),
-		) );
+			$this->getStatementWithSnak( 2, 'bar' )
+		);
 
-		$secondStatements = new StatementList( array(
+		$secondStatements = new StatementList(
 			$this->getStatementWithSnak( 1, 'foo' ),
 			$this->getStatementWithSnak( 2, 'bar' ),
-			$this->getStatementWithSnak( 2, 'bar' ),
-		) );
+			$this->getStatementWithSnak( 2, 'bar' )
+		);
 
 		$this->assertFalse( $firstStatements->equals( $secondStatements ) );
 	}
 
 	public function testGivenListsWithDifferentOrder_equalsReturnsFalse() {
-		$firstStatements = new StatementList( array(
+		$firstStatements = new StatementList(
 			$this->getStatementWithSnak( 1, 'foo' ),
 			$this->getStatementWithSnak( 2, 'bar' ),
-			$this->getStatementWithSnak( 3, 'baz' ),
-		) );
+			$this->getStatementWithSnak( 3, 'baz' )
+		);
 
-		$secondStatements = new StatementList( array(
+		$secondStatements = new StatementList(
 			$this->getStatementWithSnak( 1, 'foo' ),
 			$this->getStatementWithSnak( 3, 'baz' ),
-			$this->getStatementWithSnak( 2, 'bar' ),
-		) );
+			$this->getStatementWithSnak( 2, 'bar' )
+		);
 
 		$this->assertFalse( $firstStatements->equals( $secondStatements ) );
 	}
@@ -402,21 +399,21 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	public function testEmptyListDoesNotEqualNonEmptyList() {
 		$firstStatements = new StatementList();
 
-		$secondStatements = new StatementList( array(
+		$secondStatements = new StatementList(
 			$this->getStatementWithSnak( 1, 'foo' ),
 			$this->getStatementWithSnak( 3, 'baz' ),
-			$this->getStatementWithSnak( 2, 'bar' ),
-		) );
+			$this->getStatementWithSnak( 2, 'bar' )
+		);
 
 		$this->assertFalse( $firstStatements->equals( $secondStatements ) );
 	}
 
 	public function testNonEmptyListDoesNotEqualEmptyList() {
-		$firstStatements = new StatementList( array(
+		$firstStatements = new StatementList(
 			$this->getStatementWithSnak( 1, 'foo' ),
 			$this->getStatementWithSnak( 3, 'baz' ),
-			$this->getStatementWithSnak( 2, 'bar' ),
-		) );
+			$this->getStatementWithSnak( 2, 'bar' )
+		);
 
 		$secondStatements = new StatementList();
 
@@ -430,9 +427,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testNonEmptyListIsNotEmpty() {
-		$list = new StatementList( array(
-			$this->getStatementWithSnak( 1, 'foo' ),
-		) );
+		$list = new StatementList( $this->getStatementWithSnak( 1, 'foo' ) );
 
 		$this->assertFalse( $list->isEmpty() );
 	}
@@ -496,15 +491,15 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$thirdStatement = new Statement( new Claim( new PropertyNoValueSnak( 9001 ) ) );
 		$thirdStatement->setRank( Statement::RANK_DEPRECATED );
 
-		$list = new StatementList( array( $statement, $secondStatement, $thirdStatement ) );
+		$list = new StatementList( $statement, $secondStatement, $thirdStatement );
 
 		$this->assertEquals(
-			new StatementList( array( $statement ) ),
+			new StatementList( $statement ),
 			$list->getWithRank( Statement::RANK_PREFERRED )
 		);
 
 		$this->assertEquals(
-			new StatementList( array( $secondStatement, $thirdStatement ) ),
+			new StatementList( $secondStatement, $thirdStatement ),
 			$list->getWithRank( array( Statement::RANK_NORMAL, Statement::RANK_DEPRECATED ) )
 		);
 	}
@@ -521,7 +516,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$secondStatement = new Statement( new Claim( new PropertyNoValueSnak( 9001 ) ) );
 		$secondStatement->setRank( Statement::RANK_DEPRECATED );
 
-		$list = new StatementList( array( $statement, $secondStatement ) );
+		$list = new StatementList( $statement, $secondStatement );
 		$this->assertEquals( new StatementList(), $list->getBestStatements() );
 	}
 
@@ -538,9 +533,9 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$fourthStatement = new Statement( new Claim( new PropertyNoValueSnak( 23 ) ) );
 		$fourthStatement->setRank( Statement::RANK_PREFERRED );
 
-		$list = new StatementList( array( $statement, $secondStatement, $thirdStatement, $fourthStatement ) );
+		$list = new StatementList( $statement, $secondStatement, $thirdStatement, $fourthStatement );
 		$this->assertEquals(
-			new StatementList( array( $statement, $fourthStatement ) ),
+			new StatementList( $statement, $fourthStatement ),
 			$list->getBestStatements()
 		);
 	}
@@ -555,9 +550,9 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$thirdStatement = new Statement( new Claim( new PropertyNoValueSnak( 9001 ) ) );
 		$thirdStatement->setRank( Statement::RANK_DEPRECATED );
 
-		$list = new StatementList( array( $statement, $secondStatement, $thirdStatement ) );
+		$list = new StatementList( $statement, $secondStatement, $thirdStatement );
 		$this->assertEquals(
-			new StatementList( array( $statement, $secondStatement ) ),
+			new StatementList( $statement, $secondStatement ),
 			$list->getBestStatements()
 		);
 	}

--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -25,13 +25,6 @@ use Wikibase\DataModel\Statement\Statement;
  */
 class StatementTest extends \PHPUnit_Framework_TestCase {
 
-	public function testConstructorTakesGuidFromClaim() {
-		$claim = new Claim( new PropertyNoValueSnak( new PropertyId( 'P42' ) ) );
-		$claim->setGuid( 'meh' );
-		$statement = new Statement( $claim );
-		$this->assertEquals( 'meh', $statement->getGuid() );
-	}
-
 	/**
 	 * @dataProvider instanceProvider
 	 */
@@ -54,7 +47,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 
 	public function testSetAndGetMainSnak() {
 		$mainSnak = new PropertyNoValueSnak( new PropertyId( 'P42' ) );
-		$statement = new Statement( new Claim( $mainSnak ) );
+		$statement = new Statement( $mainSnak );
 		$this->assertSame( $mainSnak, $statement->getMainSnak() );
 	}
 
@@ -63,10 +56,10 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 			new PropertyValueSnak( new PropertyId( 'P42' ), new StringValue( 'a' ) )
 		) );
 
-		$statement = new Statement( new Claim(
+		$statement = new Statement(
 			new PropertyNoValueSnak( new PropertyId( 'P42' ) ),
 			$qualifiers
-		) );
+		);
 
 		$this->assertSame( $qualifiers, $statement->getQualifiers() );
 	}
@@ -81,17 +74,17 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGuidDoesNotAffectHash() {
-		$statement0 = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement0 = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement0->setGuid( 'statement0' );
 
-		$statement1 = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement1 = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement1->setGuid( 'statement1' );
 
 		$this->assertEquals( $statement0->getHash(), $statement1->getHash() );
 	}
 
 	public function testSetInvalidGuidCausesException() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 
 		$this->setExpectedException( 'InvalidArgumentException' );
 		$statement->setGuid( 42 );
@@ -101,7 +94,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 		$instances = array();
 
 		$propertyId = new PropertyId( 'P42' );
-		$baseInstance = new Statement( new Claim( new PropertyNoValueSnak( $propertyId ) ) );
+		$baseInstance = new Statement( new PropertyNoValueSnak( $propertyId ) );
 
 		$instances[] = $baseInstance;
 
@@ -244,7 +237,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenNonStatement_equalsReturnsFalse() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 
 		$this->assertFalse( $statement->equals( null ) );
 		$this->assertFalse( $statement->equals( 42 ) );
@@ -253,12 +246,10 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGivenSameStatement_equalsReturnsTrue() {
 		$statement = new Statement(
-			new Claim(
-				new PropertyNoValueSnak( 42 ),
-				new SnakList( array(
-					new PropertyNoValueSnak( 1337 ),
-				) )
-			),
+			new PropertyNoValueSnak( 42 ),
+			new SnakList( array(
+				new PropertyNoValueSnak( 1337 ),
+			) ),
 			new ReferenceList( array(
 				new PropertyNoValueSnak( 1337 ),
 			) )
@@ -271,37 +262,37 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenStatementWithDifferentProperty_equalsReturnsFalse() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
-		$this->assertFalse( $statement->equals( new Statement( new Claim( new PropertyNoValueSnak( 43 ) ) ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$this->assertFalse( $statement->equals( new Statement( new PropertyNoValueSnak( 43 ) ) ) );
 	}
 
 	public function testGivenStatementWithDifferentSnakType_equalsReturnsFalse() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
-		$this->assertFalse( $statement->equals( new Statement( new Claim( new PropertySomeValueSnak( 42 ) ) ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$this->assertFalse( $statement->equals( new Statement( new PropertySomeValueSnak( 42 ) ) ) );
 	}
 
 	public function testStatementClaimWithDifferentQualifiers_equalsReturnsFalse() {
-		$statement = new Statement( new Claim(
+		$statement = new Statement(
 			new PropertyNoValueSnak( 42 ),
 			new SnakList( array(
 				new PropertyNoValueSnak( 1337 ),
 			) )
-		) );
+		);
 
-		$differentStatement = new Statement( new Claim(
+		$differentStatement = new Statement(
 			new PropertyNoValueSnak( 42 ),
 			new SnakList( array(
 				new PropertyNoValueSnak( 32202 ),
 			) )
-		) );
+		);
 
 		$this->assertFalse( $statement->equals( $differentStatement ) );
 	}
 
 	public function testGivenStatementWithDifferentGuids_equalsReturnsFalse() {
-		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 
-		$differentStatement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$differentStatement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$differentStatement->setGuid( 'kittens' );
 
 		$this->assertFalse( $statement->equals( $differentStatement ) );
@@ -309,20 +300,16 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 
 	public function testStatementClaimWithDifferentReferences_equalsReturnsFalse() {
 		$statement = new Statement(
-			new Claim(
-				new PropertyNoValueSnak( 42 ),
-				new SnakList( array() )
-			),
+			new PropertyNoValueSnak( 42 ),
+			new SnakList( array() ),
 			new ReferenceList( array(
 				new PropertyNoValueSnak( 1337 ),
 			) )
 		);
 
 		$differentStatement = new Statement(
-			new Claim(
-				new PropertyNoValueSnak( 42 ),
-				new SnakList( array() )
-			),
+			new PropertyNoValueSnak( 42 ),
+			new SnakList( array() ),
 			new ReferenceList( array(
 				new PropertyNoValueSnak( 32202 ),
 			) )
@@ -372,7 +359,8 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 		$qualifiers = new SnakList( array( new PropertyNoValueSnak( 23 ) ) );
 
 		$statement = new Statement(
-			new Claim( new PropertyNoValueSnak( 42 ), $qualifiers ),
+			new PropertyNoValueSnak( 42 ),
+			$qualifiers,
 			new ReferenceList( array( new PropertyNoValueSnak( 1337 ) ) )
 		);
 


### PR DESCRIPTION
This patch does a single thing: Replace `( Claim $claim, ... )` with `( Snak $mainSnak, Snaks $qualifiers, ... )` in the `Statement` constructor (what I originally tried to submit as #268). This is split from #317 to make it easier to review.

Commit 1 is a separate pull request, see #367. Please merge #367 first.