### PR TITLE
Drop deprecated Entity::newClaim

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,7 @@
 	* Removed `ClaimList`
 	* Removed `ClaimListAccess`
 	* Removed `hasClaims` from all entity classes
+	* Removed `newClaim` from all entity classes
 * Removed `Claims::getBestClaims` (you can use `StatementList::getBestStatements` instead)
 * Removed `Claims::getByRank` and `Claims::getByRanks` (you can use `StatementList::getWithRank` instead)
 * Removed `Claims::getMainSnaks` (you can use `StatementList::getMainSnaks` instead)

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -372,18 +372,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	}
 
 	/**
-	 * @since 0.3
-	 * @deprecated since 1.0, use new Statement() instead.
-	 *
-	 * @param Snak $mainSnak
-	 *
-	 * @return Statement
-	 */
-	public function newClaim( Snak $mainSnak ) {
-		return new Statement( $mainSnak );
-	}
-
-	/**
 	 * Returns an EntityDiff between $this and the provided Entity.
 	 *
 	 * @since 0.1

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -200,17 +200,6 @@ class Item extends Entity implements StatementListProvider {
 	}
 
 	/**
-	 * @deprecated since 1.0, use new Statement() instead.
-	 *
-	 * @param Snak $mainSnak
-	 *
-	 * @return Statement
-	 */
-	public function newClaim( Snak $mainSnak ) {
-		return new Statement( $mainSnak );
-	}
-
-	/**
 	 * Returns if the Item has no content.
 	 * Having an id set does not count as having content.
 	 *

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -223,17 +223,6 @@ class Property extends Entity implements StatementListProvider {
 	}
 
 	/**
-	 * @deprecated since 1.0, use new Statement() instead.
-	 *
-	 * @param Snak $mainSnak
-	 *
-	 * @return Statement
-	 */
-	public function newClaim( Snak $mainSnak ) {
-		return new Statement( $mainSnak );
-	}
-
-	/**
 	 * @deprecated since 1.0, use getStatements()->addStatement() instead.
 	 *
 	 * @param Statement $statement

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -494,17 +494,6 @@ class ItemTest extends EntityTest {
 		$this->assertTrue( $item->getSiteLinkList()->hasLinkWithSiteId( 'foo bar' ) );
 	}
 
-	public function testNewClaimReturnsStatementWithProvidedMainSnak() {
-		/** @var Snak $snak */
-		$snak = $this->getMock( 'Wikibase\DataModel\Snak\Snak' );
-
-		$item = new Item();
-		$statement = $item->newClaim( $snak );
-
-		$this->assertInstanceOf( 'Wikibase\DataModel\Statement\Statement', $statement );
-		$this->assertEquals( $snak, $statement->getMainSnak() );
-	}
-
 	public function testSetClaims() {
 		$item = new Item();
 

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -232,16 +232,6 @@ class PropertyTest extends EntityTest {
 		$this->assertFalse( $property->isEmpty() );
 	}
 
-	public function testNewClaimReturnsStatementWithProvidedMainSnak() {
-		$snak = $this->getMock( 'Wikibase\DataModel\Snak\Snak' );
-
-		$property = Property::newFromType( 'string' );
-		$statement = $property->newClaim( $snak );
-
-		$this->assertInstanceOf( 'Wikibase\DataModel\Statement\Statement', $statement );
-		$this->assertEquals( $snak, $statement->getMainSnak() );
-	}
-
 	public function testSetClaims() {
 		$property = Property::newFromType( 'string' );
 


### PR DESCRIPTION
This method is already unused, as far as I can tell. I can not find any occurrence of the word `newClaim` in my local code base.