### PR TITLE
Add ReferenceList::isEmpty

### DIFF
--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -241,4 +241,11 @@ class ReferenceList extends HashableObjectStorage {
 		$this->__construct( unserialize( $data ) );
 	}
 
+	/**
+	 * @return bool
+	 */
+	public function isEmpty() {
+		return $this->count() === 0;
+	}
+
 }

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -351,4 +351,26 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $references->equals( unserialize( $serialized ) ) );
 	}
 
+	public function testGivenEmptyList_isEmpty() {
+		$references = new ReferenceList();
+		$this->assertTrue( $references->isEmpty() );
+	}
+
+	public function testGivenNonEmptyList_isNotEmpty() {
+		$references = new ReferenceList();
+		$references->addNewReference( new PropertyNoValueSnak( 1 ) );
+
+		$this->assertFalse( $references->isEmpty() );
+	}
+
+	public function testGivenNonEmptyListWithForwardedIterator_isNotEmpty() {
+		$references = new ReferenceList();
+		$references->addNewReference( new PropertyNoValueSnak( 1 ) );
+		$references->next();
+
+		$this->assertFalse( $references->valid(), 'post condition' );
+		$this->assertFalse( $references->isEmpty() );
+		$this->assertFalse( $references->valid(), 'pre condition' );
+	}
+
 }


### PR DESCRIPTION
Motivated by https://gerrit.wikimedia.org/r/#/c/242084/1/view/src/ClaimHtmlGenerator.php.

The second test with the iterator stuff is because an other valid implementation of an isEmpty method could use `!$this->valid()` (this is done in the HashArray class) but would reset the iterator.