### PR TITLE
Undeprecate term setters in Item and Property

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -57,6 +57,11 @@ Other breaking changes:
 * Renamed `Claim\ClaimGuidParsingException` to `Statement\StatementGuidParsingException`, leaving a b/c alias in place
 * Renamed `StatementListProvider` to `Statement\StatementListProvider`, leaving a b/c alias in place
 
+#### Other changes
+
+* `Item::setLabel`, `Item::setDescription` and `Item::setAliases` are no longer deprecated
+* `Property::setLabel`, `Property::setDescription` and `Property::setAliases` are no longer deprecated
+
 ## Version 2.6.1 (2015-04-25)
 
 * Allow installation together with Diff 2.x.

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -77,6 +77,36 @@ class Item extends Entity implements StatementListHolder {
 	}
 
 	/**
+	 * @param string $languageCode
+	 * @param string $value
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function setLabel( $languageCode, $value ) {
+		$this->fingerprint->setLabel( $languageCode, $value );
+	}
+
+	/**
+	 * @param string $languageCode
+	 * @param string $value
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function setDescription( $languageCode, $value ) {
+		$this->fingerprint->setDescription( $languageCode, $value );
+	}
+
+	/**
+	 * @param string $languageCode
+	 * @param string[] $aliases
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function setAliases( $languageCode, array $aliases ) {
+		$this->fingerprint->setAliasGroup( $languageCode, $aliases );
+	}
+
+	/**
 	 * @since 0.1 return type changed in 0.3
 	 *
 	 * @return ItemId|null

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -74,6 +74,36 @@ class Property extends Entity implements StatementListHolder {
 	}
 
 	/**
+	 * @param string $languageCode
+	 * @param string $value
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function setLabel( $languageCode, $value ) {
+		$this->fingerprint->setLabel( $languageCode, $value );
+	}
+
+	/**
+	 * @param string $languageCode
+	 * @param string $value
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function setDescription( $languageCode, $value ) {
+		$this->fingerprint->setDescription( $languageCode, $value );
+	}
+
+	/**
+	 * @param string $languageCode
+	 * @param string[] $aliases
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function setAliases( $languageCode, array $aliases ) {
+		$this->fingerprint->setAliasGroup( $languageCode, $aliases );
+	}
+
+	/**
 	 * @since 0.1 return type changed in 0.3
 	 *
 	 * @return PropertyId|null


### PR DESCRIPTION
Right now code as follows is deprecated:

```php
$item = new Item();
$item->setLabel( 'en', 'foo' );
$item->setDescription( 'de', 'bar' );
```

This is caused by these setters being deprecated in Entity, which
was done to deprecate code assuming all entities have these terms,
and to discourage bad interface segregation. The above code suffers
from neither these problems, and is a style often used in tests,
and has no clean alternative due to PHPs lack of named parameters.
Hence this undeprecation in Item and Property, keeping the one in
Entity.