### PR TITLE
Drop deprecated Entity::hasClaims

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,6 +11,7 @@
 	* `Statement::setClaim` and `Statement::getClaim` have been removed
 	* Removed `ClaimList`
 	* Removed `ClaimListAccess`
+	* Removed `hasClaims` from all entity classes
 * Removed `Claims::getBestClaims` (you can use `StatementList::getBestStatements` instead)
 * Removed `Claims::getByRank` and `Claims::getByRanks` (you can use `StatementList::getWithRank` instead)
 * Removed `Claims::getMainSnaks` (you can use `StatementList::getMainSnaks` instead)

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -372,21 +372,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	}
 
 	/**
-	 * Convenience function to check if the entity contains any claims.
-	 *
-	 * On top of being a convenience function, this implementation allows for doing
-	 * the check without forcing an unstub in contrast to count( $this->getClaims() ).
-	 *
-	 * @since 0.2
-	 * @deprecated since 1.0, use getStatements()->isEmpty() instead.
-	 *
-	 * @return bool
-	 */
-	public function hasClaims() {
-		return false;
-	}
-
-	/**
 	 * @since 0.3
 	 * @deprecated since 1.0, use new Statement() instead.
 	 *

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -291,15 +291,6 @@ class Item extends Entity implements StatementListProvider {
 	}
 
 	/**
-	 * @deprecated since 1.0, use getStatements()->isEmpty() instead.
-	 *
-	 * @return bool
-	 */
-	public function hasClaims() {
-		return !$this->statements->isEmpty();
-	}
-
-	/**
 	 * @see Comparable::equals
 	 *
 	 * Two items are considered equal if they are of the same

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -224,15 +224,6 @@ class Property extends Entity implements StatementListProvider {
 	}
 
 	/**
-	 * @deprecated since 1.0, use getStatements()->isEmpty() instead.
-	 *
-	 * @return bool
-	 */
-	public function hasClaims() {
-		return !$this->statements->isEmpty();
-	}
-
-	/**
 	 * @deprecated since 1.0, use new Statement() instead.
 	 *
 	 * @param Snak $mainSnak

--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -403,17 +403,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( $entity->getId(), $instance->getId() );
 	}
 
-	/**
-	 * @dataProvider instanceProvider
-	 * @param Entity $entity
-	 */
-	public function testHasClaims( Entity $entity ) {
-		$has = $entity->hasClaims();
-		$this->assertInternalType( 'boolean', $has );
-
-		$this->assertEquals( count( $entity->getClaims() ) !== 0, $has );
-	}
-
 	public function diffProvider() {
 		$argLists = array();
 


### PR DESCRIPTION
This method is already unused, as far as I can tell. I can not find any occurrence of the word `hasClaims` in my local code base.