### PR TITLE
Clean-up dataProvider docs and type hints

### DIFF
--- a/tests/unit/ByPropertyIdArrayTest.php
+++ b/tests/unit/ByPropertyIdArrayTest.php
@@ -117,7 +117,6 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider listProvider
-	 * @param Snak[] $objects
 	 */
 	public function testGetIds( array $objects ) {
 		$indexedArray = new ByPropertyIdArray( $objects );
@@ -140,7 +139,6 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider listProvider
-	 * @param array $objects
 	 */
 	public function testGetById( array $objects ) {
 		$indexedArray = new ByPropertyIdArray( $objects );
@@ -172,7 +170,6 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider listProvider
-	 * @param array $objects
 	 */
 	public function testRemoveObject( array $objects ) {
 		$lastIndex = count( $objects ) - 1;
@@ -222,7 +219,6 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider listProvider
-	 * @param array $objects
 	 */
 	public function testGetFlatArrayIndexOfObject( array $objects ) {
 		$indexedArray = new ByPropertyIdArray( $objects );
@@ -242,7 +238,6 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider listProvider
-	 * @param array $objects
 	 */
 	public function testToFlatArray( array $objects ) {
 		$indexedArray = new ByPropertyIdArray( $objects );
@@ -308,10 +303,10 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider moveProvider
-	 * @param array $objectsSource
+	 * @param object[] $objectsSource
 	 * @param object $object
 	 * @param int $toIndex
-	 * @param array $objectsDestination
+	 * @param object[] $objectsDestination
 	 */
 	public function testMoveObjectToIndex(
 		array $objectsSource,
@@ -387,10 +382,10 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider addProvider
-	 * @param array $objectsSource
+	 * @param object[] $objectsSource
 	 * @param object $object
-	 * @param int $index
-	 * @param array $objectsDestination
+	 * @param int|null $index
+	 * @param object[] $objectsDestination
 	 */
 	public function testAddObjectAtIndex(
 		array $objectsSource,

--- a/tests/unit/ByPropertyIdGrouperTest.php
+++ b/tests/unit/ByPropertyIdGrouperTest.php
@@ -50,7 +50,6 @@ class ByPropertyIdGrouperTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider provideGetPropertyIds
-	 *
 	 * @param PropertyIdProvider[] $propertyIdProviders
 	 * @param PropertyId[] $expectedPropertyIds
 	 */
@@ -82,7 +81,6 @@ class ByPropertyIdGrouperTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider provideGetByPropertyId
-	 *
 	 * @param PropertyIdProvider[] $propertyIdProviders
 	 * @param string $propertyId
 	 * @param string[] $expectedValues
@@ -120,10 +118,9 @@ class ByPropertyIdGrouperTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider provideHasPropertyId
-	 *
 	 * @param PropertyIdProvider[] $propertyIdProviders
 	 * @param string $propertyId
-	 * @param boolean $expectedValue
+	 * @param bool $expectedValue
 	 */
 	public function testHasPropertyId( array $propertyIdProviders, $propertyId, $expectedValue ) {
 		$byPropertyIdGrouper = new ByPropertyIdGrouper( $propertyIdProviders );

--- a/tests/unit/Claim/ClaimGuidTest.php
+++ b/tests/unit/Claim/ClaimGuidTest.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel\Tests\Claim;
 
 use Exception;
 use Wikibase\DataModel\Claim\ClaimGuid;
+use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\ItemId;
 
 /**
@@ -20,12 +21,11 @@ class ClaimGuidTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider provideConstructionData
-	 *
-	 * @param $entityId
-	 * @param $guid
-	 * @param $expected
+	 * @param EntityId $entityId
+	 * @param string $guid
+	 * @param string $expected
 	 */
-	public function testConstructor( $entityId, $guid, $expected ) {
+	public function testConstructor( EntityId $entityId, $guid, $expected ) {
 		$claimGuid = new ClaimGuid( $entityId, $guid );
 
 		$this->assertEquals( $expected, $claimGuid->getSerialization() );
@@ -56,9 +56,6 @@ class ClaimGuidTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider provideBadConstruction
-	 *
-	 * @param $entityId
-	 * @param $guid
 	 */
 	public function testBadConstruction( $entityId, $guid ) {
 		$this->setExpectedException( 'InvalidArgumentException' );
@@ -90,10 +87,9 @@ class ClaimGuidTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider provideClaimGuids
-	 *
 	 * @param ClaimGuid $claimGuid
 	 */
-	public function testEquals( $claimGuid ) {
+	public function testEquals( ClaimGuid $claimGuid ) {
 		$claimGuidCopy = clone $claimGuid;
 		$this->assertTrue( $claimGuid->equals( $claimGuidCopy ) );
 		$this->assertTrue( $claimGuidCopy->equals( $claimGuid ) );
@@ -101,10 +97,9 @@ class ClaimGuidTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider provideClaimGuids
-	 *
 	 * @param ClaimGuid $claimGuid
 	 */
-	public function testNotEquals( $claimGuid ) {
+	public function testNotEquals( ClaimGuid $claimGuid ) {
 		$notEqualClaimGuid = new ClaimGuid( new ItemId( 'q9999' ), 'someguid' );
 		$this->assertFalse( $claimGuid->equals( $notEqualClaimGuid ) );
 		$this->assertFalse( $notEqualClaimGuid->equals( $claimGuid ) );

--- a/tests/unit/Claim/ClaimListAccessTest.php
+++ b/tests/unit/Claim/ClaimListAccessTest.php
@@ -62,9 +62,8 @@ class ClaimListAccessTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider claimTestProvider
-	 *
 	 * @param ClaimListAccess $list
-	 * @param array $claims
+	 * @param Claim[] $claims
 	 */
 	public function testAllOfTheStuff( ClaimListAccess $list, array $claims ) {
 		foreach ( $claims as $claim ) {

--- a/tests/unit/Claim/ClaimTest.php
+++ b/tests/unit/Claim/ClaimTest.php
@@ -60,7 +60,6 @@ class ClaimTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider constructorProvider
-	 *
 	 * @param Snak $mainSnak
 	 * @param Snaks|null $qualifiers
 	 */
@@ -183,7 +182,6 @@ class ClaimTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 *
 	 * @param Claim $claim
 	 */
 	public function testGetAllSnaks( Claim $claim ) {

--- a/tests/unit/Entity/Diff/EntityDiffTest.php
+++ b/tests/unit/Entity/Diff/EntityDiffTest.php
@@ -52,9 +52,8 @@ class EntityDiffTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider isEmptyProvider
-	 *
-	 * @param array $diffOps
-	 * @param boolean $isEmpty
+	 * @param Diff[] $diffOps
+	 * @param bool $isEmpty
 	 */
 	public function testIsEmpty( array $diffOps, $isEmpty ) {
 		$diff = new EntityDiff( $diffOps );

--- a/tests/unit/Entity/Diff/ItemDiffTest.php
+++ b/tests/unit/Entity/Diff/ItemDiffTest.php
@@ -251,9 +251,8 @@ class ItemDiffTest extends EntityDiffOldTest {
 
 	/**
 	 * @dataProvider isEmptyProvider
-	 *
-	 * @param array $diffOps
-	 * @param boolean $isEmpty
+	 * @param Diff[] $diffOps
+	 * @param bool $isEmpty
 	 */
 	public function testIsEmpty( array $diffOps, $isEmpty ) {
 		$diff = new ItemDiff( $diffOps );

--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -107,15 +107,15 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider descriptionProvider
 	 * @param string $languageCode
-	 * @param string $labelText
+	 * @param string $description
 	 * @param string $moarText
 	 */
-	public function testSetDescription( $languageCode, $labelText, $moarText = 'ohi there' ) {
+	public function testSetDescription( $languageCode, $description, $moarText = 'ohi there' ) {
 		$entity = $this->getNewEmpty();
 
-		$entity->setDescription( $languageCode, $labelText );
+		$entity->setDescription( $languageCode, $description );
 
-		$this->assertEquals( $labelText, $entity->getDescription( $languageCode ) );
+		$this->assertEquals( $description, $entity->getDescription( $languageCode ) );
 
 		$entity->setDescription( $languageCode, $moarText );
 
@@ -125,26 +125,26 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider descriptionProvider
 	 * @param string $languageCode
-	 * @param string $labelText
+	 * @param string $description
 	 */
-	public function testGetDescription( $languageCode, $labelText ) {
+	public function testGetDescription( $languageCode, $description ) {
 		$entity = $this->getNewEmpty();
 
 		$this->assertFalse( $entity->getDescription( $languageCode ) );
 
-		$entity->setDescription( $languageCode, $labelText );
+		$entity->setDescription( $languageCode, $description );
 
-		$this->assertEquals( $labelText, $entity->getDescription( $languageCode ) );
+		$this->assertEquals( $description, $entity->getDescription( $languageCode ) );
 	}
 
 	/**
 	 * @dataProvider descriptionProvider
 	 * @param string $languageCode
-	 * @param string $labelText
+	 * @param string $description
 	 */
-	public function testRemoveDescription( $languageCode, $labelText ) {
+	public function testRemoveDescription( $languageCode, $description ) {
 		$entity = $this->getNewEmpty();
-		$entity->setDescription( $languageCode, $labelText );
+		$entity->setDescription( $languageCode, $description );
 		$entity->removeDescription( $languageCode );
 		$this->assertFalse( $entity->getDescription( $languageCode ) );
 	}
@@ -372,7 +372,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 *
 	 * @param Entity $entity
 	 */
 	public function testCopy( Entity $entity ) {
@@ -399,7 +398,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 *
 	 * @param Entity $entity
 	 */
 	public function testSerialize( Entity $entity ) {
@@ -415,7 +413,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 *
 	 * @param Entity $entity
 	 */
 	public function testHasClaims( Entity $entity ) {
@@ -490,7 +487,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider diffProvider
-	 *
 	 * @param Entity $entity0
 	 * @param Entity $entity1
 	 * @param EntityDiff $expected
@@ -507,7 +503,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 *
 	 * @param Entity $entity
 	 */
 	public function testGetClaims( Entity $entity ) {
@@ -518,7 +513,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 *
 	 * @param Entity $entity
 	 */
 	public function testGetAllSnaks( Entity $entity ) {

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -79,7 +79,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 *
 	 * @param ReferenceList $array
 	 */
 	public function testHasReferenceBeforeRemoveButNotAfter( ReferenceList $array ) {
@@ -115,7 +114,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 *
 	 * @param ReferenceList $array
 	 */
 	public function testRemoveReference( ReferenceList $array ) {
@@ -213,7 +211,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 *
 	 * @param ReferenceList $array
 	 */
 	public function testIndexOf( ReferenceList $array ) {
@@ -227,7 +224,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 *
 	 * @param ReferenceList $array
 	 */
 	public function testEquals( ReferenceList $array ) {
@@ -237,7 +233,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 *
 	 * @param ReferenceList $array
 	 */
 	public function testGetHashReturnsString( ReferenceList $array ) {
@@ -246,7 +241,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 *
 	 * @param ReferenceList $array
 	 */
 	public function testGetHashValueIsTheSameForClone( ReferenceList $array ) {

--- a/tests/unit/ReferenceTest.php
+++ b/tests/unit/ReferenceTest.php
@@ -81,7 +81,6 @@ class ReferenceTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider snakListProvider
-	 *
 	 * @param Snaks $snaks
 	 */
 	public function testConstructor( Snaks $snaks ) {
@@ -257,7 +256,6 @@ class ReferenceTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider invalidConstructorArgumentsProvider
-	 * @param mixed $snaks
 	 * @expectedException InvalidArgumentException
 	 */
 	public function testGivenInvalidConstructorArguments_constructorThrowsException( $snaks ) {

--- a/tests/unit/Snak/SnakListTest.php
+++ b/tests/unit/Snak/SnakListTest.php
@@ -74,7 +74,6 @@ class SnakListTest extends HashArrayTest {
 
 	/**
 	 * @dataProvider invalidConstructorArgumentsProvider
-	 * @param mixed $input
 	 * @expectedException InvalidArgumentException
 	 */
 	public function testGivenInvalidConstructorArguments_constructorThrowsException( $input ) {


### PR DESCRIPTION
* Rename copy-pasted `$labelText` in description tests.
* Make existing docs more specific.
* Add some missing type hints.
* No empty line between `@dataProvider` and `@param`. Why? The params are what the provider provides, these two things are very strongly connected.
* No `@param` doc for "invalid" providers. Having docs that say `mixed` doesn't help. Some of the docs I'm removing in this patch were wrong.