### PR TITLE
Drop index parameter from Claims::addClaim

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,7 @@
 	* Removed `ClaimList`
 	* Removed `ClaimListAccess`
 	* Removed `addClaim`, `hasClaims` and `newClaim` from all entity classes
+* `Claims::addClaim` no longer supports setting an index
 * Removed `Claims::getBestClaims` (you can use `StatementList::getBestStatements` instead)
 * Removed `Claims::getByRank` and `Claims::getByRanks` (you can use `StatementList::getWithRank` instead)
 * Removed `Claims::getMainSnaks` (you can use `StatementList::getMainSnaks` instead)

--- a/src/Claim/Claims.php
+++ b/src/Claim/Claims.php
@@ -7,10 +7,6 @@ use Comparable;
 use Hashable;
 use InvalidArgumentException;
 use Traversable;
-use Wikibase\DataModel\ByPropertyIdGrouper;
-use Wikibase\DataModel\Entity\PropertyId;
-use Wikibase\DataModel\Snak\Snak;
-use Wikibase\DataModel\Statement\Statement;
 
 /**
  * A claim (identified using it's GUID) can only be added once.
@@ -83,38 +79,15 @@ class Claims extends ArrayObject {
 	 * @since 0.1
 	 *
 	 * @param Claim $claim
-	 * @param int|null $index
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function addClaim( Claim $claim, $index = null ) {
-		if ( !is_null( $index ) && !is_integer( $index ) ) {
-			throw new InvalidArgumentException( '$index must be an integer or null; got ' . gettype( $index ) );
-		} elseif ( is_null( $index ) || $index >= count( $this ) ) {
-			$this[] = $claim;
-		} else {
-			$this->insertClaimAtIndex( $claim, $index );
-		}
-	}
-
-	/**
-	 * @param Claim $claim
-	 * @param int $index
-	 */
-	private function insertClaimAtIndex( Claim $claim, $index ) {
-		// Determine the claims to shift and remove them from the array:
-		$claimsToShift = array_slice( (array)$this, $index );
-
-		foreach ( $claimsToShift as $object ) {
-			$this->offsetUnset( $this->getClaimKey( $object ) );
+	public function addClaim( Claim $claim ) {
+		if ( func_num_args() > 1 ) {
+			throw new InvalidArgumentException( '$index is not supported any more' );
 		}
 
-		// Append the new claim and re-append the previously removed claims:
 		$this[] = $claim;
-
-		foreach ( $claimsToShift as $object ) {
-			$this[] = $object;
-		}
 	}
 
 	/**

--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -234,25 +234,19 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 		$this->assertNotNull( $claims->getClaimWithGuid( $claim1->getGuid() ) );
 		$this->assertNotNull( $claims->getClaimWithGuid( $claim2->getGuid() ) );
 
-		// Insert claim at the beginning:
-		$claim3 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P17' ) ) );
-		$claims->addClaim( $claim3, 0 );
-
-		// Insert claim at another index:
-		$claim4 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P18' ) ) );
-		$claims->addClaim( $claim4, 1 );
-
-		// Insert claim with an index out of bounds:
-		$claim5 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P19' ) ) );
-		$claims->addClaim( $claim5, 99999 );
-
 		$this->assertSame( array(
-			'TEST$CLAIM-3' => $claim3,
-			'TEST$CLAIM-4' => $claim4,
 			'TEST$CLAIM-1' => $claim1,
 			'TEST$CLAIM-2' => $claim2,
-			'TEST$CLAIM-5' => $claim5,
 		), $claims->getArrayCopy() );
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testAddClaimWithIndexFails() {
+		$claims = new Claims();
+		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
+		$claims->addClaim( $claim, 0 );
 	}
 
 	public function testAppend() {


### PR DESCRIPTION
As suggested in #157. This parameter is indeed not used in our code base. Adding an exception to make sure outdated code fails and does not silently do unexpected things.