### PR TITLE
Replace Claim alias usages

### DIFF
--- a/tests/unit/ByPropertyIdArrayTest.php
+++ b/tests/unit/ByPropertyIdArrayTest.php
@@ -6,7 +6,6 @@ use DataValues\StringValue;
 use ReflectionClass;
 use ReflectionMethod;
 use Wikibase\DataModel\ByPropertyIdArray;
-use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
@@ -29,18 +28,18 @@ use Wikibase\DataModel\Statement\Statement;
 class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 
 	public function testArrayObjectNotConstructedFromObject() {
-		$claim1 = new Claim( new PropertyNoValueSnak( 1 ) );
-		$claim1->setGuid( '1' );
-		$claim2 = new Claim( new PropertyNoValueSnak( 2 ) );
-		$claim2->setGuid( '2' );
+		$statement1 = new Statement( new PropertyNoValueSnak( 1 ) );
+		$statement1->setGuid( '1' );
+		$statement2 = new Statement( new PropertyNoValueSnak( 2 ) );
+		$statement2->setGuid( '2' );
 
 		$claims = new Claims();
-		$claims->append( $claim1 );
+		$claims->append( $statement1 );
 
 		$byPropertyIdArray = new ByPropertyIdArray( $claims );
 		// According to the documentation append() "cannot be called when the ArrayObject was
 		// constructed from an object." This test makes sure it was not constructed from an object.
-		$byPropertyIdArray->append( $claim2 );
+		$byPropertyIdArray->append( $statement2 );
 
 		$this->assertCount( 2, $byPropertyIdArray );
 	}
