### PR TITLE
Alternative provider interfaces for labels, descriptions and aliases

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,7 @@
 ## Version 3.1 (dev)
 
 * Added `DerivedPropertyValueSnak`
+* Added `LabelsProvider`, `DescriptionsProvider` and `AliasesProvider`
 
 ## Version 3.0.1 (2015-07-01)
 

--- a/src/Term/AliasesProvider.php
+++ b/src/Term/AliasesProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 3.1
+ *
+ * @licence GNU GPL v2+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+interface AliasesProvider {
+
+	/**
+	 * @return AliasGroupList
+	 */
+	public function getAliasList();
+
+}

--- a/src/Term/DescriptionsProvider.php
+++ b/src/Term/DescriptionsProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 3.1
+ *
+ * @licence GNU GPL v2+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+interface DescriptionsProvider {
+
+	/**
+	 * @return TermList
+	 */
+	public function getDescriptionList();
+
+}

--- a/src/Term/LabelsProvider.php
+++ b/src/Term/LabelsProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 3.1
+ *
+ * @licence GNU GPL v2+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+interface LabelsProvider {
+
+	/**
+	 * @return TermList
+	 */
+	public function getLabelList();
+
+}


### PR DESCRIPTION
This is an alternative to #513 without creating breaking changes

If we decide to do it this way, we should rename the methods to `getLabels`, `getDescriptions` and `getAliases` in 4.0