### PR TITLE
More descriptive Term/AliasGroup docs

### DIFF
--- a/src/Term/AliasGroup.php
+++ b/src/Term/AliasGroup.php
@@ -19,7 +19,8 @@ use InvalidArgumentException;
 class AliasGroup implements Comparable, Countable {
 
 	/**
-	 * @var string
+	 * @var string Language code identifying the language of the aliases, but note that there is
+	 * nothing this class can do to enforce this convention.
 	 */
 	private $languageCode;
 
@@ -29,7 +30,7 @@ class AliasGroup implements Comparable, Countable {
 	private $aliases;
 
 	/**
-	 * @param string $languageCode
+	 * @param string $languageCode Language of the aliases.
 	 * @param string[] $aliases
 	 *
 	 * @throws InvalidArgumentException

--- a/src/Term/Term.php
+++ b/src/Term/Term.php
@@ -16,7 +16,8 @@ use InvalidArgumentException;
 class Term implements Comparable {
 
 	/**
-	 * @var string
+	 * @var string Language code identifying the language of the text, but note that there is
+	 * nothing this class can do to enforce this convention.
 	 */
 	private $languageCode;
 
@@ -26,7 +27,7 @@ class Term implements Comparable {
 	private $text;
 
 	/**
-	 * @param string $languageCode
+	 * @param string $languageCode Language of the text.
 	 * @param string $text
 	 *
 	 * @throws InvalidArgumentException


### PR DESCRIPTION
This describes how the classes **should** be used. Note that the fallback subclasses violate this convention. Which is the reason why I want to add some documentation to the base classes.

The wording is similar to the one in https://github.com/DataValues/Time/pull/35.