### PR TITLE
Make constructor signature of DerivedPropertyValueSnak match parent

### DIFF
--- a/src/Snak/DerivedPropertyValueSnak.php
+++ b/src/Snak/DerivedPropertyValueSnak.php
@@ -34,12 +34,12 @@ class DerivedPropertyValueSnak extends PropertyValueSnak {
 	private $derivedDataValues = array();
 
 	/**
-	 * @param PropertyId $propertyId
+	 * @param PropertyId|EntityId|int $propertyId
 	 * @param DataValue $dataValue
 	 * @param DataValue[] $derivedDataValues
 	 */
 	public function __construct(
-		PropertyId $propertyId,
+		$propertyId,
 		DataValue $dataValue,
 		array $derivedDataValues
 	) {
@@ -72,6 +72,7 @@ class DerivedPropertyValueSnak extends PropertyValueSnak {
 		if ( isset( $this->derivedDataValues[$key] ) ) {
 			return $this->derivedDataValues[$key];
 		}
+
 		return null;
 	}
 

--- a/tests/unit/Snak/DerivedPropertyValueSnakTest.php
+++ b/tests/unit/Snak/DerivedPropertyValueSnakTest.php
@@ -42,6 +42,11 @@ class DerivedPropertyValueSnakTest extends PHPUnit_Framework_TestCase {
 				new StringValue( 'bc' ),
 				array( 'foo' => new StringValue( 'foo' ), 'bar' => new StringValue( 'bar' ) ),
 			),
+			'numeric id' => array(
+				42,
+				new StringValue( 'foo' ),
+				array()
+			)
 		);
 	}
 


### PR DESCRIPTION
This allows using the short constructor in tests etc.