### PR TITLE
Also allow a Snak parameter in Statement

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel release notes
 
+## Version 2.6.2 (dev)
+
+* The `Statement` constructor now also accepts a `Snak` parameter
+
 ## Version 2.6.1 (2015-04-25)
 
 * Allow installation together with Diff 2.x.

--- a/WikibaseDataModel.php
+++ b/WikibaseDataModel.php
@@ -12,7 +12,7 @@ if ( defined( 'WIKIBASE_DATAMODEL_VERSION' ) ) {
 	return 1;
 }
 
-define( 'WIKIBASE_DATAMODEL_VERSION', '2.6.1' );
+define( 'WIKIBASE_DATAMODEL_VERSION', '2.6.2' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	call_user_func( function() {

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -45,10 +45,38 @@ class Statement extends Claim {
 	 *
 	 * @param Claim $claim
 	 * @param ReferenceList|null $references
+	 * or
+	 * @param Snak $mainSnak
+	 * @param Snaks|null $qualifiers
+	 * @param ReferenceList|null $references
+	 * @param string|null $guid
 	 */
-	public function __construct( Claim $claim, ReferenceList $references = null ) {
+	public function __construct( $claim /* , $args */ ) {
+		if ( $claim instanceof Claim ) {
+			call_user_func_array( array( $this, 'initFromClaim' ), func_get_args() );
+		} else {
+			call_user_func_array( array( $this, 'initFromSnaks' ), func_get_args() );
+		}
+	}
+
+	private function initFromClaim(
+		Claim $claim,
+		ReferenceList $references = null
+	) {
 		$this->setClaim( $claim );
 		$this->references = $references ?: new ReferenceList();
+	}
+
+	private function initFromSnaks(
+		Snak $mainSnak,
+		Snaks $qualifiers = null,
+		ReferenceList $references = null,
+		$guid = null
+	) {
+		$this->mainSnak = $mainSnak;
+		$this->qualifiers = $qualifiers ?: new SnakList();
+		$this->references = $references ?: new ReferenceList();
+		$this->setGuid( $guid );
 	}
 
 	/**

--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -32,6 +32,13 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'meh', $statement->getGuid() );
 	}
 
+	public function testConstructorWithtoutClaim() {
+		$snak = new PropertyNoValueSnak( new PropertyId( 'P42' ) );
+		$statement = new Statement( $snak );
+
+		$this->assertTrue( $statement->getMainSnak()->equals( $snak ) );
+	}
+
 	/**
 	 * @dataProvider instanceProvider
 	 */


### PR DESCRIPTION
This makes the transition to DataModel 3.0 much easier on other components, because this allows both the use of the old and the new constructor in `Statement`

This will be a <s>2.6.2</s> **2.7** release.