### PR TITLE
Drop deprecated entity::getAllSnaks

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 * Removed `Claims::getHash` (and `Claims` no longer implements `Hashable`)
 * Removed `Claims::isEmpty` (you can use `StatementList::isEmpty` instead)
 * Removed `Claims::indexOf` (you can use `StatementList::getIndexByGuid` instead)
+* Removed `Entity::getAllSnaks`, use `StatementList::getAllSnaks` instead
 * Removed `EntityId::getPrefixedId`, use `getSerialization` instead
 
 #### Additions

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -428,30 +428,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	}
 
 	/**
-	 * Returns a list of all Snaks on this Entity. This includes at least the main snaks of
-	 * Claims, the snaks from Claim qualifiers, and the snaks from Statement References.
-	 *
-	 * This is a convenience method for use in code that needs to operate on all snaks, e.g.
-	 * to find all referenced Entities.
-	 *
-	 * @since 0.5
-	 * @deprecated since 1.0 - use StatementList::getAllSnaks instead
-	 *
-	 * @return Snak[]
-	 */
-	public function getAllSnaks() {
-		$snaks = array();
-
-		foreach ( $this->getClaims() as $claim ) {
-			foreach( $claim->getAllSnaks() as $snak ) {
-				$snaks[] = $snak;
-			}
-		}
-
-		return $snaks;
-	}
-
-	/**
 	 * @since 0.7.3
 	 *
 	 * @return Fingerprint

--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -503,38 +503,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInternalType( 'array', $claims );
 	}
 
-	/**
-	 * @dataProvider instanceProvider
-	 * @param Entity $entity
-	 */
-	public function testGetAllSnaks( Entity $entity ) {
-		$snaks = $entity->getAllSnaks();
-		$claims = $entity->getClaims();
-
-		$this->assertInternalType( 'array', $snaks );
-
-		$this->assertGreaterThanOrEqual( count( $claims ), count( $snaks ), "At least one snak per Claim" );
-
-		foreach ( $claims as $claim ) {
-			$snak = $claim->getMainSnak();
-			$this->assertContains( $snak, $snaks, "main snak" );
-
-			$qualifiers = $claim->getQualifiers();
-
-			// check the first qualifier
-			foreach ( $qualifiers as $snak ) {
-				$this->assertContains( $snak, $snaks, "qualifier snak" );
-			}
-
-			// check the first reference
-			if ( $claim instanceof Statement ) {
-				foreach ( $claim->getAllSnaks() as $snak ) {
-					$this->assertContains( $snak, $snaks, "statement snak" );
-				}
-			}
-		}
-	}
-
 	public function testWhenNoStuffIsSet_getFingerprintReturnsEmptyFingerprint() {
 		$entity = $this->getNewEmpty();
 


### PR DESCRIPTION
This method is already unused, as far as I can see.