### PR TITLE
Drop deprecated Entity::addClaim

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,8 +11,7 @@
 	* `Statement::setClaim` and `Statement::getClaim` have been removed
 	* Removed `ClaimList`
 	* Removed `ClaimListAccess`
-	* Removed `hasClaims` from all entity classes
-	* Removed `newClaim` from all entity classes
+	* Removed `addClaim`, `hasClaims` and `newClaim` from all entity classes
 * Removed `Claims::getBestClaims` (you can use `StatementList::getBestStatements` instead)
 * Removed `Claims::getByRank` and `Claims::getByRanks` (you can use `StatementList::getWithRank` instead)
 * Removed `Claims::getMainSnaks` (you can use `StatementList::getMainSnaks` instead)

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -3,11 +3,9 @@
 namespace Wikibase\DataModel\Entity;
 
 use InvalidArgumentException;
-use RuntimeException;
 use Wikibase\DataModel\Entity\Diff\EntityDiff;
 use Wikibase\DataModel\Entity\Diff\EntityDiffer;
 use Wikibase\DataModel\Entity\Diff\EntityPatcher;
-use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;
@@ -346,19 +344,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 */
 	public function copy() {
 		return unserialize( serialize( $this ) );
-	}
-
-	/**
-	 * @since 0.3
-	 * @deprecated since 1.0, use getStatements()->addStatement() instead.
-	 *
-	 * @param Statement $statement
-	 *
-	 * @throws InvalidArgumentException
-	 * @throws RuntimeException
-	 */
-	public function addClaim( Statement $statement ) {
-		throw new RuntimeException( 'Statements on entities are not supported any more.' );
 	}
 
 	/**

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -7,7 +7,6 @@ use OutOfBoundsException;
 use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\SiteLinkList;
-use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 use Wikibase\DataModel\StatementListProvider;
@@ -223,21 +222,6 @@ class Item extends Entity implements StatementListProvider {
 		$this->fingerprint = new Fingerprint();
 		$this->siteLinks = new SiteLinkList();
 		$this->statements = new StatementList();
-	}
-
-	/**
-	 * @deprecated since 1.0, use getStatements()->addStatement() instead.
-	 *
-	 * @param Statement $statement
-	 *
-	 * @throws InvalidArgumentException
-	 */
-	public function addClaim( Statement $statement ) {
-		if ( $statement->getGuid() === null ) {
-			throw new InvalidArgumentException( 'Can\'t add a Claim without a GUID.' );
-		}
-
-		$this->statements->addStatement( $statement );
 	}
 
 	/**

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -4,7 +4,6 @@ namespace Wikibase\DataModel\Entity;
 
 use InvalidArgumentException;
 use Wikibase\DataModel\Claim\Claims;
-use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 use Wikibase\DataModel\StatementListProvider;
@@ -220,21 +219,6 @@ class Property extends Entity implements StatementListProvider {
 	 */
 	public function setClaims( Claims $claims ) {
 		$this->statements = new StatementList( iterator_to_array( $claims ) );
-	}
-
-	/**
-	 * @deprecated since 1.0, use getStatements()->addStatement() instead.
-	 *
-	 * @param Statement $statement
-	 *
-	 * @throws InvalidArgumentException
-	 */
-	public function addClaim( Statement $statement ) {
-		if ( $statement->getGuid() === null ) {
-			throw new InvalidArgumentException( 'Can\'t add a Claim without a GUID.' );
-		}
-
-		$this->statements->addStatement( $statement );
 	}
 
 }

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -15,7 +15,6 @@ use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
-use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 
@@ -549,7 +548,7 @@ class ItemTest extends EntityTest {
 		$this->assertFalse( $item->isEmpty() );
 
 		$item = new Item();
-		$item->addClaim( $this->newStatement() );
+		$item->getStatements()->addStatement( $this->newStatement() );
 		$this->assertFalse( $item->isEmpty() );
 	}
 
@@ -574,7 +573,7 @@ class ItemTest extends EntityTest {
 		$item = new Item( new ItemId( 'Q42' ) );
 		$item->getFingerprint()->setLabel( 'en', 'foo' );
 		$item->getSiteLinkList()->addNewSiteLink( 'enwiki', 'Foo' );
-		$item->addClaim( $this->newStatement() );
+		$item->getStatements()->addStatement( $this->newStatement() );
 
 		$item->clear();
 


### PR DESCRIPTION
This is part of #282. I prepared patches for the remaining usages of Entity::addClaim in the relevant components (mainly PropertySuggester and Wikibase.git).

Bug: [T78290](https://phabricator.wikimedia.org/T78290)