### PR TITLE
Add SnakList constructor

### DIFF
--- a/src/Snak/SnakList.php
+++ b/src/Snak/SnakList.php
@@ -2,6 +2,8 @@
 
 namespace Wikibase\DataModel\Snak;
 
+use InvalidArgumentException;
+use Traversable;
 use Wikibase\DataModel\HashArray;
 use Wikibase\DataModel\Internal\MapValueHasher;
 
@@ -16,6 +18,21 @@ use Wikibase\DataModel\Internal\MapValueHasher;
  * @author Addshore
  */
 class SnakList extends HashArray {
+
+	/**
+	 * @param Snak[]|Traversable $snaks
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function __construct( $snaks = [] ) {
+		if ( !is_array( $snaks ) && !( $snaks instanceof Traversable ) ) {
+			throw new InvalidArgumentException( '$snaks must be an array or an instance of Traversable' );
+		}
+
+		foreach ( $snaks as $index => $snak ) {
+			$this->setElement( $index, $snak );
+		}
+	}
 
 	/**
 	 * @see GenericArrayObject::getObjectType

--- a/tests/unit/HashArray/HashArrayTest.php
+++ b/tests/unit/HashArray/HashArrayTest.php
@@ -35,7 +35,7 @@ abstract class HashArrayTest extends \PHPUnit_Framework_TestCase {
 		$instances = [];
 
 		foreach ( $this->constructorProvider() as $args ) {
-			$instances[] = [ new $class( array_key_exists( 0, $args ) ? $args[0] : null ) ];
+			$instances[] = [ new $class( array_key_exists( 0, $args ) ? $args[0] : [] ) ];
 		}
 
 		return $instances;

--- a/tests/unit/Snak/SnakListTest.php
+++ b/tests/unit/Snak/SnakListTest.php
@@ -84,6 +84,7 @@ class SnakListTest extends HashArrayTest {
 		$id1 = new PropertyId( 'P1' );
 
 		return [
+			[ null ],
 			[ false ],
 			[ 1 ],
 			[ 0.1 ],


### PR DESCRIPTION
This introduces a constructor to the SnakList class that does not call the parent constructor. This is done on purpose to decrease the inheritance and possibly get rid of the `ArrayObject` dependency some day.

This also drops the possibility to call the constructor with null ~~and adds the possibility to call it with variable length arguments (as some similar constructors and add methods already do)~~.

This is split from #416.
