### PR TITLE
Favor float over alias double

### DIFF
--- a/src/Entity/EntityIdValue.php
+++ b/src/Entity/EntityIdValue.php
@@ -42,10 +42,10 @@ class EntityIdValue extends DataValueObject {
 	 * though cannot be removed until we ditch the "numeric id" part
 	 * from the serialization.
 	 *
-	 * @return double Numeric id as a whole number. Can not be int because of 32-bit PHP.
+	 * @return float Numeric id as a whole number. Can not be int because of 32-bit PHP.
 	 */
 	protected function getNumericId() {
-		return doubleval( substr( $this->entityId->getSerialization(), 1 ) );
+		return floatval( substr( $this->entityId->getSerialization(), 1 ) );
 	}
 
 	/**


### PR DESCRIPTION
`doubleval` is an alias in PHP. So is `double`. We use the word "double" for test doubles, for example, but never (except for this single place) as a type.