### PR TITLE
Rename getWithRank to getByRank

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,7 +18,7 @@ Phasing out of `Claims`:
 
 * `Claims::addClaim` no longer supports setting an index
 * Removed `Claims::getBestClaims`, use `StatementList::getBestStatements` instead
-* Removed `Claims::getByRank` and `Claims::getByRanks`, use `StatementList::getWithRank` instead
+* Removed `Claims::getByRank` and `Claims::getByRanks`, use `StatementList::getByRank` instead
 * Removed `Claims::getMainSnaks`, use `StatementList::getMainSnaks` instead
 * Removed `Claims::getClaimsForProperty`, use `StatementList::getWithPropertyId` instead
 * Removed `Claims::getHashes`
@@ -37,6 +37,7 @@ Other breaking changes:
 * Removed previously deprecated `EntityId::getPrefixedId`, use `EntityId::getSerialization` instead
 * Removed previously deprecated `Property::newEmpty`, use `Property::newFromType` or `new Property()` instead
 * Renamed `StatementList::getWithPropertyId` to `StatementList::getByPropertyId`
+* Renamed `StatementList::getWithRank` to `StatementList::getByRank`
 * `Reference` and `ReferenceList`s no longer can not be instantiated with `null`
 * Added `setId` method to `EntityDocument`
 

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -159,13 +159,13 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	/**
-	 * @since 2.4
+	 * @since 3.0
 	 *
 	 * @param int|int[] $acceptableRanks
 	 *
 	 * @return self
 	 */
-	public function getWithRank( $acceptableRanks ) {
+	public function getByRank( $acceptableRanks ) {
 		$acceptableRanks = array_flip( (array)$acceptableRanks );
 		$statementList = new self();
 
@@ -188,13 +188,13 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	 * @return self
 	 */
 	public function getBestStatements() {
-		$statements = $this->getWithRank( Statement::RANK_PREFERRED );
+		$statements = $this->getByRank( Statement::RANK_PREFERRED );
 
 		if ( !$statements->isEmpty() ) {
 			return $statements;
 		}
 
-		return $this->getWithRank( Statement::RANK_NORMAL );
+		return $this->getByRank( Statement::RANK_NORMAL );
 	}
 
 	/**

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -530,12 +530,12 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGivenInvalidRank_getWithRankReturnsEmptyList() {
+	public function testGivenInvalidRank_getByRankReturnsEmptyList() {
 		$list = new StatementList();
-		$this->assertEquals( new StatementList(), $list->getWithRank( 42 ) );
+		$this->assertEquals( new StatementList(), $list->getByRank( 42 ) );
 	}
 
-	public function testGivenValidRank_getWithRankReturnsOnlyMatchingStatements() {
+	public function testGivenValidRank_getByRankReturnsOnlyMatchingStatements() {
 		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setRank( Statement::RANK_PREFERRED );
 
@@ -549,12 +549,12 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			new StatementList( $statement ),
-			$list->getWithRank( Statement::RANK_PREFERRED )
+			$list->getByRank( Statement::RANK_PREFERRED )
 		);
 
 		$this->assertEquals(
 			new StatementList( $secondStatement, $thirdStatement ),
-			$list->getWithRank( array( Statement::RANK_NORMAL, Statement::RANK_DEPRECATED ) )
+			$list->getByRank( array( Statement::RANK_NORMAL, Statement::RANK_DEPRECATED ) )
 		);
 	}
 


### PR DESCRIPTION
As requested by @Benestar in https://phabricator.wikimedia.org/T98180#1283186 and for the reasons outlined in https://github.com/wmde/WikibaseDataModel/pull/487#issue-75975410.

Not a big deal, the method is used only a single time in `SnaksFinder` in Wikibase.git.

[Bug: T98180](https://phabricator.wikimedia.org/T98180)