### PR TITLE
Switch to MediaWiki code sniffer 0.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,10 @@
 		"wikimedia/assert": "~0.2.2"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~4.8",
+		"mediawiki/mediawiki-codesniffer": "~0.7.0",
 		"ockcyp/covers-validator": "~0.4.0",
-		"squizlabs/php_codesniffer": "~2.3",
-		"phpmd/phpmd": "~2.3"
+		"phpmd/phpmd": "~2.3",
+		"phpunit/phpunit": "~4.8"
 	},
 	"autoload": {
 		"files" : [

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,19 +1,14 @@
 <?xml version="1.0"?>
-<!--
-	- https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
-	- https://github.com/squizlabs/PHP_CodeSniffer/tree/master/CodeSniffer/Standards
--->
 <ruleset name="WikibaseDataModel">
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
+    <!-- See https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml -->
+    <rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+        <exclude name="MediaWiki.ControlStructures.IfElseStructure" />
+        <exclude name="PSR2.Methods.MethodDeclaration.AbstractAfterVisibility" />
+    </rule>
 
-    <rule ref="Generic.Classes" />
     <rule ref="Generic.CodeAnalysis" />
-    <rule ref="Generic.ControlStructures" />
 
-    <rule ref="Generic.Files.ByteOrderMark" />
-    <rule ref="Generic.Files.EndFileNewline" />
     <rule ref="Generic.Files.InlineHTML" />
-    <rule ref="Generic.Files.LineEndings" />
     <rule ref="Generic.Files.LineLength">
         <properties>
             <property name="lineLimit" value="125" />
@@ -23,12 +18,6 @@
     <rule ref="Generic.Files.OneClassPerFile" />
     <rule ref="Generic.Files.OneInterfacePerFile" />
     <rule ref="Generic.Files.OneTraitPerFile" />
-
-    <rule ref="Generic.Formatting.DisallowMultipleStatements" />
-
-    <rule ref="Generic.Functions.CallTimePassByReference" />
-    <rule ref="Generic.Functions.FunctionCallArgumentSpacing" />
-    <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
 
     <rule ref="Generic.Metrics.CyclomaticComplexity">
         <properties>
@@ -48,15 +37,6 @@
     </rule>
 
     <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag" />
-    <rule ref="Generic.PHP.DeprecatedFunctions" />
-    <rule ref="Generic.PHP.DisallowShortOpenTag" />
-    <rule ref="Generic.PHP.ForbiddenFunctions" />
-    <rule ref="Generic.PHP.LowerCaseConstant" />
-    <rule ref="Generic.PHP.LowerCaseKeyword" />
-    <rule ref="Generic.PHP.NoSilencedErrors" />
-    <rule ref="Generic.PHP.SAPIUsage" />
-
-    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent" />
 
     <rule ref="PSR1" />
     <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
@@ -64,16 +44,11 @@
         <exclude-pattern>tests.unit*Test\.php</exclude-pattern>
     </rule>
 
-    <rule ref="PSR2.Classes.PropertyDeclaration" />
-    <rule ref="PSR2.ControlStructures.ElseIfDeclaration" />
     <rule ref="PSR2.Files" />
-    <rule ref="PSR2.Namespaces" />
 
     <rule ref="Squiz.Arrays.ArrayBracketSpacing" />
-    <rule ref="Squiz.CSS.SemicolonSpacing" />
     <rule ref="Squiz.Classes.DuplicateProperty" />
     <rule ref="Squiz.Classes.SelfMemberReference" />
-    <rule ref="Squiz.Classes.ValidClassName" />
     <rule ref="Squiz.Functions.FunctionDuplicateArgument" />
     <rule ref="Squiz.Functions.GlobalFunction" />
     <rule ref="Squiz.Scope" />
@@ -83,8 +58,6 @@
     </rule>
 
     <rule ref="Squiz.WhiteSpace.CastSpacing" />
-    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing" />
-    <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing" />
     <rule ref="Squiz.WhiteSpace.FunctionSpacing">
         <properties>
             <property name="spacing" value="1" />
@@ -95,10 +68,4 @@
             <property name="ignoreNewlines" value="true" />
         </properties>
     </rule>
-    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace" />
-    <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing" />
-    <rule ref="Squiz.WhiteSpace.SemicolonSpacing" />
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace" />
-
-    <rule ref="Zend.Files.ClosingTag" />
 </ruleset>


### PR DESCRIPTION
- I switched from PHP code sniffer to the most recent MediaWiki code sniffer 0.7.0.
- I removed all rules that are already enabled by default in the MediaWiki rule set.

Note that this is not a cosmetic patch. This enables a series of additional sniffs that only exist in the MediaWiki rule set and are currently not tested in this code repository.