### PR TITLE
StatementListProvider is not a class

### DIFF
--- a/Aliases.php
+++ b/Aliases.php
@@ -35,6 +35,6 @@ namespace Wikibase\DataModel {
 	/**
 	 * @deprecated since 3.0.0, use the base class instead.
 	 */
-	class StatementListProvider extends \Wikibase\DataModel\Statement\StatementListProvider {}
+	interface StatementListProvider extends \Wikibase\DataModel\Statement\StatementListProvider {}
 
 }

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -93,7 +93,7 @@ class PropertyTest extends EntityTest {
 		$this->assertInstanceOf( 'Wikibase\DataModel\Entity\PropertyId', $property->getId() );
 	}
 
-	public function testWhenIdSetWithEntityId_GetIdReturnsPropertyId() {
+	public function testWhenIdSetWithPropertyId_GetIdReturnsPropertyId() {
 		$property = Property::newFromType( 'string' );
 		$property->setId( new PropertyId( 'P42' ) );
 


### PR DESCRIPTION
I may confuse something here but I think this is an actual bug.

The test is unrelated, just a mismatch I found, obviously caused by replacing `new EntityId` with `new PropertyId` without renaming the test.