### PR TITLE
Stop using the Claim alias

### DIFF
--- a/src/Claim/Claims.php
+++ b/src/Claim/Claims.php
@@ -5,6 +5,7 @@ namespace Wikibase\DataModel\Claim;
 use ArrayObject;
 use InvalidArgumentException;
 use Traversable;
+use Wikibase\DataModel\Statement\Statement;
 
 /**
  * A claim (identified using it's GUID) can only be added once.
@@ -24,7 +25,7 @@ class Claims extends ArrayObject {
 	 * @since 0.3
 	 * @deprecated since 1.0, use StatementList instead.
 	 *
-	 * @param Claim[]|Traversable|null $input
+	 * @param Statement[]|Traversable|null $input
 	 *
 	 * @throws InvalidArgumentException
 	 */
@@ -58,12 +59,12 @@ class Claims extends ArrayObject {
 	}
 
 	/**
-	 * @param Claim $claim
+	 * @param Statement $claim
 	 *
 	 * @throws InvalidArgumentException
 	 * @return string
 	 */
-	private function getClaimKey( Claim $claim ) {
+	private function getClaimKey( Statement $claim ) {
 		$guid = $claim->getGuid();
 
 		if ( $guid === null ) {
@@ -78,11 +79,11 @@ class Claims extends ArrayObject {
 	 * @since 0.1
 	 * @deprecated since 1.0, use StatementList::addStatement() instead.
 	 *
-	 * @param Claim $claim
+	 * @param Statement $claim
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function addClaim( Claim $claim ) {
+	public function addClaim( Statement $claim ) {
 		if ( func_num_args() > 1 ) {
 			throw new InvalidArgumentException( '$index is not supported any more' );
 		}
@@ -120,7 +121,7 @@ class Claims extends ArrayObject {
 	 *
 	 * @param string $claimGuid
 	 *
-	 * @return Claim|null
+	 * @return Statement|null
 	 */
 	public function getClaimWithGuid( $claimGuid ) {
 		if ( $this->offsetExists( $claimGuid ) ) {
@@ -151,7 +152,7 @@ class Claims extends ArrayObject {
 	 *
 	 * @param string $guid
 	 *
-	 * @return Claim
+	 * @return Statement
 	 *
 	 * @throws InvalidArgumentException
 	 */
@@ -165,13 +166,13 @@ class Claims extends ArrayObject {
 	 * @deprecated since 1.0, should never be called.
 	 *
 	 * @param string $guid
-	 * @param Claim $claim
+	 * @param Statement $claim
 	 *
 	 * @throws InvalidArgumentException
 	 */
 	public function offsetSet( $guid, $claim ) {
-		if ( !( $claim instanceof Claim ) ) {
-			throw new InvalidArgumentException( '$claim must be an instance of Claim' );
+		if ( !( $claim instanceof Statement ) ) {
+			throw new InvalidArgumentException( '$claim must be an instance of Statement' );
 		}
 
 		$claimKey = $this->getClaimKey( $claim );


### PR DESCRIPTION
In production Claim is an alias, so there is no real difference between Claim and Statement. But the IDE and certain tools think Claim is a subclass of Statement because of Aliases.php. All code using the deprecated Claims class calls it with Statement objects, not with Claim objects. The tools think we are passing a superclass when only a subclass is allowed.

This is the most minimal fix to avoid these warnings.