### PR TITLE
Run coverage generation as part of the test command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
 	"scripts": {
 		"test": [
 			"composer validate --no-interaction",
-			"phpunit"
+			"phpunit --coverage-text=/dev/null"
 		],
 		"cs": [
 			"composer phpcs",


### PR DESCRIPTION
This is to detect incorrect @covers tags before the code gets to ScutinizerCI. We are already doing this at https://github.com/wmde/WikibaseDataModelServices/blob/master/composer.json

A better approach would be nice though, considering this slows down the execution of the test command by doing a lot of not needed work. Apparently this is not going to come from the PHPUnit side though, as per https://github.com/sebastianbergmann/phpunit/issues/1760