### PR TITLE
Drop unused Claims::removeClaim

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 * Removed `Claims::getHash` (and `Claims` no longer implements `Hashable`)
 * Removed `Claims::isEmpty` (you can use `StatementList::isEmpty` instead)
 * Removed `Claims::indexOf` (you can use `StatementList::getIndexByGuid` instead)
+* Removed `Claims::removeClaim`
 * Removed `Entity::getAllSnaks`, use `StatementList::getAllSnaks` instead
 * Removed `EntityId::getPrefixedId`, use `EntityId::getSerialization` instead
 

--- a/src/Claim/Claims.php
+++ b/src/Claim/Claims.php
@@ -136,25 +136,6 @@ class Claims extends ArrayObject {
 	}
 
 	/**
-	 * @since 0.1
-	 *
-	 * @param Claim $claim
-	 */
-	public function removeClaim( Claim $claim ) {
-		$guid = $claim->getGuid();
-
-		if ( $guid === null ) {
-			return;
-		}
-
-		$key = $this->getGuidKey( $guid );
-
-		if ( $this->offsetExists( $key ) ) {
-			$this->offsetUnset( $key );
-		}
-	}
-
-	/**
 	 * @since 0.3
 	 *
 	 * @param string $claimGuid

--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -123,30 +123,6 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $claims->hasClaimWithGuid( $claim2->getGuid() ) );
 	}
 
-	public function testRemoveClaim() {
-		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
-
-		$claims->addClaim( $claim1 );
-		$claims->addClaim( $claim2 );
-		$this->assertSame( 2, $claims->count() );
-
-		$claims->removeClaim( $claim1 );
-		$this->assertFalse( $claims->hasClaim( $claim1 ) );
-		$this->assertNull( $claims->getClaimWithGuid( $claim1->getGuid() ) );
-		$this->assertSame( 1, $claims->count() );
-
-		$claims->removeClaim( $claim2 );
-		$this->assertFalse( $claims->hasClaim( $claim2 ) );
-		$this->assertNull( $claims->getClaimWithGuid( $claim2->getGuid() ) );
-		$this->assertSame( 0, $claims->count() );
-
-		// no guid
-		$claim0 = new Claim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claims->removeClaim( $claim0 );
-	}
-
 	public function testRemoveClaimWithGuid() {
 		$claims = new Claims();
 		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );


### PR DESCRIPTION
This is part of #157. This is already unused in our code base.