### PR TITLE
Don't access vendor/bin in composer ci

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,16 +44,16 @@
 		}
 	},
 	"scripts": {
+		"ci": [
+			"composer test",
+			"composer cs"
+		],
 		"test": [
 			"composer validate --no-interaction",
 			"phpunit"
 		],
 		"cs": [
-			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp"
-		],
-		"ci": [
-			"composer test",
-			"composer cs"
+			"phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp"
 		]
 	}
 }


### PR DESCRIPTION
Remove "vendor/bin/" as suggested by @Krinkle in https://github.com/wmde/Diff/commit/acd15a05c6317c0a5a1ea446eca01123fce4bca1#commitcomment-9861167.

I'm also moving the `ci` command to the top.