### PR TITLE
More specific @param ArrayIterator PHPDocs

### DIFF
--- a/src/Entity/ItemIdSet.php
+++ b/src/Entity/ItemIdSet.php
@@ -7,7 +7,6 @@ use Comparable;
 use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
-use Traversable;
 
 /**
  * Immutable set of ItemId objects. Unordered and unique.
@@ -52,7 +51,7 @@ class ItemIdSet implements IteratorAggregate, Countable, Comparable {
 	/**
 	 * @see IteratorAggregate::getIterator
 	 *
-	 * @return Traversable|ItemId[]
+	 * @return ArrayIterator|ItemId[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->ids );

--- a/src/SiteLinkList.php
+++ b/src/SiteLinkList.php
@@ -99,7 +99,7 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	 *
 	 * Returns a Traversable of SiteLink in which the keys are the site ids.
 	 *
-	 * @return Traversable|SiteLink[]
+	 * @return ArrayIterator|SiteLink[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->siteLinks );

--- a/src/Statement/StatementByGuidMap.php
+++ b/src/Statement/StatementByGuidMap.php
@@ -107,7 +107,7 @@ class StatementByGuidMap implements IteratorAggregate, Countable {
 	 * The iterator has the GUIDs of the statements as keys.
 	 *
 	 * @see IteratorAggregate::getIterator
-	 * @return Traversable|Statement[]
+	 * @return ArrayIterator|Statement[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->statements );

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -224,7 +224,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	/**
-	 * @return Traversable|Statement[]
+	 * @return ArrayIterator|Statement[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->statements );

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -7,7 +7,6 @@ use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
 use OutOfBoundsException;
-use Traversable;
 
 /**
  * Unordered list of AliasGroup objects.
@@ -52,7 +51,7 @@ class AliasGroupList implements Countable, IteratorAggregate {
 
 	/**
 	 * @see IteratorAggregate::getIterator
-	 * @return Traversable|AliasGroup[]
+	 * @return ArrayIterator|AliasGroup[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->groups );

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -8,7 +8,6 @@ use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
 use OutOfBoundsException;
-use Traversable;
 
 /**
  * Unordered list of Term objects.
@@ -65,7 +64,7 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 
 	/**
 	 * @see IteratorAggregate::getIterator
-	 * @return Traversable|Term[]
+	 * @return ArrayIterator|Term[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->terms );


### PR DESCRIPTION
`getIterator` comes from the `IteratorAggregate` interface. It is documented as `@return Traversable` there. The most simple thing is to copy-paste this line. *But* why not be honest and use the *actual* type? These classes are *guaranteed* to return this type.