### PR TITLE
[RFC] Drop IteratorAggregate from StatementList

### DIFF
--- a/src/Statement/BestStatementsFinder.php
+++ b/src/Statement/BestStatementsFinder.php
@@ -29,10 +29,6 @@ class BestStatementsFinder {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $statements ) {
-		if ( !( $statements instanceof StatementList ) ) {
-			$statements = new StatementList( $statements );
-		}
-
 		$this->byPropertyIdGrouper = new ByPropertyIdGrouper( $statements );
 	}
 

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -27,7 +27,7 @@ use Wikibase\DataModel\Snak\Snaks;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class StatementList implements IteratorAggregate, Comparable, Countable {
+class StatementList implements Comparable, Countable {
 
 	/**
 	 * @var Statement[]
@@ -66,7 +66,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	 * @return self
 	 */
 	public function getBestStatementPerProperty() {
-		$bestStatementsFinder = new BestStatementsFinder( $this );
+		$bestStatementsFinder = new BestStatementsFinder( $this->toArray() );
 		return new self( $bestStatementsFinder->getBestStatementsPerProperty() );
 	}
 
@@ -216,13 +216,6 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 		}
 
 		return $snaks;
-	}
-
-	/**
-	 * @return Traversable
-	 */
-	public function getIterator() {
-		return new ArrayIterator( $this->statements );
 	}
 
 	/**

--- a/src/Statement/StatementListDiffer.php
+++ b/src/Statement/StatementListDiffer.php
@@ -46,10 +46,7 @@ class StatementListDiffer {
 	private function toDiffArray( StatementList $statementList ) {
 		$statementArray = array();
 
-		/**
-		 * @var Statement $statement
-		 */
-		foreach ( $statementList as $statement ) {
+		foreach ( $statementList->toArray() as $statement ) {
 			$statementArray[$statement->getGuid()] = $statement;
 		}
 

--- a/src/Statement/StatementListPatcher.php
+++ b/src/Statement/StatementListPatcher.php
@@ -40,10 +40,7 @@ class StatementListPatcher {
 	public function getPatchedStatementList( StatementList $statements, Diff $patch ) {
 		$statementsByGuid = array();
 
-		/**
-		 * @var Statement $statement
-		 */
-		foreach ( $statements as $statement ) {
+		foreach ( $statements->toArray() as $statement ) {
 			$statementsByGuid[$statement->getGuid()] = $statement;
 		}
 

--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -57,10 +57,9 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 		$statement1 = $this->makeStatement( new PropertyNoValueSnak( 1 ) );
 		$statement2 = $this->makeStatement( new PropertyNoValueSnak( 2 ) );
 
-		$statementList = new StatementList();
-		$statementList->addStatement( $statement1 );
+		$list = new \ArrayObject( array( $statement1 ) );
 
-		$claims = new Claims( $statementList );
+		$claims = new Claims( $list );
 		// According to the documentation append() "cannot be called when the ArrayObject was
 		// constructed from an object." This test makes sure it was not constructed from an object.
 		$claims->append( $statement2 );


### PR DESCRIPTION
As discussed in https://gerrit.wikimedia.org/r/#/c/204511/5/repo/includes/ChangeOp/ChangeOpClaim.php.

If having an iterable StatementList is not useful and we are calling `toArray` anyway, why have the class iterable in the first place? This will save us a lot of `/* @var Statement $statement */`.