### PR TITLE
Use tarballs rather than clones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
 
 sudo: false
 
-install: travis_retry composer install --prefer-source
+install: travis_retry composer install
 
 script: composer ci
 


### PR DESCRIPTION
They are faster, esp now we are using the cache. Originally we switched to clones since the tarballs failed sometimes, though this should already be mitigated by us now using `travis_retry`