### PR TITLE
Add FingerprintHolder interface

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,7 @@
 * Added `StatementList::filter`
 * Added `StatementFilter` and `ReferencedStatementFilter`
 * Added `LabelsProvider`, `DescriptionsProvider` and `AliasesProvider`
+* Added `FingerprintHolder`
 
 ## Version 4.0 (2015-07-28)
 

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -6,7 +6,7 @@ use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;
 use Wikibase\DataModel\Term\Fingerprint;
-use Wikibase\DataModel\Term\FingerprintProvider;
+use Wikibase\DataModel\Term\FingerprintHolder;
 use Wikibase\DataModel\Term\TermList;
 
 /**
@@ -19,7 +19,7 @@ use Wikibase\DataModel\Term\TermList;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-abstract class Entity implements \Comparable, FingerprintProvider, EntityDocument {
+abstract class Entity implements \Comparable, FingerprintHolder, EntityDocument {
 
 	/**
 	 * Sets the value for the label in a certain value.
@@ -323,14 +323,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	public function getClaims() {
 		return array();
 	}
-
-	/**
-	 * @since 0.7.3
-	 * @deprecated since 1.0
-	 *
-	 * @param Fingerprint $fingerprint
-	 */
-	public abstract function setFingerprint( Fingerprint $fingerprint );
 
 	/**
 	 * Returns if the Entity has no content.

--- a/src/Term/FingerprintHolder.php
+++ b/src/Term/FingerprintHolder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Wikibase\DataModel\Term;
+
+/**
+ * @since 4.1
+ *
+ * @licence GNU GPL v2+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+interface FingerprintHolder extends FingerprintProvider {
+
+	/**
+	 * @param Fingerprint $fingerprint
+	 */
+	public function setFingerprint( Fingerprint $fingerprint );
+
+}


### PR DESCRIPTION
This interface is the same as `StatementListHolder` for `StatementListProvider`. We might also consider to add the setter to `FingerprintProvider` itself but I guess the same argumentation as for `StatementListHolder` will happen and we should stay consistent here.