### PR TITLE
Replace Claim alias with Statement

### DIFF
--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -4,11 +4,11 @@ namespace Wikibase\DataModel\Entity;
 
 use InvalidArgumentException;
 use RuntimeException;
-use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Entity\Diff\EntityDiff;
 use Wikibase\DataModel\Entity\Diff\EntityDiffer;
 use Wikibase\DataModel\Entity\Diff\EntityPatcher;
 use Wikibase\DataModel\Snak\Snak;
+use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;
 use Wikibase\DataModel\Term\Fingerprint;
@@ -352,20 +352,20 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 * @since 0.3
 	 * @deprecated since 1.0, use getStatements()->addStatement() instead.
 	 *
-	 * @param Claim $claim
+	 * @param Statement $statement
 	 *
 	 * @throws InvalidArgumentException
 	 * @throws RuntimeException
 	 */
-	public function addClaim( Claim $claim ) {
-		throw new RuntimeException( 'Claims on entities are not supported any more.' );
+	public function addClaim( Statement $statement ) {
+		throw new RuntimeException( 'Statements on entities are not supported any more.' );
 	}
 
 	/**
 	 * @since 0.3
 	 * @deprecated since 1.0, use getStatements()->toArray() instead.
 	 *
-	 * @return Claim[]
+	 * @return Statement[]
 	 */
 	public function getClaims() {
 		return array();
@@ -392,10 +392,10 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 *
 	 * @param Snak $mainSnak
 	 *
-	 * @return Claim
+	 * @return Statement
 	 */
 	public function newClaim( Snak $mainSnak ) {
-		return new Claim( $mainSnak );
+		return new Statement( $mainSnak );
 	}
 
 	/**

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -4,7 +4,6 @@ namespace Wikibase\DataModel\Entity;
 
 use InvalidArgumentException;
 use OutOfBoundsException;
-use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\SiteLinkList;
@@ -240,14 +239,12 @@ class Item extends Entity implements StatementListProvider {
 	/**
 	 * @deprecated since 1.0, use getStatements()->addStatement() instead.
 	 *
-	 * @param Claim $statement This needs to be a Statement as of 1.0
+	 * @param Statement $statement
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function addClaim( Claim $statement ) {
-		if ( !( $statement instanceof Statement ) ) {
-			throw new InvalidArgumentException( '$statement must be an instance of Statement' );
-		} elseif ( $statement->getGuid() === null ) {
+	public function addClaim( Statement $statement ) {
+		if ( $statement->getGuid() === null ) {
 			throw new InvalidArgumentException( 'Can\'t add a Claim without a GUID.' );
 		}
 

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -3,7 +3,6 @@
 namespace Wikibase\DataModel\Entity;
 
 use InvalidArgumentException;
-use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Statement\Statement;
@@ -246,14 +245,12 @@ class Property extends Entity implements StatementListProvider {
 	/**
 	 * @deprecated since 1.0, use getStatements()->addStatement() instead.
 	 *
-	 * @param Claim $statement This needs to be a Statement as of 1.0
+	 * @param Statement $statement
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function addClaim( Claim $statement ) {
-		if ( !( $statement instanceof Statement ) ) {
-			throw new InvalidArgumentException( '$statement must be an instance of Statement' );
-		} elseif ( $statement->getGuid() === null ) {
+	public function addClaim( Statement $statement ) {
+		if ( $statement->getGuid() === null ) {
 			throw new InvalidArgumentException( 'Can\'t add a Claim without a GUID.' );
 		}
 


### PR DESCRIPTION
`Claim` is an alias for `Statement` now. Therefor this is a no-op change that does not change any semantics.