### PR TITLE
Rename getWithPropertyId to getByPropertyId

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,6 +36,7 @@ Other breaking changes:
 * Removed previously deprecated `Entity::getAllSnaks`, use `StatementList::getAllSnaks` instead
 * Removed previously deprecated `EntityId::getPrefixedId`, use `EntityId::getSerialization` instead
 * Removed previously deprecated `Property::newEmpty`, use `Property::newFromType` or `new Property()` instead
+* Renamed `StatementList::getWithPropertyId` to `StatementList::getByPropertyId`
 * `Reference` and `ReferenceList`s no longer can not be instantiated with `null`
 * Added `setId` method to `EntityDocument`
 

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -138,13 +138,13 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	/**
-	 * @since 2.3
+	 * @since 3.0
 	 *
 	 * @param PropertyId $id
 	 *
 	 * @return self
 	 */
-	public function getWithPropertyId( PropertyId $id ) {
+	public function getByPropertyId( PropertyId $id ) {
 		$statementList = new self();
 
 		foreach ( $this->statements as $statement ) {

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -516,17 +516,17 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGivenNotKnownPropertyId_getWithPropertyIdReturnsEmptyList() {
+	public function testGivenNotKnownPropertyId_getByPropertyIdReturnsEmptyList() {
 		$list = new StatementList();
 		$list->addNewStatement( new PropertyNoValueSnak( 42 ) );
 
 		$this->assertEquals(
 			new StatementList(),
-			$list->getWithPropertyId( new PropertyId( 'P2' ) )
+			$list->getByPropertyId( new PropertyId( 'P2' ) )
 		);
 	}
 
-	public function testGivenKnownPropertyId_getWithPropertyIdReturnsListWithOnlyMatchingStatements() {
+	public function testGivenKnownPropertyId_getByPropertyIdReturnsListWithOnlyMatchingStatements() {
 		$list = new StatementList();
 		$list->addNewStatement( new PropertyNoValueSnak( 42 ) );
 		$list->addNewStatement( new PropertyNoValueSnak( 9001 ) );
@@ -539,7 +539,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			$expected,
-			$list->getWithPropertyId( new PropertyId( 'P42' ) )
+			$list->getByPropertyId( new PropertyId( 'P42' ) )
 		);
 	}
 


### PR DESCRIPTION
For parity with
* `ByPropertyIdArray::getByPropertyId`
* `ByPropertyIdGrouper::getByPropertyId`

and for the reasons outlined in https://github.com/wmde/WikibaseDataModel/pull/487#issue-75975410.

[Bug: T98180](https://phabricator.wikimedia.org/T98180)