### PR TITLE
Introduce provider interfaces for labels, descriptions and aliases

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,7 @@
 
 * Added `StatementFilter` and `ReferencedStatementFilter`
 * Added `StatementList::filter`
+* Added `LabelsProvider`, `DescriptionsProvider` and `AliasesProvider`
 
 ## Version 4.0 (2015-07-28)
 

--- a/src/Term/AliasesProvider.php
+++ b/src/Term/AliasesProvider.php
@@ -11,6 +11,8 @@ namespace Wikibase\DataModel\Term;
 interface AliasesProvider {
 
 	/**
+	 * It is not guaranteed that this method returns the original object.
+	 *
 	 * @return AliasGroupList
 	 */
 	public function getAliasGroups();

--- a/src/Term/AliasesProvider.php
+++ b/src/Term/AliasesProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 4.0
+ *
+ * @licence GNU GPL v2+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+interface AliasesProvider {
+
+	/**
+	 * @return AliasGroupList
+	 */
+	public function getAliases();
+
+}

--- a/src/Term/AliasesProvider.php
+++ b/src/Term/AliasesProvider.php
@@ -3,7 +3,7 @@
 namespace Wikibase\DataModel\Term;
 
 /**
- * @since 4.0
+ * @since 4.1
  *
  * @licence GNU GPL v2+
  * @author Bene* < benestar.wikimedia@gmail.com >
@@ -13,6 +13,6 @@ interface AliasesProvider {
 	/**
 	 * @return AliasGroupList
 	 */
-	public function getAliases();
+	public function getAliasGroups();
 
 }

--- a/src/Term/DescriptionsProvider.php
+++ b/src/Term/DescriptionsProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 4.0
+ *
+ * @licence GNU GPL v2+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+interface DescriptionsProvider {
+
+	/**
+	 * @return TermList
+	 */
+	public function getDescriptions();
+
+}

--- a/src/Term/DescriptionsProvider.php
+++ b/src/Term/DescriptionsProvider.php
@@ -11,6 +11,8 @@ namespace Wikibase\DataModel\Term;
 interface DescriptionsProvider {
 
 	/**
+	 * It is not guaranteed that this method returns the original object.
+	 *
 	 * @return TermList
 	 */
 	public function getDescriptions();

--- a/src/Term/DescriptionsProvider.php
+++ b/src/Term/DescriptionsProvider.php
@@ -3,7 +3,7 @@
 namespace Wikibase\DataModel\Term;
 
 /**
- * @since 4.0
+ * @since 4.1
  *
  * @licence GNU GPL v2+
  * @author Bene* < benestar.wikimedia@gmail.com >

--- a/src/Term/Fingerprint.php
+++ b/src/Term/Fingerprint.php
@@ -13,7 +13,7 @@ use OutOfBoundsException;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Mättig
  */
-class Fingerprint implements Comparable {
+class Fingerprint implements Comparable, LabelsProvider, DescriptionsProvider, AliasesProvider {
 
 	/**
 	 * @deprecated since 2.5, use new Fingerprint() instead.

--- a/src/Term/LabelsProvider.php
+++ b/src/Term/LabelsProvider.php
@@ -3,7 +3,7 @@
 namespace Wikibase\DataModel\Term;
 
 /**
- * @since 4.0
+ * @since 4.1
  *
  * @licence GNU GPL v2+
  * @author Bene* < benestar.wikimedia@gmail.com >

--- a/src/Term/LabelsProvider.php
+++ b/src/Term/LabelsProvider.php
@@ -11,6 +11,8 @@ namespace Wikibase\DataModel\Term;
 interface LabelsProvider {
 
 	/**
+	 * It is not guaranteed that this method returns the original object.
+	 *
 	 * @return TermList
 	 */
 	public function getLabels();

--- a/src/Term/LabelsProvider.php
+++ b/src/Term/LabelsProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 4.0
+ *
+ * @licence GNU GPL v2+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+interface LabelsProvider {
+
+	/**
+	 * @return TermList
+	 */
+	public function getLabels();
+
+}


### PR DESCRIPTION
The method names currently conflict with the ones defined in `Entity`. <s>We should consider renaming them to `getLabelList`, `getDescriptionList` and `getAliasList` and rename them again in the next breaking release (4.0).</s>