### PR TITLE
[RFC] StatementList internally indexed by GUID

### DIFF
--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -54,7 +54,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 				throw new InvalidArgumentException( 'Every element in $statements must be an instance of Statement' );
 			}
 
-			$this->statements[] = $statement;
+			$this->addStatement( $statement );
 		}
 	}
 
@@ -87,7 +87,13 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	public function addStatement( Statement $statement ) {
-		$this->statements[] = $statement;
+		if ( $statement->getGuid() !== null
+			&& !array_key_exists( $statement->getGuid(), $this->statements )
+		) {
+			$this->statements[$statement->getGuid()] = $statement;
+		} else {
+			$this->statements[] = $statement;
+		}
 	}
 
 	/**
@@ -226,7 +232,8 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	/**
-	 * @return Statement[] Numerically indexed (non-sparse) array.
+	 * @return Statement[] Array indexed by GUID (numerically indexed for statements that do not
+	 * have a GUID). Use array_values befor passing this to a for loop.
 	 */
 	public function toArray() {
 		return $this->statements;

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -48,7 +48,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$statement = $this->getStatement( 1, 'guid' );
 		$list = new StatementList( array( 'ignore-me' => $statement ) );
 
-		$this->assertSame( array( 0 => $statement ), $list->toArray() );
+		$this->assertSame( array( 'guid' => $statement ), $list->toArray() );
 	}
 
 	/**
@@ -91,25 +91,22 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 			$this->getStatement( 1, 'one', Statement::RANK_PREFERRED ),
 			$this->getStatement( 1, 'two', Statement::RANK_NORMAL ),
 			$this->getStatement( 1, 'three', Statement::RANK_PREFERRED ),
-
 			$this->getStatement( 2, 'four', Statement::RANK_DEPRECATED ),
-
 			$this->getStatement( 3, 'five', Statement::RANK_DEPRECATED ),
 			$this->getStatement( 3, 'six', Statement::RANK_NORMAL ),
-
 			$this->getStatement( 4, 'seven', Statement::RANK_PREFERRED )
 		);
 
+		$expected = array(
+			$this->getStatement( 1, 'one', Statement::RANK_PREFERRED ),
+			$this->getStatement( 1, 'three', Statement::RANK_PREFERRED ),
+			$this->getStatement( 3, 'six', Statement::RANK_NORMAL ),
+			$this->getStatement( 4, 'seven', Statement::RANK_PREFERRED ),
+		);
+
 		$this->assertEquals(
-			array(
-				$this->getStatement( 1, 'one', Statement::RANK_PREFERRED ),
-				$this->getStatement( 1, 'three', Statement::RANK_PREFERRED ),
-
-				$this->getStatement( 3, 'six', Statement::RANK_NORMAL ),
-
-				$this->getStatement( 4, 'seven', Statement::RANK_PREFERRED ),
-			),
-			$list->getBestStatementPerProperty()->toArray()
+			$expected,
+			array_values( $list->getBestStatementPerProperty()->toArray() )
 		);
 	}
 


### PR DESCRIPTION
See the discussion in #446.

TODO: Tests.
* Add two statements with no GUID. Check if the indexes are `0` and `1`.
* Add two statements with the **same** GUID. Check if the indexes are the GUID for the first and `0` for the second statement.
* Maybe it's better to index the **last** statement with the same GUID by it's GUID? Clarify the contract of the relevant methods accordingly.
* Add a test that mixes statements with conflicting and without GUIDs.
* Add a test that **changes** the GUID of a statement after it was added to the list. The index can not change and will desync.