### PR TITLE
Deprecate methods in Entity

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,11 @@
 ## Version 3.1 (dev)
 
 * Added `DerivedPropertyValueSnak`
+* Deprecated `Entity::copy`
+* Deprecated `Entity::getFingerprint`
+* Deprecated `Entity::setFingerprint`
+* Deprecated `Entity::isEmpty`
+* Deprecated `Entity::clear`
 
 ## Version 3.0.1 (2015-07-01)
 

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -332,6 +332,7 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 * Returns a deep copy of the entity.
 	 *
 	 * @since 0.1
+	 * @deprecated since 3.1
 	 *
 	 * @return self
 	 */
@@ -380,6 +381,7 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 
 	/**
 	 * @since 0.7.3
+	 * @deprecated since 3.1, use FingerprintProvider instead
 	 *
 	 * @return Fingerprint
 	 */
@@ -389,6 +391,7 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 
 	/**
 	 * @since 0.7.3
+	 * @deprecated since 3.1
 	 *
 	 * @param Fingerprint $fingerprint
 	 */
@@ -401,6 +404,7 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 * Having an id set does not count as having content.
 	 *
 	 * @since 0.1
+	 * @deprecated since 3.1
 	 *
 	 * @return bool
 	 */
@@ -411,6 +415,7 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 * The id is not part of the content.
 	 *
 	 * @since 0.1
+	 * @deprecated since 3.1
 	 */
 	public abstract function clear();
 


### PR DESCRIPTION
Deprecate methods which are in `Entity` but not in `EntityDocument`