### PR TITLE
Dont modifiy StatementList when invalid arguments passed to setStatements

### DIFF
--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -50,7 +50,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 
 	/**
 	 * @since 3.0
-	 * 
+	 *
 	 * @param Statement[]|Traversable
 	 *
 	 * @throws InvalidArgumentException
@@ -60,14 +60,17 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 			throw new InvalidArgumentException( '$statements must be an array or an instance of Traversable' );
 		}
 
-		$this->statements = array();
+		$statementsToSet = array();
+
 		foreach ( $statements as $statement ) {
 			if ( !( $statement instanceof Statement ) ) {
 				throw new InvalidArgumentException( 'Every element in $statements must be an instance of Statement' );
 			}
 
-			$this->addStatement( $statement );
+			$statementsToSet[] = $statement;
 		}
+
+		$this->statements = $statementsToSet;
 	}
 
 	/**
@@ -119,6 +122,8 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	/**
+	 * @since 3.0
+	 *
 	 * @param string|null $guid
 	 */
 	public function removeStatementsWithGuid( $guid ) {

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -3,6 +3,7 @@
 namespace Wikibase\DataModel\Tests\Statement;
 
 use DataValues\StringValue;
+use InvalidArgumentException;
 use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
@@ -694,12 +695,56 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGivenNoTraversable_setStatementsThrowsException() {
+	public function testGivenNonTraversable_setStatementsThrowsException() {
 		$statement1 = $this->getStatement( 1, 'guid1' );
 		$statements = new StatementList();
 
 		$this->setExpectedException( 'InvalidArgumentException' );
 		$statements->setStatements( $statement1 );
+	}
+
+	public function testGivenNonStatement_setStatementsThrowsException() {
+		$statement1 = $this->getStatement( 1, 'guid1' );
+		$statements = new StatementList();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$statements->setStatements( array( $statement1, false ) );
+	}
+
+	public function testGivenNonTraversable_setStatementsDoesNotEditList() {
+		$statement1 = $this->getStatement( 1, 'guid1' );
+		$statement2 = $this->getStatement( 2, 'guid2' );
+		$statement3 = $this->getStatement( 3, 'guid3' );
+		$statement4 = $this->getStatement( 2, 'guid5' );
+		$statements = new StatementList( $statement1, $statement2, $statement3, $statement4 );
+
+		try {
+			$statements->setStatements( $statement1 );
+		}
+		catch ( InvalidArgumentException $e ) {
+			$this->assertEquals(
+				new StatementList( $statement1, $statement2, $statement3, $statement4 ),
+				$statements
+			);
+		}
+	}
+
+	public function testGivenNonStatement_setStatementsDoesNotEditList() {
+		$statement1 = $this->getStatement( 1, 'guid1' );
+		$statement2 = $this->getStatement( 2, 'guid2' );
+		$statement3 = $this->getStatement( 3, 'guid3' );
+		$statement4 = $this->getStatement( 2, 'guid5' );
+		$statements = new StatementList( $statement1, $statement2, $statement3, $statement4 );
+
+		try {
+			$statements->setStatements( array( $statement4, false ) );
+		}
+		catch ( InvalidArgumentException $e ) {
+			$this->assertEquals(
+				new StatementList( $statement1, $statement2, $statement3, $statement4 ),
+				$statements
+			);
+		}
 	}
 
 }


### PR DESCRIPTION
@JeroenDeDauw Addresses your comment and adds tests for those cases.

*Edit:* Added a missing `@since 3.0` tag as well.