### PR TITLE
Add `setStatements` to `StatementListProvider`

### DIFF
--- a/src/StatementListProvider.php
+++ b/src/StatementListProvider.php
@@ -7,7 +7,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * Interface for classes that contain a StatementList.
  *
- * @since 2.2.0
+ * @since 2.2.0, modified in 3.0
  *
  * @license GNU GPL v2+
  * @author Marius Hoch < hoo@online.de >
@@ -20,6 +20,7 @@ interface StatementListProvider {
 	public function getStatements();
 
 	/**
+	 * @since 3.0
 	 * @param StatementList $statements
 	 */
 	public function setStatements( StatementList $statements );

--- a/src/StatementListProvider.php
+++ b/src/StatementListProvider.php
@@ -19,4 +19,9 @@ interface StatementListProvider {
 	 */
 	public function getStatements();
 
+	/**
+	 * @param StatementList $statements
+	 */
+	public function setStatements( StatementList $statements );
+
 }


### PR DESCRIPTION
This method is required since there is no other way to remove or rebuild the list of statements of a `StatementListProvider` without knowing it is an `Item` or `Property` instance.

*Edit:* For an alternative proposal, see #470