### PR TITLE
Throw exception when adding empty reference

### DIFF
--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel;
 
 use Hashable;
 use InvalidArgumentException;
+use RuntimeException;
 use Traversable;
 use Wikibase\DataModel\Snak\Snak;
 
@@ -74,11 +75,15 @@ class ReferenceList extends HashableObjectStorage {
 	 *
 	 * @param Reference $reference
 	 * @param mixed $data Unused in the ReferenceList class.
+	 *
+	 * @throws RuntimeException
 	 */
 	public function attach( $reference, $data = null ) {
-		if ( !$reference->isEmpty() ) {
-			parent::attach( $reference, $data );
+		if ( $reference->isEmpty() ) {
+			throw new RuntimeException( 'Cannot attach empty reference' );
 		}
+
+		parent::attach( $reference, $data );
 	}
 
 	/**

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -35,7 +35,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	public function getElementInstances() {
 		return array(
-			new Reference(),
 			new Reference( array( new PropertyNoValueSnak( 2 ) ) ),
 			new Reference( array( new PropertyNoValueSnak( 3 ) ) ),
 		);
@@ -184,28 +183,24 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSameReferenceOrder( $expectedList, $references );
 	}
 
-	public function testGivenEmptyReference_addReferenceDoesNotAdd() {
+	public function testGivenEmptyReference_addReferenceThrowsException() {
 		$reference1 = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
 		$reference2 = new Reference( array( new PropertyNoValueSnak( 2 ) ) );
 		$emptyReference = new Reference( array() );
 
 		$references = new ReferenceList( array( $reference1, $reference2 ) );
+		$this->setExpectedException( 'RuntimeException' );
 		$references->addReference( $emptyReference );
-
-		$expectedList = new ReferenceList( array( $reference1, $reference2 ) );
-		$this->assertSameReferenceOrder( $expectedList, $references );
 	}
 
-	public function testGivenEmptyReferenceAndIndex_addReferenceDoesNotAdd() {
+	public function testGivenEmptyReferenceAndIndex_addReferenceThrowsException() {
 		$reference1 = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
 		$reference2 = new Reference( array( new PropertyNoValueSnak( 2 ) ) );
 		$emptyReference = new Reference( array() );
 
 		$references = new ReferenceList( array( $reference1, $reference2 ) );
+		$this->setExpectedException( 'RuntimeException' );
 		$references->addReference( $emptyReference, 0 );
-
-		$expectedList = new ReferenceList( array( $reference1, $reference2 ) );
-		$this->assertSameReferenceOrder( $expectedList, $references );
 	}
 
 	/**
@@ -341,8 +336,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	public function testSerializeRoundtrip() {
 		$references = new ReferenceList();
-
-		$references->addReference( new Reference() );
 
 		$references->addReference( new Reference( array(
 			new PropertyNoValueSnak( 2 ),


### PR DESCRIPTION
This reworks #399.

I just run into this problem when working on unrelated tests. I added a reference in a test and it was ignored without a hint what's going on. This is at least confusing and hides possible errors.