### PR TITLE
Drop support for numeric ids in EntityDocument::setId and add proper typehinting

### DIFF
--- a/src/Entity/EntityDocument.php
+++ b/src/Entity/EntityDocument.php
@@ -38,8 +38,10 @@ interface EntityDocument {
 	 *
 	 * @since 3.0
 	 *
+	 * @param EntityId|null $id
+	 *
 	 * @throws InvalidArgumentException if the id is not of the correct type.
 	 */
-	public function setId( $id );
+	public function setId( EntityId $id = null );
 
 }

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -56,24 +56,19 @@ class Item extends Entity implements StatementListProvider {
 	}
 
 	/**
-	 * Can be integer since 0.1.
 	 * Can be ItemId since 0.5.
 	 * Can be null since 1.0.
 	 *
-	 * @param ItemId|int|null $id
+	 * @param ItemId|null $id
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function setId( $id ) {
-		if ( $id === null || $id instanceof ItemId ) {
-			$this->id = $id;
+	public function setId( EntityId $id = null ) {
+		if ( !( $id instanceof ItemId ) && $id !== null ) {
+			throw new InvalidArgumentException( '$id must be an instance of ItemId or null' );
 		}
-		elseif ( is_integer( $id ) ) {
-			$this->id = ItemId::newFromNumber( $id );
-		}
-		else {
-			throw new InvalidArgumentException( '$id must be an instance of ItemId, an integer, or null' );
-		}
+
+		$this->id = $id;
 	}
 
 	/**

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -53,24 +53,19 @@ class Property extends Entity implements StatementListProvider {
 	}
 
 	/**
-	 * Can be integer since 0.1.
 	 * Can be PropertyId since 0.5.
 	 * Can be null since 1.0.
 	 *
-	 * @param PropertyId|int|null $id
+	 * @param PropertyId|null $id
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function setId( $id ) {
-		if ( $id === null || $id instanceof PropertyId ) {
-			$this->id = $id;
+	public function setId( EntityId $id = null ) {
+		if ( !( $id instanceof PropertyId ) && $id !== null ) {
+			throw new InvalidArgumentException( '$id must be an instance of PropertyId or null' );
 		}
-		elseif ( is_integer( $id ) ) {
-			$this->id = PropertyId::newFromNumber( $id );
-		}
-		else {
-			throw new InvalidArgumentException( '$id must be an instance of PropertyId, an integer, or null' );
-		}
+
+		$this->id = $id;
 	}
 
 	/**

--- a/tests/fixtures/EntityOfUnknownType.php
+++ b/tests/fixtures/EntityOfUnknownType.php
@@ -3,6 +3,7 @@
 namespace Wikibase\DataModel\Fixtures;
 
 use Wikibase\DataModel\Entity\EntityDocument;
+use Wikibase\DataModel\Entity\EntityId;
 
 /**
  * @licence GNU GPL v2+
@@ -18,7 +19,7 @@ class EntityOfUnknownType implements EntityDocument {
 		return 'unknown-entity-type';
 	}
 
-	public function setId( $id ) {
+	public function setId( EntityId $id = null ) {
 	}
 
 }

--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -34,6 +34,14 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 	 */
 	protected abstract function getNewEmpty();
 
