### PR TITLE
Drop long deprecated Property::newEmpty

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -34,6 +34,7 @@ Other breaking changes:
 
 * Removed previously deprecated `Entity::getAllSnaks`, use `StatementList::getAllSnaks` instead
 * Removed previously deprecated `EntityId::getPrefixedId`, use `EntityId::getSerialization` instead
+* Removed previously deprecated `Property::newEmpty`, use `Property::newFromType` or `new Property()` instead
 * `Reference` and `ReferenceList`s no longer can not be instantiated with `null`
 * Added `setId` method to `EntityDocument`
 

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -177,15 +177,6 @@ class Property extends Entity implements StatementListProvider {
 	}
 
 	/**
-	 * @deprecated since 0.7.3. Use Property::newFromType
-	 *
-	 * @return Property
-	 */
-	public static function newEmpty() {
-		return self::newFromType( '' );
-	}
-
-	/**
 	 * @since 1.1
 	 *
 	 * @return StatementList


### PR DESCRIPTION
The last 2 remaining uses of this method I could find (in my local code base, please double check) are removed in:
* https://gerrit.wikimedia.org/r/#/c/201428/
* https://github.com/wmde/WikibaseQuery/pull/61