### PR TITLE
Restore Property::newEmpty

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel release notes
 
+## Version 3.0.1 (2015-06-10)
+
+* Restored removed `Property::newEmpty` for compatibility reasons
+
 ## Version 3.0.0 (2015-06-06)
 
 #### Breaking changes

--- a/WikibaseDataModel.php
+++ b/WikibaseDataModel.php
@@ -12,7 +12,7 @@ if ( defined( 'WIKIBASE_DATAMODEL_VERSION' ) ) {
 	return 1;
 }
 
-define( 'WIKIBASE_DATAMODEL_VERSION', '3.0.0' );
+define( 'WIKIBASE_DATAMODEL_VERSION', '3.0.1' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	call_user_func( function() {

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -207,6 +207,15 @@ class Property extends Entity implements StatementListHolder {
 	}
 
 	/**
+	 * @deprecated since 0.7.3, use Property::newFromType() or new Property() instead.
+	 *
+	 * @return Property
+	 */
+	public static function newEmpty() {
+		return self::newFromType( '' );
+	}
+
+	/**
 	 * @since 1.1
 	 *
 	 * @return StatementList


### PR DESCRIPTION
This reverts #425.

When phasing out this method we missed code in Wikibase.git that relies on the fact that all `Entity` classes do have a `newEmpty` method. Most notably https://github.com/wikimedia/mediawiki-extensions-Wikibase/blob/398af20d17c119a37350e5ce3df89940945d7f0f/lib/includes/EntityFactory.php#L114. This is a single place in our code base and we already worked around it. The actual reason why I'm suggesting to restore the function is that other code may also depend on the same assumption. Such code breaks when switching to 3.0 with no easy way forward. People can not look into Wikibase.git and replicate what we did. We currently do not have a good alternative in our own code base.

These are the reasons why I'm suggesting to release this as a bugfix release, even if you could argue that the addition of a method requires a 3.1.0.

It's sad that `newEmpty` is not backed by an interface or something but that's how it is at the moment.