### PR TITLE
[RFC] Drop getClaims/setClaims from all Entity classes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,7 +11,7 @@
 	* `Statement::setClaim` and `Statement::getClaim` have been removed
 	* Removed `ClaimList`
 	* Removed `ClaimListAccess`
-	* Removed `addClaim`, `hasClaims` and `newClaim` from all entity classes
+	* Removed `addClaim`, `getClaims`, `hasClaims`, `newClaim` and `setClaims` from all entity classes
 * `Claims::addClaim` no longer supports setting an index
 * Removed `Claims::getBestClaims` (you can use `StatementList::getBestStatements` instead)
 * Removed `Claims::getByRank` and `Claims::getByRanks` (you can use `StatementList::getWithRank` instead)

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -6,7 +6,6 @@ use InvalidArgumentException;
 use Wikibase\DataModel\Entity\Diff\EntityDiff;
 use Wikibase\DataModel\Entity\Diff\EntityDiffer;
 use Wikibase\DataModel\Entity\Diff\EntityPatcher;
-use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;
 use Wikibase\DataModel\Term\Fingerprint;
@@ -344,16 +343,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 */
 	public function copy() {
 		return unserialize( serialize( $this ) );
-	}
-
-	/**
-	 * @since 0.3
-	 * @deprecated since 1.0, use getStatements()->toArray() instead.
-	 *
-	 * @return Statement[]
-	 */
-	public function getClaims() {
-		return array();
 	}
 
 	/**

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -4,10 +4,8 @@ namespace Wikibase\DataModel\Entity;
 
 use InvalidArgumentException;
 use OutOfBoundsException;
-use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\SiteLinkList;
-use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 use Wikibase\DataModel\StatementListProvider;
 use Wikibase\DataModel\Term\Fingerprint;
@@ -240,24 +238,6 @@ class Item extends Entity implements StatementListProvider {
 	 */
 	public function setStatements( StatementList $statements ) {
 		$this->statements = $statements;
-	}
-
-	/**
-	 * @deprecated since 1.0, use getStatements()->toArray() instead.
-	 *
-	 * @return Statement[]
-	 */
-	public function getClaims() {
-		return $this->statements->toArray();
-	}
-
-	/**
-	 * @deprecated since 1.0, use setStatements instead
-	 *
-	 * @param Claims $claims
-	 */
-	public function setClaims( Claims $claims ) {
-		$this->statements = new StatementList( iterator_to_array( $claims ) );
 	}
 
 	/**

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -3,8 +3,6 @@
 namespace Wikibase\DataModel\Entity;
 
 use InvalidArgumentException;
-use Wikibase\DataModel\Claim\Claims;
-use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 use Wikibase\DataModel\StatementListProvider;
 use Wikibase\DataModel\Term\Fingerprint;
@@ -201,24 +199,6 @@ class Property extends Entity implements StatementListProvider {
 	 */
 	public function setStatements( StatementList $statements ) {
 		$this->statements = $statements;
-	}
-
-	/**
-	 * @deprecated since 1.0, use getStatements()->toArray() instead.
-	 *
-	 * @return Statement[]
-	 */
-	public function getClaims() {
-		return $this->statements->toArray();
-	}
-
-	/**
-	 * @deprecated since 1.0, use setStatements instead
-	 *
-	 * @param Claims $claims
-	 */
-	public function setClaims( Claims $claims ) {
-		$this->statements = new StatementList( iterator_to_array( $claims ) );
 	}
 
 }

--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -481,16 +481,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 		// (simple serialize does not work, since the order is not relevant, and not only on the top level)
 	}
 
-	/**
-	 * @dataProvider instanceProvider
-	 * @param Entity $entity
-	 */
-	public function testGetClaims( Entity $entity ) {
-		$claims = $entity->getClaims();
-
-		$this->assertInternalType( 'array', $claims );
-	}
-
 	public function testWhenNoStuffIsSet_getFingerprintReturnsEmptyFingerprint() {
 		$entity = $this->getNewEmpty();
 

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -492,25 +492,6 @@ class ItemTest extends EntityTest {
 		$this->assertTrue( $item->getSiteLinkList()->hasLinkWithSiteId( 'foo bar' ) );
 	}
 
-	public function testSetClaims() {
-		$item = new Item();
-
-		$statement0 = new Statement( new PropertyNoValueSnak( 42 ) );
-		$statement0->setGuid( 'TEST$NVS42' );
-
-		$statement1 = new Statement( new PropertySomeValueSnak( 42 ) );
-		$statement1->setGuid( 'TEST$SVS42' );
-
-		$statements = array( $statement0, $statement1 );
-
-		$item->setClaims( new Claims( $statements ) );
-		$this->assertEquals( count( $statements ), $item->getStatements()->count(), "added some statements" );
-
-		$item->setClaims( new Claims() );
-		$this->assertTrue( $item->getStatements()->isEmpty(), "should be empty again" );
-	}
-
-
 	public function testEmptyItemReturnsEmptySiteLinkList() {
 		$item = new Item();
 		$this->assertTrue( $item->getSiteLinkList()->isEmpty() );

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -232,22 +232,4 @@ class PropertyTest extends EntityTest {
 		$this->assertFalse( $property->isEmpty() );
 	}
 
-	public function testSetClaims() {
-		$property = Property::newFromType( 'string' );
-
-		$statement0 = new Statement( new PropertyNoValueSnak( 42 ) );
-		$statement0->setGuid( 'TEST$NVS42' );
-
-		$statement1 = new Statement( new PropertySomeValueSnak( 42 ) );
-		$statement1->setGuid( 'TEST$SVS42' );
-
-		$statements = array( $statement0, $statement1 );
-
-		$property->setClaims( new Claims( $statements ) );
-		$this->assertEquals( count( $statements ), $property->getStatements()->count(), "added some statements" );
-
-		$property->setClaims( new Claims() );
-		$this->assertTrue( $property->getStatements()->isEmpty(), "should be empty again" );
-	}
-
 }


### PR DESCRIPTION
`getClaims` is the last remaining method in `Entity` that refers to claim(s).

This patch removes **all** claim methods from **all** Entity classes. I'm not sure if this is a good idea. This will cause a lot of work in Wikibase.git. Are we sure we want to do that?

[Bug: T78290](https://phabricator.wikimedia.org/T78290) | Issue #282