### PR TITLE
Revert to use non-deprecated Item::copy and Property::copy

### DIFF
--- a/tests/unit/Entity/EntityTest.php
+++ b/tests/unit/Entity/EntityTest.php
@@ -377,7 +377,7 @@ abstract class EntityTest extends \PHPUnit_Framework_TestCase {
 		$item->getFingerprint()->setLabel( 'en', 'foo' );
 		$item->getFingerprint()->setLabel( 'de', 'bar' );
 
-		$newItem = unserialize( serialize( $item ) );
+		$newItem = $item->copy();
 
 		$this->assertTrue( $newItem->getFingerprint()->getLabels()->hasTermForLanguage( 'en' ) );
 		$this->assertTrue( $newItem->getFingerprint()->getLabels()->hasTermForLanguage( 'de' ) );

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -344,10 +344,10 @@ class ItemTest extends EntityTest {
 		$secondItem = new Item();
 		$secondItem->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
 
-		$secondItemWithId = unserialize( serialize( $secondItem ) );
+		$secondItemWithId = $secondItem->copy();
 		$secondItemWithId->setId( 42 );
 
-		$differentId = unserialize( serialize( $secondItemWithId ) );
+		$differentId = $secondItemWithId->copy();
 		$differentId->setId( 43 );
 
 		return array(

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -158,10 +158,10 @@ class PropertyTest extends EntityTest {
 		$secondProperty = Property::newFromType( 'string' );
 		$secondProperty->setStatements( $this->newNonEmptyStatementList() );
 
-		$secondPropertyWithId = unserialize( serialize( $secondProperty ) );
+		$secondPropertyWithId = $secondProperty->copy();
 		$secondPropertyWithId->setId( 42 );
 
-		$differentId = unserialize( serialize( $secondPropertyWithId ) );
+		$differentId = $secondPropertyWithId->copy();
 		$differentId->setId( 43 );
 
 		return array(


### PR DESCRIPTION
This reverts parts of https://gerrit.wikimedia.org/r/#/c/222978/. See https://github.com/wmde/WikibaseDataModel/pull/531 for arguments. In short: Yes, `Entity` is deprecated and calls to `Entity::copy` should not be called. But `Item::copy` and `Property::copy` are **not** deprecated.