### PR TITLE
Catch exception for invalid EntityId in GUID parser

### DIFF
--- a/src/Claim/ClaimGuidParser.php
+++ b/src/Claim/ClaimGuidParser.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel\Claim;
 
 use Wikibase\DataModel\Entity\DispatchingEntityIdParser;
 use Wikibase\DataModel\Entity\EntityIdParser;
+use Wikibase\DataModel\Entity\EntityIdParsingException;
 
 /**
  * @since 0.5
@@ -41,7 +42,12 @@ class ClaimGuidParser {
 			throw new ClaimGuidParsingException( '$serialization does not have the correct number of parts' );
 		}
 
-		return new ClaimGuid( $this->entityIdParser->parse( $keyParts[0] ), $keyParts[1] );
+		try {
+			return new ClaimGuid( $this->entityIdParser->parse( $keyParts[0] ), $keyParts[1] );
+		}
+		catch( EntityIdParsingException $exception ) {
+			throw new ClaimGuidParsingException( '$serialization contains invalid EntityId: ' . $exception->getMessage() );
+		}
 	}
 
 }

--- a/tests/unit/Claim/ClaimGuidParserTest.php
+++ b/tests/unit/Claim/ClaimGuidParserTest.php
@@ -56,6 +56,7 @@ class ClaimGuidParserTest extends \PHPUnit_Framework_TestCase {
 			array( '' ),
 			array( 'q0' ),
 			array( '1p' ),
+			array( 'Q0$5627445f-43cb-ed6d-3adb-760e85bd17ee' ),
 		);
 	}
 


### PR DESCRIPTION
As in PHPdoc the ClaimGuidParser::parse method
should return ClaimGuidParsingExceptions

This catchs previously uncaught EntityIdParsingExceptions

This relates to https://phabricator.wikimedia.org/T89100