### PR TITLE
Drop obsolete Claim related test code

### DIFF
--- a/tests/unit/Entity/Diff/EntityDiffTest.php
+++ b/tests/unit/Entity/Diff/EntityDiffTest.php
@@ -119,8 +119,8 @@ class EntityDiffTest extends \PHPUnit_Framework_TestCase {
 		foreach ( $diff as $diffOp ) {
 			$this->assertTrue( $diffOp instanceof DiffOpAdd || $diffOp instanceof DiffOpRemove );
 
-			$claim = $diffOp instanceof DiffOpAdd ? $diffOp->getNewValue() : $diffOp->getOldValue();
-			$this->assertInstanceOf( 'Wikibase\DataModel\Claim\Claim', $claim );
+			$statement = $diffOp instanceof DiffOpAdd ? $diffOp->getNewValue() : $diffOp->getOldValue();
+			$this->assertInstanceOf( 'Wikibase\DataModel\Statement\Statement', $statement );
 		}
 	}
 

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -3,7 +3,6 @@
 namespace Wikibase\DataModel\Tests\Statement;
 
 use DataValues\StringValue;
-use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;

--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -3,7 +3,6 @@
 namespace Wikibase\DataModel\Tests\Statement;
 
 use DataValues\StringValue;
-use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\ReferenceList;
@@ -198,19 +197,6 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 	public function testSetInvalidRank( Statement $statement ) {
 		$this->setExpectedException( 'InvalidArgumentException' );
 		$statement->setRank( 9001 );
-	}
-
-	public function testStatementRankCompatibility() {
-		$this->assertEquals( Claim::RANK_DEPRECATED, Statement::RANK_DEPRECATED );
-		$this->assertEquals( Claim::RANK_PREFERRED, Statement::RANK_PREFERRED );
-		$this->assertEquals( Claim::RANK_NORMAL, Statement::RANK_NORMAL );
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 */
-	public function testIsClaim( Statement $statement ) {
-		$this->assertInstanceOf( 'Wikibase\DataModel\Claim\Claim', $statement );
 	}
 
 	/**


### PR DESCRIPTION
* `Claim` is an alias for `Statement` now, both refer to the exact same class anyway.
* The compatibility test now compares each constant with itself.
* `testIsClaim` was a test to make sure `Statement` is a subclass or implements `Claim`. Now it's the other way around, `Claim` is an alias of `Statement`. There could be a test for this, but it does not belong to `StatementTest`.