### PR TITLE
Not all Snaks implementations do have an isEmpty

### DIFF
--- a/src/Reference.php
+++ b/src/Reference.php
@@ -70,6 +70,7 @@ class Reference implements \Hashable, \Comparable, \Immutable, \Countable {
 	 * @return bool
 	 */
 	public function isEmpty() {
+		// FIXME: Not all implementations of Snaks are guaranteed to have an isEmpty method.
 		return $this->snaks->isEmpty();
 	}
 


### PR DESCRIPTION
This is currently not a problem because we do have a single class implementing the Snaks interface.

A simple workaround is to use `count()`, but I remember this caused big trouble somewhere else and we avoided it on purpose.