### PR TITLE
Add workaround type hints to getIterator implementations

### DIFF
--- a/src/Entity/ItemIdSet.php
+++ b/src/Entity/ItemIdSet.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Entity;
 
+use ArrayIterator;
 use Comparable;
 use Countable;
 use InvalidArgumentException;
@@ -51,10 +52,10 @@ class ItemIdSet implements IteratorAggregate, Countable, Comparable {
 	/**
 	 * @see IteratorAggregate::getIterator
 	 *
-	 * @return Traversable
+	 * @return Traversable|ItemId[]
 	 */
 	public function getIterator() {
-		return new \ArrayIterator( $this->ids );
+		return new ArrayIterator( $this->ids );
 	}
 
 	/**

--- a/src/Statement/StatementByGuidMap.php
+++ b/src/Statement/StatementByGuidMap.php
@@ -23,6 +23,9 @@ use Traversable;
  */
 class StatementByGuidMap implements IteratorAggregate, Countable {
 
+	/**
+	 * @var Statement[]
+	 */
 	private $statements = array();
 
 	/**
@@ -104,7 +107,7 @@ class StatementByGuidMap implements IteratorAggregate, Countable {
 	 * The iterator has the GUIDs of the statements as keys.
 	 *
 	 * @see IteratorAggregate::getIterator
-	 * @return Traversable
+	 * @return Traversable|Statement[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->statements );

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -224,7 +224,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	/**
-	 * @return Traversable
+	 * @return Traversable|Statement[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->statements );

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Term;
 
+use ArrayIterator;
 use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
@@ -51,10 +52,10 @@ class AliasGroupList implements Countable, IteratorAggregate {
 
 	/**
 	 * @see IteratorAggregate::getIterator
-	 * @return Traversable
+	 * @return Traversable|AliasGroup[]
 	 */
 	public function getIterator() {
-		return new \ArrayIterator( $this->groups );
+		return new ArrayIterator( $this->groups );
 	}
 
 	/**

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Term;
 
+use ArrayIterator;
 use Comparable;
 use Countable;
 use InvalidArgumentException;
@@ -64,10 +65,10 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 
 	/**
 	 * @see IteratorAggregate::getIterator
-	 * @return Traversable
+	 * @return Traversable|Term[]
 	 */
 	public function getIterator() {
-		return new \ArrayIterator( $this->terms );
+		return new ArrayIterator( $this->terms );
 	}
 
 	/**


### PR DESCRIPTION
Note that we already did this in https://github.com/wmde/WikibaseDataModel/blob/master/src/SiteLinkList.php#L102. The "perfect" type hint would be `Traversable<ItemId>`, but PHP does not support this and IDEs don't understand it and get confused. The combination of `Traversable|ItemId[]` is a workaround to help IDEs understand what type the elements in a foreach loop are.