### PR TITLE
Do not return anything from Entity setters

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -38,11 +38,12 @@ Other breaking changes:
 * Removed previously deprecated `Property::newEmpty`, use `Property::newFromType` or `new Property()` instead
 * Renamed `StatementList::getWithPropertyId` to `StatementList::getByPropertyId`
 * Renamed `StatementList::getWithRank` to `StatementList::getByRank`
-* `Reference` and `ReferenceList`s no longer can not be instantiated with `null`
-* Added `setId` method to `EntityDocument`
+* `Entity::setLabel` and `Entity::setDescription` no longer return anything
+* `Reference` and `ReferenceList`s no longer can be instantiated with `null`
 
 #### Additions
 
+* Added `EntityDocument::setId`
 * Added `StatementByGuidMap`
 * Added `StatementListHolder`
 * Added `StatementList::getFirstStatementWithGuid`

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -54,12 +54,9 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 *
 	 * @param string $languageCode
 	 * @param string $value
-	 *
-	 * @return string
 	 */
 	public function setLabel( $languageCode, $value ) {
 		$this->fingerprint->setLabel( $languageCode, $value );
-		return $value;
 	}
 
 	/**
@@ -69,12 +66,9 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 *
 	 * @param string $languageCode
 	 * @param string $value
-	 *
-	 * @return string
 	 */
 	public function setDescription( $languageCode, $value ) {
 		$this->fingerprint->setDescription( $languageCode, $value );
-		return $value;
 	}
 
 	/**

--- a/tests/unit/Entity/ItemIdSetTest.php
+++ b/tests/unit/Entity/ItemIdSetTest.php
@@ -91,14 +91,14 @@ class ItemIdSetTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider setProvider
+	 * @dataProvider itemIdSetProvider
 	 */
 	public function testGivenTheSameSet_equalsReturnsTrue( ItemIdSet $set ) {
 		$this->assertTrue( $set->equals( $set ) );
 		$this->assertTrue( $set->equals( clone $set ) );
 	}
 
-	public function setProvider() {
+	public function itemIdSetProvider() {
 		return array(
 			array(
 				new ItemIdSet(),


### PR DESCRIPTION
I realized this in https://github.com/wmde/WikibaseDataModel/pull/492#discussion_r31474648.

~~I consider this a mistake that's not worth any documentation.~~ I did a quick check in our code base and could not find a user relying on these return values.

The renamed method is unrelated, I just found this setter that's not a setter while searching for setters that may return something.