### PR TITLE
Partial revert of the With vs. By inconsistency

### DIFF
--- a/src/Statement/StatementByGuidMap.php
+++ b/src/Statement/StatementByGuidMap.php
@@ -72,7 +72,7 @@ class StatementByGuidMap implements IteratorAggregate, Countable {
 	 *
 	 * @return Statement|null
 	 */
-	public function getStatementWithGuid( $statementGuid ) {
+	public function getStatementByGuid( $statementGuid ) {
 		$this->assertIsStatementGuid( $statementGuid );
 
 		if ( array_key_exists( $statementGuid, $this->statements ) ) {

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -138,6 +138,8 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	 * Statements that have a main snak already in the list are filtered out.
 	 * The last occurrences are retained.
 	 *
+	 * @since 1.0
+	 *
 	 * @return self
 	 */
 	public function getWithUniqueMainSnaks() {

--- a/tests/unit/Statement/StatementByGuidMapTest.php
+++ b/tests/unit/Statement/StatementByGuidMapTest.php
@@ -56,28 +56,28 @@ class StatementByGuidMapTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGivenGuidOfPresentStatement_getStatementWithGuidReturnsStatement() {
+	public function testGivenGuidOfPresentStatement_getStatementByGuidReturnsStatement() {
 		$statement = $this->newStatement( 1, 'some guid' );
 
 		$statements = new StatementByGuidMap( array( $statement ) );
 
-		$this->assertEquals( $statement, $statements->getStatementWithGuid( 'some guid' ) );
+		$this->assertEquals( $statement, $statements->getStatementByGuid( 'some guid' ) );
 	}
 
-	public function testGivenGuidOfNotPresentStatement_getStatementWithGuidReturnsNull() {
+	public function testGivenGuidOfNotPresentStatement_getStatementByGuidReturnsNull() {
 		$statements = new StatementByGuidMap();
 
-		$this->assertNull( $statements->getStatementWithGuid( 'some guid' ) );
+		$this->assertNull( $statements->getStatementByGuid( 'some guid' ) );
 	}
 
 	/**
 	 * @dataProvider nonStringProvider
 	 */
-	public function testGivenNonStringGuid_getStatementWithGuidThrowsException( $nonString ) {
+	public function testGivenNonStringGuid_getStatementByGuidThrowsException( $nonString ) {
 		$statements = new StatementByGuidMap();
 
 		$this->setExpectedException( 'InvalidArgumentException' );
-		$statements->getStatementWithGuid( $nonString );
+		$statements->getStatementByGuid( $nonString );
 	}
 
 	public function testGivenGuidOfPresentStatement_removeStatementWithGuidRemovesTheStatement() {
@@ -177,7 +177,7 @@ class StatementByGuidMapTest extends \PHPUnit_Framework_TestCase {
 
 		$statements->addStatement( $statement2 );
 
-		$this->assertEquals( $statement2, $statements->getStatementWithGuid( 'some guid' ) );
+		$this->assertEquals( $statement2, $statements->getStatementByGuid( 'some guid' ) );
 	}
 
 	public function testToArray() {


### PR DESCRIPTION
Existing "byId" methods:
* `ByPropertyIdArray::getByPropertyId`
* `ByPropertyIdGrouper::getByPropertyId`
* `SiteLinkList::getBySiteId`

Existing "withId" methods:
* `SiteLinkList::hasLinkWithSiteId`
* `SiteLinkList::removeLinkWithSiteId`
* `StatementByGuidMap::hasStatementWithGuid`
* `StatementByGuidMap::getStatementWithGuid`
* `StatementByGuidMap::removeStatementWithGuid`
* `StatementList::removeStatementsWithGuid`
* `StatementList::getWithPropertyId`
* `StatementList::getFirstStatementWithGuid`
* 3 more in the deprecated `Claims`

Suggested naming scheme:
* The object type should not be repeated if a method returns an instance of `self`, e.g. not ~~`Foo::getFooByBar`~~ but `Foo::getByBar`.
* "has*Object*With" and "remove*Object*With" no matter if the parameter is an unique identifier or not.
* But "removeBy" when the object type is not repeated.
* "getBy" for methods that are guaranteed to return all matching elements, either as a list, or as a single element when the selection criteria is an unique identifier.
* "getWith" otherwise, e.g. `StatementList::getFirstStatementWithGuid`.

This patch tries to apply this naming scheme without introducing more breaking changes. This fixes #486.

[Bug: T98180](https://phabricator.wikimedia.org/T98180)