+	/**
+	 * @since 3.0
+	 *
+	 * @param int $numericId
+	 * @return EntityId
+	 */
+	protected abstract function getNewId( $numericId );
+
 	public function labelProvider() {
 		return array(
 			array( 'en', 'spam' ),
@@ -334,7 +342,7 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 
 		// ID only
 		$entity = clone $entity;
-		$entity->setId( 44 );
+		$entity->setId( $this->getNewId( 44 ) );
 
 		$entities[] = $entity;
 
@@ -348,7 +356,7 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 
 		// with labels etc and ID
 		$entity = clone $entity;
-		$entity->setId( 42 );
+		$entity->setId( $this->getNewId( 42 ) );
 
 		$entities[] = $entity;
 

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -49,17 +49,22 @@ class ItemTest extends EntityTest {
 		return new Item();
 	}
 
+	/**
+	 * @see EntityTest::getNewId
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $numericId
+	 * @return ItemId
+	 */
+	protected function getNewId( $numericId ) {
+		return new ItemId( 'Q' . $numericId );
+	}
+
 	public function testGetId() {
 		foreach ( TestItems::getItems() as $item ) {
 			$id = $item->getId();
 			$this->assertTrue( $id === null || $id instanceof ItemId );
-		}
-	}
-
-	public function testSetIdUsingNumber() {
-		foreach ( TestItems::getItems() as $item ) {
-			$item->setId( 42 );
-			$this->assertEquals( new ItemId( 'Q42' ), $item->getId() );
 		}
 	}
 
@@ -627,10 +632,10 @@ class ItemTest extends EntityTest {
 		$secondItem->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
 
 		$secondItemWithId = unserialize( serialize( $secondItem ) );
-		$secondItemWithId->setId( 42 );
+		$secondItemWithId->setId( new ItemId( 'Q42' ) );
 
 		$differentId = unserialize( serialize( $secondItemWithId ) );
-		$differentId->setId( 43 );
+		$differentId->setId( new ItemId( 'Q43' ) );
 
 		return array(
 			array( new Item(), new Item() ),

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -37,6 +37,18 @@ class PropertyTest extends EntityTest {
 		return Property::newFromType( 'string' );
 	}
 
+	/**
+	 * @see EntityTest::getNewId
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $numericId
+	 * @return PropertyId
+	 */
+	protected function getNewId( $numericId ) {
+		return new PropertyId( 'P' . $numericId );
+	}
+
 	public function testConstructorWithAllParameters() {
 		$property = new Property(
 			new PropertyId( 'P42' ),
@@ -82,13 +94,6 @@ class PropertyTest extends EntityTest {
 		}
 	}
 
-	public function testWhenIdSetWithNumber_GetIdReturnsPropertyId() {
-		$property = Property::newFromType( 'string' );
-		$property->setId( 42 );
-
-		$this->assertHasCorrectIdType( $property );
-	}
-
 	protected function assertHasCorrectIdType( Property $property ) {
 		$this->assertInstanceOf( 'Wikibase\DataModel\Entity\PropertyId', $property->getId() );
 	}
@@ -106,7 +111,7 @@ class PropertyTest extends EntityTest {
 
 	public function testPropertyWithIdIsEmpty() {
 		$property = Property::newFromType( 'string' );
-		$property->setId( 1337 );
+		$property->setId( new PropertyId( 'P1337' ) );
 		$this->assertTrue( $property->isEmpty() );
 	}
 
@@ -119,7 +124,7 @@ class PropertyTest extends EntityTest {
 	public function testClearRemovesAllButId() {
 		$property = Property::newFromType( 'string' );
 
-		$property->setId( 42 );
+		$property->setId( new PropertyId( 'P42' ) );
 		$property->getFingerprint()->setLabel( 'en', 'foo' );
 
 		$property->clear();
@@ -159,10 +164,10 @@ class PropertyTest extends EntityTest {
 		$secondProperty->setStatements( $this->newNonEmptyStatementList() );
 
 		$secondPropertyWithId = unserialize( serialize( $secondProperty ) );
-		$secondPropertyWithId->setId( 42 );
+		$secondPropertyWithId->setId( new PropertyId( 'P42' ) );
 
 		$differentId = unserialize( serialize( $secondPropertyWithId ) );
-		$differentId->setId( 43 );
+		$differentId->setId( new PropertyId( 'P43' ) );
 
 		return array(
 			array( Property::newFromType( 'string' ), Property::newFromType( 'string' ) ),
@@ -183,7 +188,7 @@ class PropertyTest extends EntityTest {
 	private function getBaseProperty() {
 		$property = Property::newFromType( 'string' );
 
-		$property->setId( 42 );
+		$property->setId( new PropertyId( 'P42' ) );
 		$property->getFingerprint()->setLabel( 'en', 'Same' );
 		$property->getFingerprint()->setDescription( 'en', 'Same' );
 		$property->getFingerprint()->setAliasGroup( 'en', array( 'Same' ) );


### PR DESCRIPTION
Only `EntityId` objects are accepted in `EntityDocment::setId` per its documentation. This patch introduces proper typehinting in `EntityDocument` which also assures that programming wise. It also drops support for numeric ids (which was only used in tests).

Tracked in https://phabricator.wikimedia.org/T98343