### PR TITLE
[WIP] Rework ...List constructors

### DIFF
--- a/src/Reference.php
+++ b/src/Reference.php
@@ -26,22 +26,25 @@ class Reference implements \Hashable, \Comparable, \Immutable, \Countable {
 	/**
 	 * An array of Snak is only supported since version 1.1.
 	 *
-	 * @param Snaks|Snak[]|null $snaks
+	 * @param Snak[]|Snaks|Snak $snaks
+	 * @param Snak [$snak2,...]
+	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function __construct( $snaks = null ) {
-		if ( $snaks === null ) {
-			$this->snaks = new SnakList();
+	public function __construct( $snaks = array() /*...*/ ) {
+		if ( $snaks instanceof Snak ) {
+			$snaks = func_get_args();
 		}
-		elseif ( $snaks instanceof Snaks ) {
-			$this->snaks = $snaks;
+
+		if ( is_array( $snaks ) ) {
+			$snaks = new SnakList( $snaks );
 		}
-		elseif ( is_array( $snaks ) ) {
-			$this->snaks = new SnakList( $snaks );
+
+		if ( !( $snaks instanceof Snaks ) ) {
+			throw new InvalidArgumentException( '$snaks must be an array or an instance of Snaks' );
 		}
-		else {
-			throw new InvalidArgumentException( '$snaks must be an instance of Snaks, an array of instances of Snak, or null' );
-		}
+
+		$this->snaks = $snaks;
 	}
 
 	/**

--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -25,6 +25,30 @@ use Wikibase\DataModel\Snak\SnakList;
 class ReferenceList extends HashableObjectStorage {
 
 	/**
+	 * @param Reference[]|Traversable|Reference $references
+	 * @param Reference [$reference2,...]
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function __construct( $references = array() /*...*/ ) {
+		if ( $references instanceof Reference ) {
+			$references = func_get_args();
+		}
+
+		if ( !is_array( $references ) && !( $references instanceof Traversable ) ) {
+			throw new InvalidArgumentException( '$references must be an array or an instance of Traversable' );
+		}
+
+		foreach ( $references as $reference ) {
+			if ( !( $reference instanceof Reference ) ) {
+				throw new InvalidArgumentException( 'Every element in $references must be an instance of Reference' );
+			}
+
+			$this->addReference( $reference );
+		}
+	}
+
+	/**
 	 * Adds the provided reference to the list.
 	 *
 	 * @since 0.1

--- a/src/Snak/SnakList.php
+++ b/src/Snak/SnakList.php
@@ -2,6 +2,8 @@
 
 namespace Wikibase\DataModel\Snak;
 
+use InvalidArgumentException;
+use Traversable;
 use Wikibase\DataModel\HashArray;
 use Wikibase\DataModel\Internal\MapValueHasher;
 
@@ -16,6 +18,30 @@ use Wikibase\DataModel\Internal\MapValueHasher;
  * @author Adam Shorland
  */
 class SnakList extends HashArray implements Snaks {
+
+	/**
+	 * @param Snak[]|Traversable|Snak $snaks
+	 * @param Snak [$snak2,...]
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function __construct( $snaks = array() /*...*/ ) {
+		if ( $snaks instanceof Snak ) {
+			$snaks = func_get_args();
+		}
+
+		if ( !is_array( $snaks ) && !( $snaks instanceof Traversable ) ) {
+			throw new InvalidArgumentException( '$snaks must be an array or an instance of Traversable' );
+		}
+
+		foreach ( $snaks as $snak ) {
+			if ( !( $snak instanceof Snak ) ) {
+				throw new InvalidArgumentException( 'Every element in $snaks must be an instance of Snak' );
+			}
+
+			$this->addSnak( $snak );
+		}
+	}
 
 	/**
 	 * @see GenericArrayObject::getObjectType

--- a/tests/unit/HashArray/HashArrayTest.php
+++ b/tests/unit/HashArray/HashArrayTest.php
@@ -35,7 +35,7 @@ abstract class HashArrayTest extends \PHPUnit_Framework_TestCase {
 		$instances = array();
 
 		foreach ( $this->constructorProvider() as $args ) {
-			$instances[] = array( new $class( array_key_exists( 0, $args ) ? $args[0] : null ) );
+			$instances[] = array( new $class( array_key_exists( 0, $args ) ? $args[0] : array() ) );
 		}
 
 		return $instances;

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -40,9 +40,34 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	public function getConstructorArg() {
 		return array(
-			null,
 			array(),
 			$this->getElementInstances(),
+		);
+	}
+
+	/**
+	 * @dataProvider invalidConstructorArgumentsProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidConstructorArguments_constructorThrowsException( $input ) {
+		new ReferenceList( $input );
+	}
+
+	public function invalidConstructorArgumentsProvider() {
+		$id1 = new PropertyId( 'P1' );
+
+		return array(
+			array( null ),
+			array( false ),
+			array( 1 ),
+			array( 0.1 ),
+			array( 'string' ),
+			array( $id1 ),
+			array( new PropertyNoValueSnak( $id1 ) ),
+			array( new SnakList( array( new PropertyNoValueSnak( $id1 ) ) ) ),
+			array( array( new PropertyNoValueSnak( $id1 ) ) ),
+			array( array( new ReferenceList() ) ),
+			array( array( new SnakList() ) ),
 		);
 	}
 
@@ -66,7 +91,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 			$this->assertFalse( $array->hasReference( $hashable ) );
 		}
 	}
-
 
 	public function testGivenCloneOfReferenceInList_hasReferenceReturnsTrue() {
 		$list = new ReferenceList();

--- a/tests/unit/ReferenceTest.php
+++ b/tests/unit/ReferenceTest.php
@@ -265,16 +265,13 @@ class ReferenceTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function invalidConstructorArgumentsProvider() {
-		$id1 = new PropertyId( 'P1' );
-
 		return array(
 			array( false ),
 			array( 1 ),
 			array( 0.1 ),
 			array( 'string' ),
-			array( $id1 ),
-			array( new PropertyNoValueSnak( $id1 ) ),
-			array( new PropertyValueSnak( $id1, new StringValue( 'a' ) ) ),
+			array( new PropertyId( 'P1' ) ),
+			array( array( new Reference() ) ),
 			array( array( new SnakList() ) ),
 			array( new Reference() ),
 		);

--- a/tests/unit/Snak/SnakListTest.php
+++ b/tests/unit/Snak/SnakListTest.php
@@ -82,16 +82,14 @@ class SnakListTest extends HashArrayTest {
 	}
 
 	public function invalidConstructorArgumentsProvider() {
-		$id1 = new PropertyId( 'P1' );
-
 		return array(
+			array( null ),
 			array( false ),
 			array( 1 ),
 			array( 0.1 ),
 			array( 'string' ),
-			array( $id1 ),
-			array( new PropertyNoValueSnak( $id1 ) ),
-			array( new PropertyValueSnak( $id1, new StringValue( 'a' ) ) ),
+			array( new PropertyId( 'P1' ) ),
+			array( array( new SnakList() ) ),
 		);
 	}
 

--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -241,9 +241,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 			new SnakList( array(
 				new PropertyNoValueSnak( 1337 ),
 			) ),
-			new ReferenceList( array(
-				new PropertyNoValueSnak( 1337 ),
-			) )
+			new ReferenceList( new Reference( new PropertyNoValueSnak( 1337 ) ) )
 		);
 
 		$statement->setGuid( 'kittens' );
@@ -293,17 +291,13 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 		$statement = new Statement(
 			new PropertyNoValueSnak( 42 ),
 			new SnakList( array() ),
-			new ReferenceList( array(
-				new PropertyNoValueSnak( 1337 ),
-			) )
+			new ReferenceList( new Reference( new PropertyNoValueSnak( 1337 ) ) )
 		);
 
 		$differentStatement = new Statement(
 			new PropertyNoValueSnak( 42 ),
 			new SnakList( array() ),
-			new ReferenceList( array(
-				new PropertyNoValueSnak( 32202 ),
-			) )
+			new ReferenceList( new Reference( new PropertyNoValueSnak( 32202 ) ) )
 		);
 
 		$this->assertFalse( $statement->equals( $differentStatement ) );
@@ -352,7 +346,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 		$statement = new Statement(
 			new PropertyNoValueSnak( 42 ),
 			$qualifiers,
-			new ReferenceList( array( new PropertyNoValueSnak( 1337 ) ) )
+			new ReferenceList( new Reference( new PropertyNoValueSnak( 1337 ) ) )
 		);
 
 		$statement->setRank( Statement::RANK_NORMAL );


### PR DESCRIPTION
This changes all three
* `Reference`
* `ReferenceList` and
* `SnakList`

classes to

1. not accept `null`,
2. reject mismatching elements and
3. accept variable constructor arguments.

This fixes #370, #371 and #372.

Note how the ReferenceList constructor was used wrong in StatementTest.

WIP because some of these new features are missing tests. And I should probably create three pull requests for the three classes.