### PR TITLE
Add removeStatementsByGuid and hasStatementWithGuid 	to StatementList

### DIFF
--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -25,6 +25,7 @@ use Wikibase\DataModel\Snak\SnakList;
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Bene* < benestar.wikimedia@gmail.com >
  */
 class StatementList implements IteratorAggregate, Comparable, Countable {
 
@@ -103,6 +104,39 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 		$statement->setGuid( $guid );
 
 		$this->addStatement( $statement );
+	}
+
+	/**
+	 * @param string $guid
+	 * @return Statement[]
+	 */
+	public function removeStatementsByGuid( $guid ) {
+		$removedStatements = array();
+
+		foreach ( $this->statements as $index => $statement ) {
+			if ( $statement->getGuid() === $guid ) {
+				$removedStatements[] = $statement;
+				unset( $this->statements[$index] );
+			}
+		}
+
+		$this->statements = array_values( $this->statements );
+
+		return $removedStatements;
+	}
+
+	/**
+	 * @param string $guid
+	 * @return bool
+	 */
+	public function hasStatementWithGuid( $guid ) {
+		foreach ( $this->statements as $statement ) {
+			if ( $statement->getGuid() === $guid ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -260,6 +260,45 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( new StatementList( $statement ), $list );
 	}
 
+	public function testRemoveStatementsByGuid() {
+		$statement1 = new Statement( $this->newSnak( 24, 'foo' ), null, null, 'foo' );
+		$statement2 = new Statement( $this->newSnak( 32, 'bar' ), null, null, 'bar' );
+		$statement3 = new Statement( $this->newSnak( 32, 'bar' ), null, null, 'bar' );
+
+		$list = new StatementList( array( $statement1, $statement2, $statement3 ) );
+
+		$result = $list->removeStatementsByGuid( 'foo' );
+
+		$this->assertEquals(
+			new StatementList( array( $statement2, $statement3 ) ),
+			$list
+		);
+		$this->assertEquals( array( $statement1 ), $result );
+
+		$result = $list->removeStatementsByGuid( 'baz' );
+
+		$this->assertEquals(
+			new StatementList( array( $statement2, $statement3 ) ),
+			$list
+		);
+		$this->assertEquals( array(), $result );
+
+		$result = $list->removeStatementsByGuid( 'bar' );
+
+		$this->assertTrue( $list->isEmpty() );
+		$this->assertEquals( array( $statement2, $statement3 ), $result );
+	}
+
+	public function testHasStatementWithGuid() {
+		$statement1 = new Statement( $this->newSnak( 24, 'foo' ), null, null, 'foo' );
+		$statement2 = new Statement( $this->newSnak( 32, 'bar' ), null, null, 'bar' );
+
+		$list = new StatementList( array( $statement1 ) );
+
+		$this->assertTrue( $list->hasStatementWithGuid( 'foo' ) );
+		$this->assertFalse( $list->hasStatementWithGuid( 'bar' ) );
+	}
+
 	public function testCanConstructWithClaimsObjectContainingOnlyStatements() {
 		$statementArray = array(
 			$this->getStatementWithSnak( 1, 'foo' ),


### PR DESCRIPTION
This is another option to make `StatementList` objects mutable. See #455 #446 #459 and #469 for reference.