### PR TITLE
Fix minor code smell issues

### DIFF
--- a/src/Claim/Claims.php
+++ b/src/Claim/Claims.php
@@ -3,8 +3,6 @@
 namespace Wikibase\DataModel\Claim;
 
 use ArrayObject;
-use Comparable;
-use Hashable;
 use InvalidArgumentException;
 use Traversable;
 

--- a/src/Entity/Diff/PropertyDiffer.php
+++ b/src/Entity/Diff/PropertyDiffer.php
@@ -95,6 +95,7 @@ class PropertyDiffer implements EntityDifferStrategy {
 	public function getConstructionDiff( EntityDocument $entity ) {
 		$this->assertIsProperty( $entity );
 
+		/** @var Property $entity */
 		$diffOps = $this->diffPropertyArrays( array(), $this->toDiffArray( $entity ) );
 		$diffOps['claim'] = $this->statementListDiffer->getDiff( new StatementList(), $entity->getStatements() );
 
@@ -110,6 +111,7 @@ class PropertyDiffer implements EntityDifferStrategy {
 	public function getDestructionDiff( EntityDocument $entity ) {
 		$this->assertIsProperty( $entity );
 
+		/** @var Property $entity */
 		$diffOps = $this->diffPropertyArrays( $this->toDiffArray( $entity ), array() );
 		$diffOps['claim'] = $this->statementListDiffer->getDiff( $entity->getStatements(), new StatementList() );
 

--- a/src/Statement/StatementByGuidMap.php
+++ b/src/Statement/StatementByGuidMap.php
@@ -38,6 +38,7 @@ class StatementByGuidMap implements IteratorAggregate, Countable {
 	 * If the provided statement has a GUID not yet in the map, it will be appended to the map.
 	 * If the GUID is already in the map, the statement with this guid will be replaced.
 	 *
+	 * @throws InvalidArgumentException
 	 * @param Statement $statement
 	 */
 	public function addStatement( Statement $statement ) {

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -287,7 +287,8 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	 *
 	 * @param string|null $statementGuid
 	 *
-	 * @return int|bool
+	 * @throws InvalidArgumentException
+	 * @return int|bool Zero-based index or false if not found.
 	 */
 	public function getIndexByGuid( $statementGuid ) {
 		if ( !is_string( $statementGuid ) && !is_null( $statementGuid ) ) {

--- a/tests/unit/Entity/Diff/ItemDiffTest.php
+++ b/tests/unit/Entity/Diff/ItemDiffTest.php
@@ -204,16 +204,13 @@ class ItemDiffTest extends EntityDiffOldTest {
 		/**
 		 * @var Item $a
 		 * @var Item $b
+		 * @var SiteLink[] $siteLinks
 		 */
-
 		$siteLinks = array_merge(
-			$a->getSiteLinks(),
-			$b->getSiteLinks()
+			$a->getSiteLinkList()->toArray(),
+			$b->getSiteLinkList()->toArray()
 		);
 
-		/**
-		 * @var SiteLink $siteLink
-		 */
 		foreach ( $siteLinks as $siteLink ) {
 			$aLink = $a->getSiteLinkList()->getBySiteId( $siteLink->getSiteId() );
 			$bLink = $a->getSiteLinkList()->getBySiteId( $siteLink->getSiteId() );

--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -8,7 +8,6 @@ use Diff\DiffOp\DiffOpRemove;
 use Wikibase\DataModel\Entity\Diff\EntityDiff;
 use Wikibase\DataModel\Entity\Entity;
 use Wikibase\DataModel\Entity\Item;
-use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;
 use Wikibase\DataModel\Term\Fingerprint;

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -2,7 +2,6 @@
 
 namespace Wikibase\DataModel\Tests\Entity;
 
-use DataValues\StringValue;
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpChange;


### PR DESCRIPTION
This patch fixes a bunch of minor code smell issues, most reported by and found with PHPStorm.
* Remove unused use clauses.
* Add missing throws tags.