### PR TITLE
Do not allow null in Reference[List] constructors

### DIFF
--- a/src/Reference.php
+++ b/src/Reference.php
@@ -24,24 +24,21 @@ class Reference implements \Hashable, \Comparable, \Immutable, \Countable {
 	private $snaks;
 
 	/**
-	 * An array of Snak is only supported since version 1.1.
+	 * An array of Snak objects is only supported since version 1.1.
 	 *
-	 * @param Snaks|Snak[]|null $snaks
+	 * @param Snak[]|Snaks $snaks
 	 * @throws InvalidArgumentException
 	 */
-	public function __construct( $snaks = null ) {
-		if ( $snaks === null ) {
-			$this->snaks = new SnakList();
+	public function __construct( $snaks = array() ) {
+		if ( is_array( $snaks ) ) {
+			$snaks = new SnakList( $snaks );
 		}
-		elseif ( $snaks instanceof Snaks ) {
-			$this->snaks = $snaks;
+
+		if ( !( $snaks instanceof Snaks ) ) {
+			throw new InvalidArgumentException( '$snaks must be an array or an instance of Snaks' );
 		}
-		elseif ( is_array( $snaks ) ) {
-			$this->snaks = new SnakList( $snaks );
-		}
-		else {
-			throw new InvalidArgumentException( '$snaks must be an instance of Snaks, an array of instances of Snak, or null' );
-		}
+
+		$this->snaks = $snaks;
 	}
 
 	/**

--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -26,15 +26,11 @@ use Wikibase\DataModel\Snak\Snak;
 class ReferenceList extends HashableObjectStorage {
 
 	/**
-	 * @param Reference[]|Traversable|null $references
+	 * @param Reference[]|Traversable $references
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function __construct( $references = null ) {
-		if ( $references === null ) {
-			return;
-		}
-
+	public function __construct( $references = array() ) {
 		if ( !is_array( $references ) && !( $references instanceof Traversable ) ) {
 			throw new InvalidArgumentException( '$references must be an array or an instance of Traversable' );
 		}

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -43,7 +43,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	public function getConstructorArg() {
 		return array(
-			null,
 			array(),
 			$this->getElementInstances(),
 		);
@@ -61,7 +60,7 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 		$id1 = new PropertyId( 'P1' );
 
 		return array(
-			// TODO: Disallow array( null ),
+			array( null ),
 			array( false ),
 			array( 1 ),
 			array( 0.1 ),
@@ -95,7 +94,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 			$this->assertFalse( $array->hasReference( $hashable ) );
 		}
 	}
-
 
 	public function testGivenCloneOfReferenceInList_hasReferenceReturnsTrue() {
 		$list = new ReferenceList();

--- a/tests/unit/ReferenceTest.php
+++ b/tests/unit/ReferenceTest.php
@@ -258,6 +258,7 @@ class ReferenceTest extends \PHPUnit_Framework_TestCase {
 		$id1 = new PropertyId( 'P1' );
 
 		return array(
+			array( null ),
 			array( false ),
 			array( 1 ),
 			array( 0.1 ),


### PR DESCRIPTION
This is split from #416 but focuses on a single change: Calling the two constructors with `null` is not allowed any more.

Release notes will be updated later.