### PR TITLE
Make ReferenceList no longer extend SplObjectStorage 

### DIFF
--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -2,29 +2,34 @@
 
 namespace Wikibase\DataModel;
 
+use ArrayIterator;
 use Comparable;
+use Countable;
+use Hashable;
 use InvalidArgumentException;
-use SplObjectStorage;
+use IteratorAggregate;
 use Traversable;
 use Wikibase\DataModel\Snak\Snak;
 
 /**
  * List of Reference objects.
  *
- * Note that this implementation is based on SplObjectStorage and
- * is not enforcing the type of objects set via it's native methods.
- * Therefore one can add non-Reference-implementing objects when
- * not sticking to the methods of the References interface.
- *
  * @since 0.1
  * Does not implement References anymore since 2.0
+ * Does not extend SplObjectStorage since 4.0
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author H. Snater < mediawiki@snater.com >
  * @author Thiemo Mättig
+ * @author Bene* < benestar.wikimedia@gmail.com >
  */
-class ReferenceList extends SplObjectStorage implements Comparable {
+class ReferenceList implements Comparable, Hashable, IteratorAggregate, Countable {
+
+	/**
+	 * @var Reference[]
+	 */
+	private $references = array();
 
 	/**
 	 * @param Reference[]|Traversable $references
@@ -47,6 +52,7 @@ class ReferenceList extends SplObjectStorage implements Comparable {
 
 	/**
 	 * Adds the provided reference to the list.
+	 * Empty references are ignored.
 	 *
 	 * @since 0.1
 	 *
@@ -56,27 +62,19 @@ class ReferenceList extends SplObjectStorage implements Comparable {
 	 * @throws InvalidArgumentException
 	 */
 	public function addReference( Reference $reference, $index = null ) {
-		if ( !is_int( $index ) && $index !== null ) {
-			throw new InvalidArgumentException( '$index must be an integer or null' );
+		if ( $index !== null && ( !is_int( $index ) || $index < 0 ) ) {
+			throw new InvalidArgumentException( '$index must be a non-negative integer or null' );
 		}
 
-		if ( $index === null || $index >= count( $this ) ) {
+		if ( $reference->isEmpty() ) {
+			return;
+		}
+
+		if ( $index === null || $index >= count( $this->references ) ) {
 			// Append object to the end of the reference list.
-			$this->attach( $reference );
+			$this->references[] = $reference;
 		} else {
 			$this->insertReferenceAtIndex( $reference, $index );
-		}
-	}
-
-	/**
-	 * @see SplObjectStorage::attach
-	 *
-	 * @param Reference $reference
-	 * @param mixed $data Unused in the ReferenceList class.
-	 */
-	public function attach( $reference, $data = null ) {
-		if ( !$reference->isEmpty() ) {
-			parent::attach( $reference, $data );
 		}
 	}
 
@@ -101,26 +99,7 @@ class ReferenceList extends SplObjectStorage implements Comparable {
 	 * @param int $index
 	 */
 	private function insertReferenceAtIndex( Reference $reference, $index ) {
-		$referencesToShift = array();
-		$i = 0;
-
-		// Determine the references that need to be shifted and detach them:
-		foreach( $this as $object ) {
-			if( $i++ >= $index ) {
-				$referencesToShift[] = $object;
-			}
-		}
-
-		foreach( $referencesToShift as $object ) {
-			$this->detach( $object );
-		}
-
-		// Attach the new reference and reattach the previously detached references:
-		$this->attach( $reference );
-
-		foreach( $referencesToShift as $object ) {
-			$this->attach( $object );
-		}
+		array_splice( $this->references, $index, 0, array( $reference ) );
 	}
 
 	/**
@@ -133,30 +112,7 @@ class ReferenceList extends SplObjectStorage implements Comparable {
 	 * @return boolean
 	 */
 	public function hasReference( Reference $reference ) {
-		return $this->contains( $reference )
-			|| $this->hasReferenceHash( $reference->getHash() );
-	}
-
-	/**
-	 * Returns the index of a reference or false if the reference could not be found.
-	 *
-	 * @since 0.5
-	 *
-	 * @param Reference $reference
-	 *
-	 * @return int|boolean
-	 */
-	public function indexOf( Reference $reference ) {
-		$index = 0;
-
-		foreach( $this as $object ) {
-			if( $object === $reference ) {
-				return $index;
-			}
-			$index++;
-		}
-
-		return false;
+		return $this->hasReferenceHash( $reference->getHash() );
 	}
 
 	/**
@@ -191,15 +147,18 @@ class ReferenceList extends SplObjectStorage implements Comparable {
 	 * @param string $referenceHash	`
 	 */
 	public function removeReferenceHash( $referenceHash ) {
-		$reference = $this->getReference( $referenceHash );
-
-		if ( $reference !== null ) {
-			$this->detach( $reference );
+		foreach ( $this->references as $index => $reference ) {
+			if ( $reference->getHash() === $referenceHash ) {
+				unset( $this->references[$index] );
+			}
 		}
+
+		$this->references = array_values( $this->references );
 	}
 
 	/**
-	 * Returns the reference with the provided hash, or null if there is no such reference in the list.
+	 * Returns the reference with the provided hash,
+	 * or null if there is no such reference in the list.
 	 *
 	 * @since 0.3
 	 *
@@ -208,12 +167,9 @@ class ReferenceList extends SplObjectStorage implements Comparable {
 	 * @return Reference|null
 	 */
 	public function getReference( $referenceHash ) {
-		/**
-		 * @var Hashable $hashable
-		 */
-		foreach ( $this as $hashable ) {
-			if ( $hashable->getHash() === $referenceHash ) {
-				return $hashable;
+		foreach ( $this->references as $reference ) {
+			if ( $reference->getHash() === $referenceHash ) {
+				return $reference;
 			}
 		}
 
@@ -221,16 +177,68 @@ class ReferenceList extends SplObjectStorage implements Comparable {
 	}
 
 	/**
-	 * The hash is purely value based. Order of the elements in the array is not held into account.
+	 * Returns the index of a reference or false if the reference could not be found.
+	 *
+	 * @since 0.5
+	 *
+	 * @param Reference $reference
+	 *
+	 * @return int|boolean
+	 */
+	public function indexOf( Reference $reference ) {
+		foreach ( $this->references as $index => $ref ) {
+			if ( $ref->equals( $reference ) ) {
+				return $index;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @see IteratorAggregate::getIterator
+	 *
+	 * @since 4.0
+	 *
+	 * @return Traversable
+	 */
+	public function getIterator() {
+		return new ArrayIterator( $this->references );
+	}
+
+	/**
+	 * @since 4.0
+	 *
+	 * @return Reference[] Numerically indexed (non-sparse) array.
+	 */
+	public function toArray() {
+		return $this->references;
+	}
+
+	/**
+	 * @see Countable::count
+	 *
+	 * @since 4.0
+	 *
+	 * @return int
+	 */
+	public function count() {
+		return count( $this->references );
+	}
+
+	/**
+	 * The hash is purely value based, ignoring the order of the elements in the array.
+	 *
+	 * @see Hashable::getHash
 	 *
 	 * @since 4.0
 	 *
 	 * @return string
 	 */
-	public function getValueHash() {
+	public function getHash() {
 		$hashes = array();
 
-		foreach ( $this->toArray() as $reference ) {
+		foreach ( $this->references as $reference ) {
 			$hashes[] = $reference->getHash();
 		}
 
@@ -240,16 +248,9 @@ class ReferenceList extends SplObjectStorage implements Comparable {
 	}
 
 	/**
-	 * @return Reference[]
-	 */
-	public function toArray() {
-		return iterator_to_array( $this );
-	}
-
-	/**
-	 * @see Comparable::equals
-	 *
 	 * The comparison is done purely value based, ignoring the order of the elements in the array.
+	 *
+	 * @see Comparable::equals
 	 *
 	 * @since 0.3
 	 *
@@ -263,7 +264,7 @@ class ReferenceList extends SplObjectStorage implements Comparable {
 		}
 
 		return $target instanceof self
-			&& $this->getValueHash() === $target->getValueHash();
+			&& $this->getHash() === $target->getHash();
 	}
 
 }

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -230,7 +230,7 @@ class Statement implements Hashable, Comparable, PropertyIdProvider {
 			array(
 				sha1( $this->mainSnak->getHash() . $this->qualifiers->getHash() ),
 				$this->rank,
-				$this->references->getValueHash(),
+				$this->references->getHash(),
 			)
 		) );
 	}

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -233,7 +233,7 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 	 * @param ReferenceList $array
 	 */
 	public function testGetHashReturnsString( ReferenceList $array ) {
-		$this->assertInternalType( 'string', $array->getValueHash() );
+		$this->assertInternalType( 'string', $array->getHash() );
 	}
 
 	/**
@@ -242,7 +242,7 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testGetHashValueIsTheSameForClone( ReferenceList $array ) {
 		$copy = unserialize( serialize( $array ) );
-		$this->assertEquals( $array->getValueHash(), $copy->getValueHash() );
+		$this->assertEquals( $array->getHash(), $copy->getHash() );
 	}
 
 	/**


### PR DESCRIPTION
Instead, it now implements some new interfaces like
Countable and IteratorAggregate.

Internally, the class uses an array to store references.
It is now no longer possible to add non-Reference objects
to a ReferenceList. Modifications are only possible through
the provided methods in the class itself.

The full diff can be found here: https://github.com/wmde/WikibaseDataModel/compare/remove-splobjectstorage-inheritance

Depends on #501