### PR TITLE
Add test to construct ReferenceList from ReferenceList

### DIFF
--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -48,6 +48,15 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructWithReferenceListObject() {
+		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
+		$original = new ReferenceList( array( $reference ) );
+		$copy = new ReferenceList( $original );
+
+		$this->assertSame( 1, $copy->count() );
+		$this->assertNotNull( $copy->getReference( $reference->getHash() ) );
+	}
+
 	/**
 	 * @dataProvider invalidConstructorArgumentsProvider
 	 * @expectedException InvalidArgumentException


### PR DESCRIPTION
I can not find a test that checks if a ReferenceList can be constructed from an other Traversable object.