### PR TITLE
Rename PHPCS rule set to WikibaseDataModel

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,7 +3,7 @@
 	- https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
 	- https://github.com/squizlabs/PHP_CodeSniffer/tree/master/CodeSniffer/Standards
 -->
-<ruleset name="MediaWiki">
+<ruleset name="WikibaseDataModel">
     <rule ref="Generic.Classes" />
     <rule ref="Generic.CodeAnalysis" />
     <rule ref="Generic.ControlStructures" />


### PR DESCRIPTION
This is not the MediaWiki rule set, right?

This is split from #565.