### PR TITLE
Fix ReferenceList accepting anything

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,7 @@
 ## Version 2.6.0 (dev)
 
 * Empty strings are now detected as invalid in the `SiteLink` constructor
+* The `ReferenceList` constructor now throws an `InvalidArgumentException` when getting a non-iterable input
 * The `SnakList` constructor now throws an `InvalidArgumentException` when getting a non-iterable input
 * The `AliasGroup::equals` and `Term::equals` methods no longer incorrectly return true for fallback objects
 

--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel;
 
 use Hashable;
 use InvalidArgumentException;
+use Traversable;
 use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Snak\SnakList;
 
@@ -21,8 +22,32 @@ use Wikibase\DataModel\Snak\SnakList;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author H. Snater < mediawiki@snater.com >
+ * @author Thiemo Mättig
  */
 class ReferenceList extends HashableObjectStorage {
+
+	/**
+	 * @param Reference[]|Traversable|null $references
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function __construct( $references = null ) {
+		if ( $references === null ) {
+			return;
+		}
+
+		if ( !is_array( $references ) && !( $references instanceof Traversable ) ) {
+			throw new InvalidArgumentException( '$references must be an array or an instance of Traversable' );
+		}
+
+		foreach ( $references as $reference ) {
+			if ( !( $reference instanceof Reference ) ) {
+				throw new InvalidArgumentException( 'Every element in $references must be an instance of Reference' );
+			}
+
+			$this->addReference( $reference );
+		}
+	}
 
 	/**
 	 * Adds the provided reference to the list.

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -3,6 +3,8 @@
 namespace Wikibase\DataModel\Tests;
 
 use Hashable;
+use InvalidArgumentException;
+use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\ReferenceList;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
@@ -17,6 +19,7 @@ use Wikibase\DataModel\Snak\SnakList;
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
 class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
@@ -43,6 +46,33 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 			null,
 			array(),
 			$this->getElementInstances(),
+		);
+	}
+
+	/**
+	 * @dataProvider invalidConstructorArgumentsProvider
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testGivenInvalidConstructorArguments_constructorThrowsException( $input ) {
+		new ReferenceList( $input );
+	}
+
+	public function invalidConstructorArgumentsProvider() {
+		$id1 = new PropertyId( 'P1' );
+
+		return array(
+			// TODO: Disallow array( null ),
+			array( false ),
+			array( 1 ),
+			array( 0.1 ),
+			array( 'string' ),
+			array( $id1 ),
+			array( new PropertyNoValueSnak( $id1 ) ),
+			array( new Reference() ),
+			array( new SnakList( array( new PropertyNoValueSnak( $id1 ) ) ) ),
+			array( array( new PropertyNoValueSnak( $id1 ) ) ),
+			array( array( new ReferenceList() ) ),
+			array( array( new SnakList() ) ),
 		);
 	}
 

--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -259,7 +259,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 				) )
 			),
 			new ReferenceList( array(
-				new PropertyNoValueSnak( 1337 ),
+				new Reference( array( new PropertyNoValueSnak( 1337 ) ) ),
 			) )
 		);
 
@@ -313,7 +313,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 				new SnakList( array() )
 			),
 			new ReferenceList( array(
-				new PropertyNoValueSnak( 1337 ),
+				new Reference( array( new PropertyNoValueSnak( 1337 ) ) ),
 			) )
 		);
 
@@ -323,7 +323,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 				new SnakList( array() )
 			),
 			new ReferenceList( array(
-				new PropertyNoValueSnak( 32202 ),
+				new Reference( array( new PropertyNoValueSnak( 32202 ) ) ),
 			) )
 		);
 
@@ -352,7 +352,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 		$statement = new Statement(
 			new Claim( new PropertyNoValueSnak( 42 ), $qualifiers ),
 			new ReferenceList( array(
-				new PropertyNoValueSnak( 1337 ),
+				new Reference( array( new PropertyNoValueSnak( 1337 ) ) ),
 			) )
 		);
 		$statement->setGuid( '~=[,,_,,]:3' );
@@ -409,7 +409,9 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 
 		$statement = new Statement(
 			new Claim( new PropertyNoValueSnak( 42 ), $qualifiers ),
-			new ReferenceList( array( new PropertyNoValueSnak( 1337 ) ) )
+			new ReferenceList( array(
+				new Reference( array( new PropertyNoValueSnak( 1337 ) ) ),
+			) )
 		);
 
 		$statement->setRank( Statement::RANK_NORMAL );


### PR DESCRIPTION
Same as #356, but for the `ReferenceList` class.

This patch reduces the `HashableObjectStorage` base class dependency by not calling the parent constructor. I'm doing this on purpose to make it easier to possibly drop the base class some day.

This is split from #376 but submitted against master.

This fixes #371.