### PR TITLE
Replace StatementList::getIndexByGuid with getFirstStatementByGuid

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,7 +23,7 @@
 * Removed `Claims::getHash` (and `Claims` no longer implements `Hashable`)
 * Removed `Claims::hasClaim`
 * Removed `Claims::isEmpty` (you can use `StatementList::isEmpty` instead)
-* Removed `Claims::indexOf` (you can use `StatementList::getIndexByGuid` instead)
+* Removed `Claims::indexOf`, use `StatementList::getFirstStatementByGuid` or `StatementByGuidMap` instead
 * Removed `Claims::removeClaim`
 * Removed `Entity::getAllSnaks`, use `StatementList::getAllSnaks` instead
 * Removed `EntityId::getPrefixedId`, use `EntityId::getSerialization` instead
@@ -32,7 +32,7 @@
 #### Additions
 
 * Added `StatementByGuidMap`
-* Added `StatementList::getIndexByGuid`
+* Added `StatementList::getFirstStatementByGuid`
 * `ReferenceList::addNewReference` and `Statement::addNewReference` support an array of Snaks now
 
 ## Version 2.6.0 (2015-03-08)

--- a/src/Claim/Claims.php
+++ b/src/Claim/Claims.php
@@ -92,7 +92,7 @@ class Claims extends ArrayObject {
 
 	/**
 	 * @since 0.3
-	 * @deprecated since 1.0, use StatementList::getIndexByGuid() instead.
+	 * @deprecated since 1.0, use StatementList::getFirstStatementByGuid() instead.
 	 *
 	 * @param string $claimGuid
 	 *
@@ -116,7 +116,7 @@ class Claims extends ArrayObject {
 
 	/**
 	 * @since 0.3
-	 * @deprecated since 1.0, use StatementList::getIndexByGuid() instead.
+	 * @deprecated since 1.0, use StatementList::getFirstStatementByGuid() instead.
 	 *
 	 * @param string $claimGuid
 	 *

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -285,27 +285,20 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 
 	/**
 	 * @since 3.0
+	 * @see StatementByGuidMap
 	 *
 	 * @param string|null $statementGuid
 	 *
-	 * @throws InvalidArgumentException
-	 * @return int|bool Zero-based index or false if not found.
+	 * @return Statement|null The first statement with the given GUID or null if not found.
 	 */
-	public function getIndexByGuid( $statementGuid ) {
-		if ( !is_string( $statementGuid ) && $statementGuid !== null ) {
-			throw new InvalidArgumentException( '$statementGuid needs to be string or null' );
-		}
-
-		$index = 0;
-
-		foreach ( $this->statements as $s ) {
-			if ( $s->getGuid() === $statementGuid ) {
-				return $index;
+	public function getFirstStatementByGuid( $statementGuid ) {
+		foreach ( $this->statements as $statement ) {
+			if ( $statement->getGuid() === $statementGuid ) {
+				return $statement;
 			}
-			$index++;
 		}
 
-		return false;
+		return null;
 	}
 
 }

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -567,57 +567,46 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGivenNotPresentStatement_getIndexByGuidReturnsFalse() {
+	public function testGivenNotPresentStatement_getFirstStatementByGuidReturnsNull() {
 		$statements = new StatementList();
 
-		$this->assertFalse( $statements->getIndexByGuid( 'kittens' ) );
+		$this->assertNull( $statements->getFirstStatementByGuid( 'kittens' ) );
 	}
 
-	public function testGivenPresentStatement_getIndexByGuidReturnsItsIndex() {
-		$statements = new StatementList( array(
-			$this->getStatement( 43, 'kittens43' ),
-			$this->getStatement( 42, 'kittens42' ),
-			$this->getStatement( 41, 'kittens41' ),
-		) );
+	public function testGivenPresentStatement_getFirstStatementByGuidReturnsStatement() {
+		$statement1 = $this->getStatement( 1, 'guid1' );
+		$statement2 = $this->getStatement( 2, 'guid2' );
+		$statement3 = $this->getStatement( 3, 'guid3' );
+		$statements = new StatementList( $statement1, $statement2, $statement3 );
 
-		$this->assertSame(
-			1,
-			$statements->getIndexByGuid( 'kittens42' )
-		);
+		$actual = $statements->getFirstStatementByGuid( 'guid2' );
+		$this->assertSame( $statement2, $actual );
 	}
 
-	public function testGivenDoublyPresentStatement_getIndexByGuidReturnsTheFirstIndex() {
-		$statements = new StatementList( array(
-			$this->getStatement( 43, 'kittens43' ),
-			$this->getStatement( 42, 'kittens42' ),
-			$this->getStatement( 41, 'kittens41' ),
-			$this->getStatement( 42, 'kittens42' ),
-		) );
+	public function testGivenDoublyPresentStatement_getFirstStatementByGuidReturnsFirstMatch() {
+		$statement1 = $this->getStatement( 1, 'guid1' );
+		$statement2 = $this->getStatement( 2, 'guid2' );
+		$statement3 = $this->getStatement( 3, 'guid3' );
+		$statement4 = $this->getStatement( 2, 'guid2' );
+		$statements = new StatementList( $statement1, $statement2, $statement3, $statement4 );
 
-		$this->assertSame(
-			1,
-			$statements->getIndexByGuid( 'kittens42' )
-		);
+		$actual = $statements->getFirstStatementByGuid( 'guid2' );
+		$this->assertSame( $statement2, $actual );
 	}
 
-	public function testGivenDifferentStatementWithSameGuid_getIndexByGuidReturnsItsIndex() {
-		$statements = new StatementList( array(
-			$this->getStatement( 1, 'kittens43' ),
-			$this->getStatement( 2, 'kittens42' ),
-			$this->getStatement( 3, 'kittens41' ),
-		) );
+	public function testGivenStatementsWithNoGuid_getFirstStatementByGuidReturnsFirstMatch() {
+		$statement1 = $this->getStatement( 1, null );
+		$statement2 = $this->getStatement( 2, null );
+		$statements = new StatementList( $statement1, $statement2 );
 
-		$this->assertSame(
-			2,
-			$statements->getIndexByGuid( 'kittens41' )
-		);
+		$actual = $statements->getFirstStatementByGuid( null );
+		$this->assertSame( $statement1, $actual );
 	}
 
-	public function testGivenInvalidGuid_getIndexByGuidThrowsException() {
+	public function testGivenInvalidGuid_getFirstStatementByGuidReturnsNull() {
 		$statements = new StatementList();
 
-		$this->setExpectedException( 'InvalidArgumentException' );
-		$statements->getIndexByGuid( false );
+		$this->assertNull( $statements->getFirstStatementByGuid( false ) );
 	}
 
 }


### PR DESCRIPTION
This reverts #414 and #434.

Yes, we need a convenient method to get a Statement by GUID from a StatementList (or an array of Statements if multiple Statements do not have a GUID or do have the same GUID, which is currently possible).

But: a method that returns an integer index is not very useful. StatementList is not an ArrayObject and does not have a getter that accepts an integer index. The only way to make use of the index is via `toArray`, a guarantee that may change (see the discussion in #446) and is odd and dangerous.

```php
$array = $list->toArray();
$index = $list->getIndexByGuid( $guid );
$statement = $array[$index];
```

Such code looks suspicious to me. The two calls are unconnected. I'm accessing an array with an index returned by an other method? Are the two methods guaranteed to use the same indexes in the same order? I can't really tell without looking at the implementations of the two methods.

Instead I suggest to have a `getStatementsByGuid` method that returns an array.

TODO: Tests.