### PR TITLE
Remove Entity::copy

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Wikibase DataModel release notes
 
+## Version 5.0 (dev)
+
+#### Breaking changes
+
+* Removed `Entity::copy`
+
 ## Version 4.0 (2015-07-28)
 
 #### Breaking changes

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -325,18 +325,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	}
 
 	/**
-	 * Returns a deep copy of the entity.
-	 *
-	 * @since 0.1
-	 * @deprecated since 1.0
-	 *
-	 * @return self
-	 */
-	public function copy() {
-		return unserialize( serialize( $this ) );
-	}
-
-	/**
 	 * @since 0.3
 	 * @deprecated since 1.0, use getStatements()->toArray() instead.
 	 *

--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -364,32 +364,6 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider instanceProvider
 	 * @param Entity $entity
 	 */
-	public function testCopy( Entity $entity ) {
-		$copy = $entity->copy();
-
-		// The equality method alone is not enough since it does not check the IDs.
-		$this->assertTrue( $entity->equals( $copy ) );
-		$this->assertEquals( $entity->getId(), $copy->getId() );
-
-		$this->assertFalse( $entity === $copy );
-	}
-
-	public function testCopyRetainsLabels() {
-		$item = new Item();
-
-		$item->getFingerprint()->setLabel( 'en', 'foo' );
-		$item->getFingerprint()->setLabel( 'de', 'bar' );
-
-		$newItem = unserialize( serialize( $item ) );
-
-		$this->assertTrue( $newItem->getFingerprint()->getLabels()->hasTermForLanguage( 'en' ) );
-		$this->assertTrue( $newItem->getFingerprint()->getLabels()->hasTermForLanguage( 'de' ) );
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 * @param Entity $entity
-	 */
 	public function testSerialize( Entity $entity ) {
 		$string = serialize( $entity );
 

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -80,7 +80,7 @@ class ItemTest extends EntityTest {
 		$items[] = $item;
 
 		/** @var Item $item */
-		$item = $item->copy();
+		$item = unserialize( serialize( $item ) );
 		$item->getStatements()->addNewStatement(
 			new PropertyNoValueSnak( new PropertyId( 'P42' ) )
 		);


### PR DESCRIPTION
Not used in Wikibase.git anymore, some usages in Wikibase DataModel Services left, which I'm going to remove as well.