### PR TITLE
Un-deprecate Fingerprint convenience methods

### DIFF
--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -52,8 +52,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	/**
 	 * Sets the value for the label in a certain value.
 	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
-	 *
 	 * @param string $languageCode
 	 * @param string $value
 	 *
@@ -66,8 +64,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 
 	/**
 	 * Sets the value for the description in a certain value.
-	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
 	 *
 	 * @param string $languageCode
 	 * @param string $value
@@ -82,8 +78,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	/**
 	 * Removes the labels in the specified languages.
 	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
-	 *
 	 * @param string $languageCode
 	 */
 	public function removeLabel( $languageCode ) {
@@ -93,8 +87,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	/**
 	 * Removes the descriptions in the specified languages.
 	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
-	 *
 	 * @param string $languageCode
 	 */
 	public function removeDescription( $languageCode ) {
@@ -103,8 +95,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 
 	/**
 	 * Returns the aliases for the item in the language with the specified code.
-	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
 	 *
 	 * @param string $languageCode
 	 *
@@ -123,8 +113,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	/**
 	 * Returns all the aliases for the item.
 	 * The result is an array with language codes pointing to an array of aliases in the language they specify.
-	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
 	 *
 	 * @param string[]|null $languageCodes
 	 *
@@ -150,8 +138,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	/**
 	 * Sets the aliases for the item in the language with the specified code.
 	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
-	 *
 	 * @param string $languageCode
 	 * @param string[] $aliases
 	 */
@@ -161,8 +147,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 
 	/**
 	 * Add the provided aliases to the aliases list of the item in the language with the specified code.
-	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
 	 *
 	 * @param string $languageCode
 	 * @param string[] $aliases
@@ -180,8 +164,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	/**
 	 * Removed the provided aliases from the aliases list of the item in the language with the specified code.
 	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
-	 *
 	 * @param string $languageCode
 	 * @param string[] $aliases
 	 */
@@ -198,8 +180,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	/**
 	 * Returns the descriptions of the entity in the provided languages.
 	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
-	 *
 	 * @param string[]|null $languageCodes Note that an empty array gives
 	 * descriptions for no languages while a null pointer gives all
 	 *
@@ -211,8 +191,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 
 	/**
 	 * Returns the labels of the entity in the provided languages.
-	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
 	 *
 	 * @param string[]|null $languageCodes Note that an empty array gives
 	 * labels for no languages while a null pointer gives all
@@ -226,8 +204,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	/**
 	 * Returns the description of the entity in the language with the provided code,
 	 * or false in cases there is none in this language.
-	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
 	 *
 	 * @param string $languageCode
 	 *
@@ -244,8 +220,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	/**
 	 * Returns the label of the entity in the language with the provided code,
 	 * or false in cases there is none in this language.
-	 *
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
 	 *
 	 * @param string $languageCode
 	 *
@@ -288,7 +262,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 * language codes pointing to the label in that language.
 	 *
 	 * @since 0.4
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
 	 *
 	 * @param string[] $labels
 	 */
@@ -306,7 +279,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 * language codes pointing to the description in that language.
 	 *
 	 * @since 0.4
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
 	 *
 	 * @param string[] $descriptions
 	 */
@@ -325,7 +297,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 * in that language.
 	 *
 	 * @since 0.4
-	 * @deprecated since 0.7.3 - use getFingerprint and setFingerprint
 	 *
 	 * @param array[] $aliasLists
 	 */


### PR DESCRIPTION
These currently cause hundreds and hundreds of deprecation warnings across our code base, but we can't do anything about this. I suggest to remove these tags as long as [the discussion related to Fingerprint](https://phabricator.wikimedia.org/T87237) is not finished.

Bug: [T87237](https://phabricator.wikimedia.org/T87237)