### PR TITLE
Remove unused methods from ReferenceList

### DIFF
--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -3,7 +3,6 @@
 namespace Wikibase\DataModel;
 
 use Comparable;
-use Hashable;
 use InvalidArgumentException;
 use SplObjectStorage;
 use Traversable;
@@ -25,7 +24,7 @@ use Wikibase\DataModel\Snak\Snak;
  * @author H. Snater < mediawiki@snater.com >
  * @author Thiemo Mättig
  */
-class ReferenceList extends SplObjectStorage implements Comparable, Hashable {
+class ReferenceList extends SplObjectStorage implements Comparable {
 
 	/**
 	 * @param Reference[]|Traversable $references
@@ -222,15 +221,13 @@ class ReferenceList extends SplObjectStorage implements Comparable, Hashable {
 	}
 
 	/**
-	 * @see Hashable::getHash
-	 *
 	 * The hash is purely value based. Order of the elements in the array is not held into account.
 	 *
 	 * @since 4.0
 	 *
 	 * @return string
 	 */
-	public function getHash() {
+	public function getValueHash() {
 		$hashes = array();
 
 		foreach ( $this->toArray() as $reference ) {
@@ -266,7 +263,7 @@ class ReferenceList extends SplObjectStorage implements Comparable, Hashable {
 		}
 
 		return $target instanceof self
-			&& $this->getHash() === $target->getHash();
+			&& $this->getValueHash() === $target->getValueHash();
 	}
 
 }

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -230,7 +230,7 @@ class Statement implements Hashable, Comparable, PropertyIdProvider {
 			array(
 				sha1( $this->mainSnak->getHash() . $this->qualifiers->getHash() ),
 				$this->rank,
-				$this->references->getHash(),
+				$this->references->getValueHash(),
 			)
 		) );
 	}

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -7,7 +7,6 @@ use Hashable;
 use InvalidArgumentException;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\PropertyIdProvider;
-use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\ReferenceList;
 use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Snak\SnakList;
@@ -231,7 +230,7 @@ class Statement implements Hashable, Comparable, PropertyIdProvider {
 			array(
 				sha1( $this->mainSnak->getHash() . $this->qualifiers->getHash() ),
 				$this->rank,
-				$this->references->getValueHash(),
+				$this->references->getHash(),
 			)
 		) );
 	}

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -351,31 +351,4 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $references->equals( unserialize( $serialized ) ) );
 	}
 
-	public function testRemoveDuplicates_noDuplicatesPresent() {
-		$list = new ReferenceList();
-
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 1 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 2 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 3 ) ) ) );
-
-		$list->removeDuplicates();
-
-		$this->assertEquals( 3, count( $list ) );
-	}
-
-	public function testRemoveDuplicates_duplicatesGetRemoved() {
-		$list = new ReferenceList();
-
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 1 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 2 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 3 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 1 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 2 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 4 ) ) ) );
-
-		$list->removeDuplicates();
-
-		$this->assertEquals( 4, count( $list ) );
-	}
-
 }


### PR DESCRIPTION
Methods which were never used in our code base or have an easy replacement got removed

See #499 for an earlier version of this PR (against the wrong base)

Depends on #498