### PR TITLE
Remove misleading deprecation tag

### DIFF
--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -306,7 +306,6 @@ abstract class Entity implements \Comparable, FingerprintProvider, EntityDocumen
 	 * Returns a deep copy of the entity.
 	 *
 	 * @since 0.1
-	 * @deprecated since 1.0
 	 *
 	 * @return self
 	 */


### PR DESCRIPTION
While Entity is deprecated, usage of this method is not.
This is entirely valid, yet is now seen as deprecated:

```php
$item = new Item();
$item->copy();
```