### PR TITLE
Alter guarantees provided by StatementList::toArray

### DIFF
--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -226,7 +226,10 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	/**
-	 * @return Statement[] Numerically indexed (non-sparse) array.
+	 * Returns the wrapped array of statements. This retrieval operation is cheap.
+	 * No guarantees are given about the keys of the returned array.
+	 *
+	 * @return Statement[]
 	 */
 	public function toArray() {
 		return $this->statements;


### PR DESCRIPTION
The idea of this method always has been that it is cheap and can be used to construct different statement collections or to get type hint support in loops

```php
foreach ( $statementList->toArray() as $statement ) { /* ... */ }
```

This means we cannot guarantee a non-spare array if we want to be able to add cheap removal methods (ie `removeStatement`).