### PR TITLE
Remove more Claims methods

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,6 +17,7 @@
 * Removed `Claims::getGuids`
 * Removed `Claims::equals` (and `Claims` no longer implements `Comparable`)
 * Removed `Claims::getHash` (and `Claims` no longer implements `Hashable`)
+* Removed `Claims::isEmpty` (you can use `StatementList::isEmpty` instead)
 
 ## Version 2.6.0 (2015-03-08)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,6 +16,7 @@
 * Removed `Claims::getHashes`
 * Removed `Claims::getGuids`
 * Removed `Claims::equals` (and `Claims` no longer implements `Comparable`)
+* Removed `Claims::getHash` (and `Claims` no longer implements `Hashable`)
 
 ## Version 2.6.0 (2015-03-08)
 

--- a/src/Claim/Claims.php
+++ b/src/Claim/Claims.php
@@ -22,7 +22,7 @@ use Wikibase\DataModel\Statement\Statement;
  * @author Daniel Kinzler
  * @author H. Snater < mediawiki@snater.com >
  */
-class Claims extends ArrayObject implements Hashable {
+class Claims extends ArrayObject {
 
 	/**
 	 * @see GenericArrayObject::__construct
@@ -277,26 +277,6 @@ class Claims extends ArrayObject implements Hashable {
 	public function offsetUnset( $guid ) {
 		$key = $this->getGuidKey( $guid );
 		parent::offsetUnset( $key );
-	}
-
-	/**
-	 * Returns a hash based on the value of the object.
-	 * The hash is based on the hashes of the claims contained,
-	 * with the order of claims considered significant.
-	 *
-	 * @since 0.5
-	 *
-	 * @return string
-	 */
-	public function getHash() {
-		$hash = sha1( '' );
-
-		/* @var Claim $claim */
-		foreach ( $this as $claim ) {
-			$hash = sha1( $hash . $claim->getHash() );
-		}
-
-		return $hash;
 	}
 
 	/**

--- a/src/Claim/Claims.php
+++ b/src/Claim/Claims.php
@@ -279,11 +279,4 @@ class Claims extends ArrayObject {
 		parent::offsetUnset( $key );
 	}
 
-	/**
-	 * @return bool
-	 */
-	public function isEmpty() {
-		return !$this->getIterator()->valid();
-	}
-
 }

--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -414,27 +414,6 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 		$this->assertNull( $list->getClaimWithGuid( $secondClaim->getGuid() ) );
 	}
 
-	public function testGetHash() {
-		$claimsA = new Claims();
-		$claimsB = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
-
-		$this->assertEquals( $claimsA->getHash(), $claimsB->getHash(), 'empty list' );
-
-		$claimsA->addClaim( $claim1 );
-		$claimsB->addClaim( $claim2 );
-		$this->assertNotEquals( $claimsA->getHash(), $claimsB->getHash(), 'different content' );
-
-		$claimsA->addClaim( $claim2 );
-		$claimsB->addClaim( $claim1 );
-		$this->assertNotEquals( $claimsA->getHash(), $claimsB->getHash(), 'different order' );
-
-		$claimsA->removeClaim( $claim1 );
-		$claimsB->removeClaim( $claim1 );
-		$this->assertEquals( $claimsA->getHash(), $claimsB->getHash(), 'same content' );
-	}
-
 	public function testIterator() {
 		$expected = array(
 			'TESTCLAIM1' => $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P42' ) ), 'testclaim1' ),

--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -428,17 +428,4 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	public function testIsEmpty() {
-		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-
-		$this->assertTrue( $claims->isEmpty() );
-
-		$claims->addClaim( $claim1 );
-		$this->assertFalse( $claims->isEmpty() );
-
-		$claims->removeClaim( $claim1 );
-		$this->assertTrue( $claims->isEmpty() );
-	}
-
 }


### PR DESCRIPTION
Part of #157

* Claims::getHash is not used by any of our code as far as I can tell
* Claims::isEmpty is used by DataModel Serialization though that can easily be changed. I started updating that component to DM 3.x in https://github.com/wmde/WikibaseDataModelSerialization/pull/115