### PR TITLE
Replace Claims with ArrayObject in tests

### DIFF
--- a/tests/unit/ByPropertyIdArrayTest.php
+++ b/tests/unit/ByPropertyIdArrayTest.php
@@ -2,11 +2,11 @@
 
 namespace Wikibase\DataModel\Tests;
 
+use ArrayObject;
 use DataValues\StringValue;
 use ReflectionClass;
 use ReflectionMethod;
 use Wikibase\DataModel\ByPropertyIdArray;
-use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
@@ -33,10 +33,10 @@ class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
 		$statement2 = new Statement( new PropertyNoValueSnak( 2 ) );
 		$statement2->setGuid( '2' );
 
-		$claims = new Claims();
-		$claims->append( $statement1 );
+		$object = new ArrayObject();
+		$object->append( $statement1 );
 
-		$byPropertyIdArray = new ByPropertyIdArray( $claims );
+		$byPropertyIdArray = new ByPropertyIdArray( $object );
 		// According to the documentation append() "cannot be called when the ArrayObject was
 		// constructed from an object." This test makes sure it was not constructed from an object.
 		$byPropertyIdArray->append( $statement2 );

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -2,8 +2,8 @@
 
 namespace Wikibase\DataModel\Tests\Statement;
 
+use ArrayObject;
 use DataValues\StringValue;
-use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\ReferenceList;
@@ -280,15 +280,14 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( new StatementList( $statement1 ), $list );
 	}
 
-	public function testCanConstructWithClaimsObjectContainingOnlyStatements() {
+	public function testCanConstructWithTraversableContainingOnlyStatements() {
 		$statementArray = array(
 			$this->getStatementWithSnak( 1, 'foo' ),
 			$this->getStatementWithSnak( 2, 'bar' ),
 		);
 
-		$claimsObject = new Claims( $statementArray );
-
-		$list = new StatementList( $claimsObject );
+		$object = new ArrayObject( $statementArray );
+		$list = new StatementList( $object );
 
 		$this->assertEquals(
 			$statementArray,


### PR DESCRIPTION
These are the only remaining usages of the Claims class (besides `Item::setClaims` and `Property::setClaims`). I'm aware that these classes are also touched in other patches. The difference is that this patch here is non-breaking. I will rebase the other patches when this is merged.

[Bug: T78281](https://phabricator.wikimedia.org/T78281)