### PR TITLE
Return null rather than false in StatementList::getIndexByGuid

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,7 +20,7 @@
 * Removed `Claims::equals` (and `Claims` no longer implements `Comparable`)
 * Removed `Claims::getHash` (and `Claims` no longer implements `Hashable`)
 * Removed `Claims::isEmpty` (you can use `StatementList::isEmpty` instead)
-* Removed `Claims::indexOf` (you can use `StatementList::getIndexByGuid` instead)
+* Removed `Claims::indexOf` (you can use `StatementList::getIndexByGuid` instead. caution: returns null instead of false)
 
 #### Additions
 

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -299,7 +299,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 			$index++;
 		}
 
-		return false;
+		return null;
 	}
 
 }

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -541,10 +541,10 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGivenNotPresentStatement_getIndexByGuidReturnsFalse() {
+	public function testGivenNotPresentStatement_getIndexByGuidReturnsNull() {
 		$statements = new StatementList();
 
-		$this->assertFalse( $statements->getIndexByGuid( $this->getStatement( 1, 'kittens' ) ) );
+		$this->assertNull( $statements->getIndexByGuid( $this->getStatement( 1, 'kittens' ) ) );
 	}
 
 	public function testGivenPresentStatement_getIndexByGuidReturnsItsIndex() {


### PR DESCRIPTION
We figured out a long time ago that it's better to return null than false.
Accidentally copied one of the remaining false usages over when reimplementing this.