@@ -73,13 +72,6 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 
 		$lists[] = array_map(
 			function( Snak $snak ) {
-				return new Claim( $snak );
-			},
-			$snaks
-		);
-
-		$lists[] = array_map(
-			function( Snak $snak ) {
 				return new Statement( $snak );
 			},
 			$snaks
@@ -95,9 +87,9 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @return Claim[]
+	 * @return Statement[]
 	 */
-	protected function claimsProvider() {
+	protected function statementsProvider() {
 		$snaks = array(
 			new PropertyNoValueSnak( new PropertyId( 'P1' ) ),
 			new PropertySomeValueSnak( new PropertyId( 'P1' ) ),
@@ -109,7 +101,7 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 
 		return array_map(
 			function( Snak $snak ) {
-				return new Claim( $snak );
+				return new Statement( $snak );
 			},
 			$snaks
 		);
@@ -247,7 +239,7 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function moveProvider() {
-		$c = $this->claimsProvider();
+		$c = $this->statementsProvider();
 		$argLists = array();
 
 		$argLists[] = array( $c, $c[0], 0, $c );
@@ -330,27 +322,27 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testMoveThrowingOutOfBoundsExceptionIfObjectNotPresent() {
-		$claims = $this->claimsProvider();
-		$indexedArray = new ByPropertyIdArray( $claims );
+		$statements = $this->statementsProvider();
+		$indexedArray = new ByPropertyIdArray( $statements );
 		$indexedArray->buildIndex();
 
 		$this->setExpectedException( 'OutOfBoundsException' );
 
-		$indexedArray->moveObjectToIndex( new Claim( new PropertyNoValueSnak( new PropertyId( 'P9999' ) ) ), 0 );
+		$indexedArray->moveObjectToIndex( new Statement( new PropertyNoValueSnak( new PropertyId( 'P9999' ) ) ), 0 );
 	}
 
 	public function testMoveThrowingOutOfBoundsExceptionOnInvalidIndex() {
-		$claims = $this->claimsProvider();
-		$indexedArray = new ByPropertyIdArray( $claims );
+		$statements = $this->statementsProvider();
+		$indexedArray = new ByPropertyIdArray( $statements );
 		$indexedArray->buildIndex();
 
 		$this->setExpectedException( 'OutOfBoundsException' );
 
-		$indexedArray->moveObjectToIndex( $claims[0], 9999 );
+		$indexedArray->moveObjectToIndex( $statements[0], 9999 );
 	}
 
 	public function addProvider() {
-		$c = $this->claimsProvider();
+		$c = $this->statementsProvider();
 
 		$argLists = array();
 

--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -328,10 +328,10 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 
 	public function testIterator() {
 		$expected = array(
-			'TESTCLAIM1' => $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P42' ) ), 'testclaim1' ),
-			'TESTCLAIM2' => $this->makeStatement( new PropertySomeValueSnak( new PropertyId( 'P42' ) ), 'testclaim2' ),
-			'TESTCLAIM3' => $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P23' ) ), 'testclaim3' ),
-			'TESTCLAIM4' => $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P9000' ) ), 'testclaim4' ),
+			'GUID1' => $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P42' ) ), 'guid1' ),
+			'GUID2' => $this->makeStatement( new PropertySomeValueSnak( new PropertyId( 'P42' ) ), 'guid2' ),
+			'GUID3' => $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P23' ) ), 'guid3' ),
+			'GUID4' => $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P9000' ) ), 'guid4' ),
 		);
 
 		$claims = new Claims( $expected );

--- a/tests/unit/Claim/ClaimsTest.php
+++ b/tests/unit/Claim/ClaimsTest.php
@@ -4,7 +4,6 @@ namespace Wikibase\DataModel\Tests\Claim;
 
 use InvalidArgumentException;
 use ReflectionClass;
-use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
@@ -27,21 +26,9 @@ use Wikibase\DataModel\Statement\StatementList;
  */
 class ClaimsTest extends \PHPUnit_Framework_TestCase {
 
-	protected $guidCounter = 0;
+	private $guidCounter = 0;
 
-	protected function makeClaim( Snak $mainSnak, $guid = null ) {
-		if ( $guid === null ) {
-			$this->guidCounter++;
-			$guid = 'TEST$claim-' . $this->guidCounter;
-		}
-
-		$claim = new Claim( $mainSnak );
-		$claim->setGuid( $guid );
-
-		return $claim;
-	}
-
-	protected function makeStatement( Snak $mainSnak, $guid = null ) {
+	private function makeStatement( Snak $mainSnak, $guid = null ) {
 		if ( $guid === null ) {
 			$this->guidCounter++;
 			$guid = 'TEST$statement-' . $this->guidCounter;
@@ -87,103 +74,103 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 
 	public function testHasClaimWithGuid() {
 		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
+		$statement1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
+		$statement2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
 
-		$this->assertFalse( $claims->hasClaimWithGuid( $claim1->getGuid() ) );
-		$this->assertFalse( $claims->hasClaimWithGuid( $claim2->getGuid() ) );
+		$this->assertFalse( $claims->hasClaimWithGuid( $statement1->getGuid() ) );
+		$this->assertFalse( $claims->hasClaimWithGuid( $statement2->getGuid() ) );
 
-		$claims->addClaim( $claim1 );
-		$this->assertTrue( $claims->hasClaimWithGuid( $claim1->getGuid() ) );
-		$this->assertFalse( $claims->hasClaimWithGuid( $claim2->getGuid() ) );
+		$claims->addClaim( $statement1 );
+		$this->assertTrue( $claims->hasClaimWithGuid( $statement1->getGuid() ) );
+		$this->assertFalse( $claims->hasClaimWithGuid( $statement2->getGuid() ) );
 
-		$claims->addClaim( $claim2 );
-		$this->assertTrue( $claims->hasClaimWithGuid( $claim1->getGuid() ) );
-		$this->assertTrue( $claims->hasClaimWithGuid( $claim2->getGuid() ) );
+		$claims->addClaim( $statement2 );
+		$this->assertTrue( $claims->hasClaimWithGuid( $statement1->getGuid() ) );
+		$this->assertTrue( $claims->hasClaimWithGuid( $statement2->getGuid() ) );
 	}
 
 	public function testRemoveClaimWithGuid() {
 		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
+		$statement1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
+		$statement2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
 
-		$claims->addClaim( $claim1 );
-		$claims->addClaim( $claim2 );
+		$claims->addClaim( $statement1 );
+		$claims->addClaim( $statement2 );
 		$this->assertSame( 2, $claims->count() );
 
-		$claims->removeClaimWithGuid( $claim1->getGuid() );
+		$claims->removeClaimWithGuid( $statement1->getGuid() );
 		$this->assertSame( 1, $claims->count() );
 
-		$claims->removeClaimWithGuid( $claim2->getGuid() );
+		$claims->removeClaimWithGuid( $statement2->getGuid() );
 		$this->assertSame( 0, $claims->count() );
 	}
 
 	public function testOffsetUnset() {
 		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
+		$statement1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
+		$statement2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
 
-		$claims->addClaim( $claim1 );
-		$claims->addClaim( $claim2 );
+		$claims->addClaim( $statement1 );
+		$claims->addClaim( $statement2 );
 		$this->assertSame( 2, $claims->count() );
 
-		$claims->offsetUnset( $claim1->getGuid() );
+		$claims->offsetUnset( $statement1->getGuid() );
 		$this->assertSame( 1, $claims->count() );
 
-		$claims->offsetUnset( $claim2->getGuid() );
+		$claims->offsetUnset( $statement2->getGuid() );
 		$this->assertSame( 0, $claims->count() );
 	}
 
 	public function testGetClaimWithGuid() {
 		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
+		$statement1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
+		$statement2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
 
-		$claims->addClaim( $claim1 );
-		$this->assertSame( $claim1, $claims->getClaimWithGuid( $claim1->getGuid() ) );
-		$this->assertNull( $claims->getClaimWithGuid( $claim2->getGuid() ) );
+		$claims->addClaim( $statement1 );
+		$this->assertSame( $statement1, $claims->getClaimWithGuid( $statement1->getGuid() ) );
+		$this->assertNull( $claims->getClaimWithGuid( $statement2->getGuid() ) );
 
-		$claims->addClaim( $claim2 );
-		$this->assertSame( $claim1, $claims->getClaimWithGuid( $claim1->getGuid() ) );
-		$this->assertSame( $claim2, $claims->getClaimWithGuid( $claim2->getGuid() ) );
+		$claims->addClaim( $statement2 );
+		$this->assertSame( $statement1, $claims->getClaimWithGuid( $statement1->getGuid() ) );
+		$this->assertSame( $statement2, $claims->getClaimWithGuid( $statement2->getGuid() ) );
 	}
 
 	public function testOffsetGet() {
 		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
+		$statement1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
+		$statement2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
 
-		$claims->addClaim( $claim1 );
-		$this->assertSame( $claim1, $claims->offsetGet( $claim1->getGuid() ) );
+		$claims->addClaim( $statement1 );
+		$this->assertSame( $statement1, $claims->offsetGet( $statement1->getGuid() ) );
 
-		$claims->addClaim( $claim2 );
-		$this->assertSame( $claim1, $claims->offsetGet( $claim1->getGuid() ) );
-		$this->assertSame( $claim2, $claims->offsetGet( $claim2->getGuid() ) );
+		$claims->addClaim( $statement2 );
+		$this->assertSame( $statement1, $claims->offsetGet( $statement1->getGuid() ) );
+		$this->assertSame( $statement2, $claims->offsetGet( $statement2->getGuid() ) );
 	}
 
 	public function testAddClaim() {
 		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
+		$statement1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
+		$statement2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
 
-		$claims->addClaim( $claim1 );
-		$claims->addClaim( $claim2 );
-
-		$this->assertSame( 2, $claims->count() );
-		$this->assertEquals( $claim1, $claims[$claim1->getGuid()] );
-		$this->assertEquals( $claim2, $claims[$claim2->getGuid()] );
-
-		$claims->addClaim( $claim1 );
-		$claims->addClaim( $claim2 );
+		$claims->addClaim( $statement1 );
+		$claims->addClaim( $statement2 );
 
 		$this->assertSame( 2, $claims->count() );
+		$this->assertEquals( $statement1, $claims[$statement1->getGuid()] );
+		$this->assertEquals( $statement2, $claims[$statement2->getGuid()] );
 
-		$this->assertNotNull( $claims->getClaimWithGuid( $claim1->getGuid() ) );
-		$this->assertNotNull( $claims->getClaimWithGuid( $claim2->getGuid() ) );
+		$claims->addClaim( $statement1 );
+		$claims->addClaim( $statement2 );
+
+		$this->assertSame( 2, $claims->count() );
+
+		$this->assertNotNull( $claims->getClaimWithGuid( $statement1->getGuid() ) );
+		$this->assertNotNull( $claims->getClaimWithGuid( $statement2->getGuid() ) );
 
 		$this->assertSame( array(
-			'TEST$CLAIM-1' => $claim1,
-			'TEST$CLAIM-2' => $claim2,
+			'TEST$STATEMENT-1' => $statement1,
+			'TEST$STATEMENT-2' => $statement2,
 		), $claims->getArrayCopy() );
 	}
 
@@ -192,42 +179,42 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testAddClaimWithIndexFails() {
 		$claims = new Claims();
-		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
-		$claims->addClaim( $claim, 0 );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$claims->addClaim( $statement, 0 );
 	}
 
 	public function testAppend() {
 		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
+		$statement1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
+		$statement2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
 
-		$claims->append( $claim1 );
-		$claims->append( $claim2 );
+		$claims->append( $statement1 );
+		$claims->append( $statement2 );
 
 		$this->assertSame( 2, $claims->count() );
-		$this->assertEquals( $claim1, $claims[$claim1->getGuid()] );
-		$this->assertEquals( $claim2, $claims[$claim2->getGuid()] );
+		$this->assertEquals( $statement1, $claims[$statement1->getGuid()] );
+		$this->assertEquals( $statement2, $claims[$statement2->getGuid()] );
 
-		$claims->append( $claim1 );
-		$claims->append( $claim2 );
+		$claims->append( $statement1 );
+		$claims->append( $statement2 );
 
 		$this->assertSame( 2, $claims->count() );
 	}
 
 	public function testAppendOperator() {
 		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
+		$statement1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
+		$statement2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
 
-		$claims[] = $claim1;
-		$claims[] = $claim2;
+		$claims[] = $statement1;
+		$claims[] = $statement2;
 
 		$this->assertSame( 2, $claims->count() );
-		$this->assertEquals( $claim1, $claims[$claim1->getGuid()] );
-		$this->assertEquals( $claim2, $claims[$claim2->getGuid()] );
+		$this->assertEquals( $statement1, $claims[$statement1->getGuid()] );
+		$this->assertEquals( $statement2, $claims[$statement2->getGuid()] );
 
-		$claims[] = $claim1;
-		$claims[] = $claim2;
+		$claims[] = $statement1;
+		$claims[] = $statement2;
 
 		$this->assertSame( 2, $claims->count() );
 	}
@@ -242,109 +229,109 @@ class ClaimsTest extends \PHPUnit_Framework_TestCase {
 
 	public function testOffsetSet() {
 		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
+		$statement1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
+		$statement2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
 
-		$claims->offsetSet( $claim1->getGuid(), $claim1 );
-		$claims->offsetSet( $claim2->getGuid(), $claim2 );
+		$claims->offsetSet( $statement1->getGuid(), $statement1 );
+		$claims->offsetSet( $statement2->getGuid(), $statement2 );
 
 		$this->assertSame( 2, $claims->count() );
-		$this->assertEquals( $claim1, $claims[$claim1->getGuid()] );
-		$this->assertEquals( $claim2, $claims[$claim2->getGuid()] );
+		$this->assertEquals( $statement1, $claims[$statement1->getGuid()] );
+		$this->assertEquals( $statement2, $claims[$statement2->getGuid()] );
 
-		$claims->offsetSet( $claim1->getGuid(), $claim1 );
-		$claims->offsetSet( $claim2->getGuid(), $claim2 );
+		$claims->offsetSet( $statement1->getGuid(), $statement1 );
+		$claims->offsetSet( $statement2->getGuid(), $statement2 );
 
 		$this->assertSame( 2, $claims->count() );
 
 		$this->setExpectedException( 'InvalidArgumentException' );
-		$claims->offsetSet( 'spam', $claim1 );
+		$claims->offsetSet( 'spam', $statement1 );
 	}
 
 	public function testOffsetSetOperator() {
 		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
+		$statement1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
+		$statement2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
 
-		$claims[$claim1->getGuid()] = $claim1;
-		$claims[$claim2->getGuid()] = $claim2;
+		$claims[$statement1->getGuid()] = $statement1;
+		$claims[$statement2->getGuid()] = $statement2;
 
 		$this->assertSame( 2, $claims->count() );
-		$this->assertEquals( $claim1, $claims[$claim1->getGuid()] );
-		$this->assertEquals( $claim2, $claims[$claim2->getGuid()] );
+		$this->assertEquals( $statement1, $claims[$statement1->getGuid()] );
+		$this->assertEquals( $statement2, $claims[$statement2->getGuid()] );
 
-		$claims[$claim1->getGuid()] = $claim1;
-		$claims[$claim2->getGuid()] = $claim2;
+		$claims[$statement1->getGuid()] = $statement1;
+		$claims[$statement2->getGuid()] = $statement2;
 
 		$this->assertSame( 2, $claims->count() );
 	}
 
 	public function testGuidNormalization() {
 		$claims = new Claims();
-		$claim1 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
-		$claim2 = $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
+		$statement1 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P15' ) ) );
+		$statement2 = $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P16' ) ) );
 
-		$claim1LowerGuid = strtolower( $claim1->getGuid() );
-		$claim2UpperGuid = strtoupper( $claim2->getGuid() );
+		$claim1LowerGuid = strtolower( $statement1->getGuid() );
+		$claim2UpperGuid = strtoupper( $statement2->getGuid() );
 
-		$claims->addClaim( $claim1 );
-		$claims->addClaim( $claim2 );
+		$claims->addClaim( $statement1 );
+		$claims->addClaim( $statement2 );
 		$this->assertSame( 2, $claims->count() );
 
-		$this->assertEquals( $claim1, $claims->getClaimWithGuid( $claim1LowerGuid ) );
-		$this->assertEquals( $claim2, $claims->getClaimWithGuid( $claim2UpperGuid ) );
+		$this->assertEquals( $statement1, $claims->getClaimWithGuid( $claim1LowerGuid ) );
+		$this->assertEquals( $statement2, $claims->getClaimWithGuid( $claim2UpperGuid ) );
 
-		$this->assertEquals( $claim1, $claims->offsetGet( $claim1LowerGuid ) );
-		$this->assertEquals( $claim2, $claims->offsetGet( $claim2UpperGuid ) );
+		$this->assertEquals( $statement1, $claims->offsetGet( $claim1LowerGuid ) );
+		$this->assertEquals( $statement2, $claims->offsetGet( $claim2UpperGuid ) );
 
-		$this->assertEquals( $claim1, $claims[$claim1LowerGuid] );
-		$this->assertEquals( $claim2, $claims[$claim2UpperGuid] );
+		$this->assertEquals( $statement1, $claims[$claim1LowerGuid] );
+		$this->assertEquals( $statement2, $claims[$claim2UpperGuid] );
 
 		$claims = new Claims();
-		$claims->offsetSet( strtoupper( $claim1LowerGuid ), $claim1 );
-		$claims->offsetSet( strtolower( $claim2UpperGuid ), $claim2 );
+		$claims->offsetSet( strtoupper( $claim1LowerGuid ), $statement1 );
+		$claims->offsetSet( strtolower( $claim2UpperGuid ), $statement2 );
 		$this->assertSame( 2, $claims->count() );
 
-		$this->assertEquals( $claim1, $claims->getClaimWithGuid( $claim1LowerGuid ) );
-		$this->assertEquals( $claim2, $claims->getClaimWithGuid( $claim2UpperGuid ) );
+		$this->assertEquals( $statement1, $claims->getClaimWithGuid( $claim1LowerGuid ) );
+		$this->assertEquals( $statement2, $claims->getClaimWithGuid( $claim2UpperGuid ) );
 	}
 
 	/**
 	 * Attempts to add Claims with no GUID set will fail.
 	 */
 	public function testNoGuidFailure() {
-		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$list = new Claims();
 
 		$this->setExpectedException( 'InvalidArgumentException' );
-		$list->addClaim( $claim );
+		$list->addClaim( $statement );
 	}
 
 	public function testDuplicateClaims() {
-		$firstClaim = $this->makeClaim( new PropertyNoValueSnak( 42 ) );
-		$secondClaim = $this->makeClaim( new PropertyNoValueSnak( 42 ) );
+		$statement1 = $this->makeStatement( new PropertyNoValueSnak( 42 ) );
+		$statement2 = $this->makeStatement( new PropertyNoValueSnak( 42 ) );
 
 		$list = new Claims();
-		$list->addClaim( $firstClaim );
-		$list->addClaim( $secondClaim );
+		$list->addClaim( $statement1 );
+		$list->addClaim( $statement2 );
 
 		$this->assertEquals( 2, $list->count(), 'Adding two duplicates to an empty list should result in a count of two' );
 
-		$this->assertEquals( $firstClaim, $list->getClaimWithGuid( $firstClaim->getGuid() ) );
-		$this->assertEquals( $secondClaim, $list->getClaimWithGuid( $secondClaim->getGuid() ) );
+		$this->assertEquals( $statement1, $list->getClaimWithGuid( $statement1->getGuid() ) );
+		$this->assertEquals( $statement2, $list->getClaimWithGuid( $statement2->getGuid() ) );
 
-		$list->removeClaimWithGuid( $secondClaim->getGuid() );
+		$list->removeClaimWithGuid( $statement2->getGuid() );
 
-		$this->assertNotNull( $list->getClaimWithGuid( $firstClaim->getGuid() ) );
-		$this->assertNull( $list->getClaimWithGuid( $secondClaim->getGuid() ) );
+		$this->assertNotNull( $list->getClaimWithGuid( $statement1->getGuid() ) );
+		$this->assertNull( $list->getClaimWithGuid( $statement2->getGuid() ) );
 	}
 
 	public function testIterator() {
 		$expected = array(
-			'TESTCLAIM1' => $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P42' ) ), 'testclaim1' ),
-			'TESTCLAIM2' => $this->makeClaim( new PropertySomeValueSnak( new PropertyId( 'P42' ) ), 'testclaim2' ),
-			'TESTCLAIM3' => $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P23' ) ), 'testclaim3' ),
-			'TESTCLAIM4' => $this->makeClaim( new PropertyNoValueSnak( new PropertyId( 'P9000' ) ), 'testclaim4' ),
+			'TESTCLAIM1' => $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P42' ) ), 'testclaim1' ),
+			'TESTCLAIM2' => $this->makeStatement( new PropertySomeValueSnak( new PropertyId( 'P42' ) ), 'testclaim2' ),
+			'TESTCLAIM3' => $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P23' ) ), 'testclaim3' ),
+			'TESTCLAIM4' => $this->makeStatement( new PropertyNoValueSnak( new PropertyId( 'P9000' ) ), 'testclaim4' ),
 		);
 
 		$claims = new Claims( $expected );


### PR DESCRIPTION
This patch removes/replaces all remaining usages of `Claim`, which is now an alias.