### PR TITLE
New methods to add and remove aliases from an AliasGroupList

### DIFF
--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -199,6 +199,39 @@ class AliasGroupList implements Countable, IteratorAggregate {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param string $languageCode
+	 * @param string[] $aliases
+	 */
+	public function addAliasesForLanguage( $languageCode, array $aliases ) {
+		if ( !$this->hasGroupForLanguage( $languageCode ) ) {
+			$this->setAliasesForLanguage( $languageCode, $aliases );
+		}
+		else {
+			$this->setAliasesForLanguage( $languageCode, array_merge(
+				$this->getByLanguage( $languageCode )->getAliases(),
+				$aliases
+			) );
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $languageCode
+	 * @param string[] $aliases
+	 */
+	public function removeAliasesForLanguage( $languageCode, array $aliases ) {
+		if ( $this->hasGroupForLanguage( $languageCode ) ) {
+			$this->setAliasesForLanguage( $languageCode, array_diff(
+				$this->getByLanguage( $languageCode )->getAliases(),
+				$aliases
+			) );
+		}
+	}
+
+	/**
 	 * Returns an array with language codes as keys the aliases as array values.
 	 *
 	 * @since 2.5

--- a/tests/unit/Term/AliasGroupListTest.php
+++ b/tests/unit/Term/AliasGroupListTest.php
@@ -323,6 +323,94 @@ class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
 		$list->setAliasesForLanguage( 'en', array( 'foo', null ) );
 	}
 
+	public function testGivenAliasGroupArgs_addAliasesForLanguageAddsAliasesToEmptyGroupList() {
+		$list = new AliasGroupList();
+
+		$list->addAliasesForLanguage( 'en', array( 'foo', 'bar' ) );
+
+		$this->assertEquals(
+			new AliasGroup( 'en', array( 'foo', 'bar' ) ),
+			$list->getByLanguage( 'en' )
+		);
+	}
+
+	public function testGivenEmptyAliasGroupArgs_addAliasesForLanguageAddsAliasesToNonEmptyGroupList() {
+		$list = new AliasGroupList();
+		$list->setAliasesForLanguage( 'en', array( 'foo', 'bar' ) );
+
+		$list->addAliasesForLanguage( 'en', array( 'baz' ) );
+
+		$this->assertEquals(
+			new AliasGroup( 'en', array( 'foo', 'bar', 'baz' ) ),
+			$list->getByLanguage( 'en' )
+		);
+	}
+
+	public function testGivenNonEmptyAliasGroupArgs_addAliasesForLanguageDoesNotAddDulicateAliases() {
+		$list = new AliasGroupList();
+		$list->setAliasesForLanguage( 'en', array( 'foo', 'bar' ) );
+
+		$list->addAliasesForLanguage( 'en', array( 'baz', 'foo', 'bar' ) );
+
+		$this->assertEquals(
+			new AliasGroup( 'en', array( 'foo', 'bar', 'baz' ) ),
+			$list->getByLanguage( 'en' )
+		);
+	}
+
+	public function testGivenInvalidLanguageCode_addAliasesForLanguageThrowsException() {
+		$list = new AliasGroupList();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$list->addAliasesForLanguage( null, array( 'foo', 'bar' ) );
+	}
+
+	public function testGivenInvalidAliases_addAliasesForLanguageThrowsException() {
+		$list = new AliasGroupList();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$list->addAliasesForLanguage( 'en', array( 'foo', null ) );
+	}
+
+	public function testGivenNonEmptyAliasGroupArgs_removeAliasesForLanguageRemovesAliases() {
+		$list = new AliasGroupList();
+		$list->setAliasesForLanguage( 'en', array( 'foo', 'bar', 'baz' ) );
+
+		$list->removeAliasesForLanguage( 'en', array( 'foo', 'bar' ) );
+
+		$this->assertEquals(
+			new AliasGroup( 'en', array( 'baz' ) ),
+			$list->getByLanguage( 'en' )
+		);
+	}
+
+	public function testGivenNonEmptyAliasGroupArgs_removeAliasesForLanguageIgnoresNotExistingAliases() {
+		$list = new AliasGroupList();
+		$list->setAliasesForLanguage( 'en', array( 'foo', 'bar' ) );
+
+		$list->removeAliasesForLanguage( 'en', array( 'bar', 'baz' ) );
+
+		$this->assertEquals(
+			new AliasGroup( 'en', array( 'foo' ) ),
+			$list->getByLanguage( 'en' )
+		);
+	}
+
+	public function testGivenNonEmptyAliasGroupArgs_removeAliasesForLanguageIgnoresNotExistingLanguage() {
+		$list = new AliasGroupList();
+
+		$list->removeAliasesForLanguage( 'en', array( 'foo', 'bar' ) );
+
+		$this->assertFalse( $list->hasGroupForLanguage( 'en' ) );
+	}
+
+	public function testGivenInvalidLanguageCode_removeAliasesForLanguageThrowsException() {
+		$list = new AliasGroupList();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$list->removeAliasesForLanguage( null, array( 'foo', 'bar' ) );
+	}
+
 	public function testToArray() {
 		$array = array(
 			'en' => new AliasGroup( 'en', array( 'foo' ) ),


### PR DESCRIPTION
These methods should act as a replacement for `Entity::addAliases` and `Entity::removeAliases` as those methods are deprecated and there exists no simple replacement yet.