### PR TITLE
Use the composer cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,7 @@ notifications:
     on_failure: always
     template:
       - "%{repository}/%{branch}/%{commit} : %{author} %{message} %{build_url}"
+
+cache:
+  directories:
+    - $HOME/.composer/cache


### PR DESCRIPTION
See http://docs.travis-ci.com/user/caching/

> The cache’s purpose is to make installing language-specific dependencies easy and fast, so everything related to tools like Bundler, pip, Composer, npm, Gradle, Maven, is what should go into the cache.