### PR TITLE
Revert "Alter guarantees provided by StatementList::toArray"

### DIFF
--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -237,10 +237,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	/**
-	 * Returns the wrapped array of statements. This retrieval operation is cheap.
-	 * No guarantees are given about the keys of the returned array.
-	 *
-	 * @return Statement[]
+	 * @return Statement[] Numerically indexed (non-sparse) array.
 	 */
 	public function toArray() {
 		return $this->statements;

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -115,6 +115,8 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 				unset( $this->statements[$index] );
 			}
 		}
+
+		$this->statements = array_values( $this->statements );
 	}
 
 	/**

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -268,11 +268,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$list = new StatementList( array( $statement1, $statement2, $statement3 ) );
 		$list->removeStatementsWithGuid( 'foo' );
 
-		$statements = array();
-		$statements[1] = $statement2;
-		$statements[2] = $statement3;
-
-		$this->assertEquals( $statements, $list->toArray() );
+		$this->assertEquals( new StatementList( $statement2, $statement3 ), $list );
 	}
 
 	public function testGivenGuidOfMultipleStatements_multipleStatementsAreRemoved() {
@@ -283,10 +279,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$list = new StatementList( array( $statement1, $statement2, $statement3 ) );
 		$list->removeStatementsWithGuid( 'bar' );
 
-		$this->assertEquals(
-			new StatementList( array( $statement1 ) ),
-			$list
-		);
+		$this->assertEquals( new StatementList( $statement1 ), $list );
 	}
 
 	public function testGivenNotPresentGuid_listIsNotModified() {
@@ -297,10 +290,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$list = new StatementList( array( $statement1, $statement2, $statement3 ) );
 		$list->removeStatementsWithGuid( 'baz' );
 
-		$this->assertEquals(
-			new StatementList( array( $statement1, $statement2, $statement3 ) ),
-			$list
-		);
+		$this->assertEquals( new StatementList( $statement1, $statement2, $statement3 ), $list );
 	}
 
 	public function testGivenNullGuid_allStatementsWithNoGuidAreRemoved() {
@@ -311,10 +301,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$list = new StatementList( array( $statement1, $statement2, $statement3 ) );
 		$list->removeStatementsWithGuid( null );
 
-		$this->assertEquals(
-			new StatementList( array( $statement1 ) ),
-			$list
-		);
+		$this->assertEquals( new StatementList( $statement1 ), $list );
 	}
 
 	public function testCanConstructWithClaimsObjectContainingOnlyStatements() {


### PR DESCRIPTION
Reverts #459. I don't understand why #459 was commited and merged without referencing the not finished discussion in #446.