### PR TITLE
Drop EntityId::getPrefixedId

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 * Removed `Claims::getHash` (and `Claims` no longer implements `Hashable`)
 * Removed `Claims::isEmpty` (you can use `StatementList::isEmpty` instead)
 * Removed `Claims::indexOf` (you can use `StatementList::getIndexByGuid` instead)
+* Removed `EntityId::getPrefixedId`, use `getSerialization` instead
 
 #### Additions
 

--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -27,17 +27,6 @@ abstract class EntityId implements \Comparable, \Serializable {
 	}
 
 	/**
-	 * Returns the id serialization.
-	 * @deprecated Use getSerialization instead.
-	 * (soft deprecation, this alias will stay until it is no longer used)
-	 *
-	 * @return string
-	 */
-	public function getPrefixedId() {
-		return $this->serialization;
-	}
-
-	/**
 	 * This is a human readable representation of the EntityId.
 	 * This format is allowed to change and should therefore not
 	 * be relied upon to be stable.

--- a/tests/unit/Entity/EntityIdTest.php
+++ b/tests/unit/Entity/EntityIdTest.php
@@ -81,11 +81,4 @@ class EntityIdTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInternalType( 'string', $id->__toString() );
 	}
 
-	/**
-	 * @dataProvider instanceProvider
-	 */
-	public function testGetPrefixedId( EntityId $id ) {
-		$this->assertEquals( $id->getSerialization(), $id->getPrefixedId() );
-	}
-
 }


### PR DESCRIPTION
The last remaining usage of this method (I could found in my local code base, please double check) is https://github.com/Wikidata-lib/PropertySuggester/pull/123.