### PR TITLE
Move StatementListProvider into the Statement namespace

### DIFF
--- a/Aliases.php
+++ b/Aliases.php
@@ -29,3 +29,12 @@ namespace Wikibase\DataModel\Claim {
 	class ClaimGuidParsingException extends \Wikibase\DataModel\Statement\StatementGuidParsingException {}
 
 }
+
+namespace Wikibase\DataModel {
+
+	/**
+	 * @deprecated since 3.0.0, use the base class instead.
+	 */
+	class StatementListProvider extends \Wikibase\DataModel\Statement\StatementListProvider {}
+
+}

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -53,6 +53,7 @@ Other breaking changes:
 * Renamed `Claim\ClaimGuid` to `Statement\StatementGuid`, leaving a b/c alias in place
 * Renamed `Claim\ClaimGuidParser` to `Statement\StatementGuidParser`, leaving a b/c alias in place
 * Renamed `Claim\ClaimGuidParsingException` to `Statement\StatementGuidParsingException`, leaving a b/c alias in place
+* Renamed `StatementListProvider` to `Statement\StatementListProvider`, leaving a b/c alias in place
 
 ## Version 2.6.1 (2015-04-25)
 

--- a/WikibaseDataModel.php
+++ b/WikibaseDataModel.php
@@ -25,3 +25,4 @@ class_alias( 'Wikibase\DataModel\Statement\Statement', 'Wikibase\DataModel\Claim
 class_alias( 'Wikibase\DataModel\Statement\StatementGuid', 'Wikibase\DataModel\Claim\ClaimGuid' );
 class_alias( 'Wikibase\DataModel\Statement\StatementGuidParser', 'Wikibase\DataModel\Claim\ClaimGuidParser' );
 class_alias( 'Wikibase\DataModel\Statement\StatementGuidParsingException', 'Wikibase\DataModel\Claim\ClaimGuidParsingException' );
+class_alias( 'Wikibase\DataModel\Statement\StatementListProvider', 'Wikibase\DataModel\StatementListProvider' );

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\SiteLinkList;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
-use Wikibase\DataModel\StatementListProvider;
+use Wikibase\DataModel\Statement\StatementListProvider;
 use Wikibase\DataModel\Term\Fingerprint;
 
 /**

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -6,7 +6,7 @@ use InvalidArgumentException;
 use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
-use Wikibase\DataModel\StatementListProvider;
+use Wikibase\DataModel\Statement\StatementListProvider;
 use Wikibase\DataModel\Term\Fingerprint;
 
 /**

--- a/src/Statement/StatementListProvider.php
+++ b/src/Statement/StatementListProvider.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel;
-
-use Wikibase\DataModel\Statement\StatementList;
+namespace Wikibase\DataModel\Statement;
 
 /**
  * Interface for classes that contain a StatementList.

--- a/tests/component/AutoloadingAliasesTest.php
+++ b/tests/component/AutoloadingAliasesTest.php
@@ -29,6 +29,7 @@ class AutoloadingAliasesTest extends \PHPUnit_Framework_TestCase {
 				'Wikibase\DataModel\Claim\ClaimGuid',
 				'Wikibase\DataModel\Claim\ClaimGuidParser',
 				'Wikibase\DataModel\Claim\ClaimGuidParsingException',
+				'Wikibase\DataModel\StatementListProvider'
 			)
 		);
 	}


### PR DESCRIPTION
When having `FingerprintProvider` in the Term namespace, `StatementListProvider` should also be in the Statement namespace.

Furthermore, this makes the src/ folder less crowded.