### PR TITLE
Add deprecated tags to all Entity methods

### DIFF
--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -332,6 +332,7 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 * Returns a deep copy of the entity.
 	 *
 	 * @since 0.1
+	 * @deprecated since 1.0
 	 *
 	 * @return self
 	 */
@@ -380,6 +381,7 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 
 	/**
 	 * @since 0.7.3
+	 * @deprecated since 1.0
 	 *
 	 * @return Fingerprint
 	 */
@@ -389,6 +391,7 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 
 	/**
 	 * @since 0.7.3
+	 * @deprecated since 1.0
 	 *
 	 * @param Fingerprint $fingerprint
 	 */
@@ -401,6 +404,7 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 * Having an id set does not count as having content.
 	 *
 	 * @since 0.1
+	 * @deprecated since 1.0
 	 *
 	 * @return bool
 	 */
@@ -411,6 +415,7 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 * The id is not part of the content.
 	 *
 	 * @since 0.1
+	 * @deprecated since 1.0
 	 */
 	public abstract function clear();
 


### PR DESCRIPTION
This is an alternative "resubmission" of #512. Technically the additional deprecation tags are not needed because the class is already deprecated. But the individual tags make the deprecation much more obvious in IDEs, because the methods are highlighted as deprecated. They are not without these tags.

[Bug: T98290](https://phabricator.wikimedia.org/T98290)