### PR TITLE
Add setStatements to StatementList

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,6 +44,7 @@ Other breaking changes:
 * Added `StatementByGuidMap`
 * Added `StatementList::getFirstStatementWithGuid`
 * Added `StatementList::removeStatementsWithGuid`
+* Added `StatementList::setStatements`
 * `ReferenceList::addNewReference` and `Statement::addNewReference` support an array of Snaks now
 * Added PHPMD support
 

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -49,6 +49,8 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	/**
+	 * @since 3.0
+	 * 
 	 * @param Statement[]|Traversable
 	 *
 	 * @throws InvalidArgumentException

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -45,10 +45,20 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 			$statements = func_get_args();
 		}
 
+		$this->setStatements( $statements );
+	}
+
+	/**
+	 * @param Statement[]|Traversable
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function setStatements( $statements ) {
 		if ( !is_array( $statements ) && !( $statements instanceof Traversable ) ) {
 			throw new InvalidArgumentException( '$statements must be an array or an instance of Traversable' );
 		}
 
+		$this->statements = array();
 		foreach ( $statements as $statement ) {
 			if ( !( $statement instanceof Statement ) ) {
 				throw new InvalidArgumentException( 'Every element in $statements must be an instance of Statement' );

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -666,4 +666,40 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertNull( $statements->getFirstStatementWithGuid( false ) );
 	}
 
+	public function testGivenEmptyStatementList_setStatementsFillsIt() {
+		$statement1 = $this->getStatement( 1, 'guid1' );
+		$statement2 = $this->getStatement( 2, 'guid2' );
+		$statement3 = $this->getStatement( 3, 'guid3' );
+		$statement4 = $this->getStatement( 2, 'guid5' );
+		$statements = new StatementList();
+
+		$statements->setStatements( array( $statement1, $statement2, $statement3, $statement4 ) );
+		$this->assertEquals(
+			new StatementList( $statement1, $statement2, $statement3, $statement4 ),
+			$statements
+		);
+	}
+
+	public function testGivenFilledStatementList_setStatementsOverridesIt() {
+		$statement1 = $this->getStatement( 1, 'guid1' );
+		$statement2 = $this->getStatement( 2, 'guid2' );
+		$statement3 = $this->getStatement( 3, 'guid3' );
+		$statement4 = $this->getStatement( 2, 'guid5' );
+		$statements = new StatementList( $statement1, $statement2, $statement3, $statement4 );
+
+		$statements->setStatements( array( $statement1, $statement4 ) );
+		$this->assertEquals(
+			new StatementList( $statement1, $statement4 ),
+			$statements
+		);
+	}
+
+	public function testGivenNoTraversable_setStatementsThrowsException() {
+		$statement1 = $this->getStatement( 1, 'guid1' );
+		$statements = new StatementList();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$statements->setStatements( $statement1 );
+	}
+
 }


### PR DESCRIPTION
As @thiemowmde [has pointed out correctly](https://phabricator.wikimedia.org/T98143#anchor-1265330), `StatementList::removeStatementsWithGuid` alone does not suffice all our needs. We also want to have a method to set a whole list of statements to the `StatementList`.

This patch just takes code from the constructor and makes it a publicly available method, so that everyone dealing with a `StatementList` no has full access and can also set the whole list. This is especially useful for classes like `ByPropertyIdGrouper` or (proposed) `ByPropertyIdMap` which return a list of statements that can be passed to this method directly.