### PR TITLE
Avoid full qualified class names

### DIFF
--- a/src/ByPropertyIdArray.php
+++ b/src/ByPropertyIdArray.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel;
 
+use ArrayObject;
 use OutOfBoundsException;
 use RuntimeException;
 use Wikibase\DataModel\Entity\PropertyId;
@@ -40,7 +41,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  * @licence GNU GPL v2+
  * @author H. Snater < mediawiki@snater.com >
  */
-class ByPropertyIdArray extends \ArrayObject {
+class ByPropertyIdArray extends ArrayObject {
 
 	/**
 	 * @var array[]|null
@@ -48,7 +49,7 @@ class ByPropertyIdArray extends \ArrayObject {
 	private $byId = null;
 
 	/**
-	 * @see \ArrayObject::__construct
+	 * @see ArrayObject::__construct
 	 *
 	 * @param array|object $input
 	 */

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Entity;
 
+use Comparable;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;
@@ -18,7 +19,7 @@ use Wikibase\DataModel\Term\TermList;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-abstract class Entity implements \Comparable, FingerprintHolder, EntityDocument {
+abstract class Entity implements Comparable, FingerprintHolder, EntityDocument {
 
 	/**
 	 * Sets the value for the label in a certain value.

--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -2,6 +2,9 @@
 
 namespace Wikibase\DataModel\Entity;
 
+use Comparable;
+use Serializable;
+
 /**
  * @since 0.5
  * Constructor non-public since 1.0
@@ -10,7 +13,7 @@ namespace Wikibase\DataModel\Entity;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com
  */
-abstract class EntityId implements \Comparable, \Serializable {
+abstract class EntityId implements Comparable, Serializable {
 
 	protected $serialization;
 

--- a/src/Entity/EntityIdParsingException.php
+++ b/src/Entity/EntityIdParsingException.php
@@ -2,12 +2,14 @@
 
 namespace Wikibase\DataModel\Entity;
 
+use RuntimeException;
+
 /**
  * @since 4.2
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class EntityIdParsingException extends \RuntimeException {
+class EntityIdParsingException extends RuntimeException {
 
 }

--- a/src/Entity/EntityIdValue.php
+++ b/src/Entity/EntityIdValue.php
@@ -155,8 +155,7 @@ class EntityIdValue extends DataValueObject {
 				$data['entity-type'],
 				$data['numeric-id']
 			);
-		}
-		catch ( \InvalidArgumentException $ex ) {
+		} catch ( InvalidArgumentException $ex ) {
 			throw new IllegalValueException( $ex->getMessage(), 0, $ex );
 		}
 

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -88,12 +88,11 @@ class Item extends Entity implements StatementListHolder {
 	public function setId( $id ) {
 		if ( $id === null || $id instanceof ItemId ) {
 			$this->id = $id;
-		}
-		elseif ( is_integer( $id ) ) {
+		} elseif ( is_int( $id ) ) {
 			$this->id = ItemId::newFromNumber( $id );
-		}
-		else {
-			throw new InvalidArgumentException( '$id must be an instance of ItemId, an integer, or null' );
+		} else {
+			throw new InvalidArgumentException( '$id must be an instance of ItemId, an integer,'
+				. ' or null' );
 		}
 	}
 

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -85,12 +85,11 @@ class Property extends Entity implements StatementListHolder {
 	public function setId( $id ) {
 		if ( $id === null || $id instanceof PropertyId ) {
 			$this->id = $id;
-		}
-		elseif ( is_integer( $id ) ) {
+		} elseif ( is_int( $id ) ) {
 			$this->id = PropertyId::newFromNumber( $id );
-		}
-		else {
-			throw new InvalidArgumentException( '$id must be an instance of PropertyId, an integer, or null' );
+		} else {
+			throw new InvalidArgumentException( '$id must be an instance of PropertyId, an integer,'
+				. ' or null' );
 		}
 	}
 

--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -2,6 +2,8 @@
 
 namespace Wikibase\DataModel;
 
+use ArrayObject;
+use Comparable;
 use Hashable;
 use InvalidArgumentException;
 use Traversable;
@@ -31,7 +33,7 @@ use Wikibase\DataModel\Internal\MapValueHasher;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-abstract class HashArray extends \ArrayObject implements \Hashable, \Comparable {
+abstract class HashArray extends ArrayObject implements Hashable, Comparable {
 
 	/**
 	 * Maps element hashes to their offsets.

--- a/src/HashableObjectStorage.php
+++ b/src/HashableObjectStorage.php
@@ -2,7 +2,9 @@
 
 namespace Wikibase\DataModel;
 
+use Comparable;
 use Hashable;
+use SplObjectStorage;
 use Wikibase\DataModel\Internal\MapValueHasher;
 
 /**
@@ -18,7 +20,7 @@ use Wikibase\DataModel\Internal\MapValueHasher;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class HashableObjectStorage extends \SplObjectStorage implements \Comparable {
+class HashableObjectStorage extends SplObjectStorage implements Comparable {
 
 	/**
 	 * @since 0.2

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -2,6 +2,10 @@
 
 namespace Wikibase\DataModel;
 
+use Comparable;
+use Countable;
+use Hashable;
+use Immutable;
 use InvalidArgumentException;
 use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Snak\SnakList;
@@ -15,7 +19,7 @@ use Wikibase\DataModel\Snak\SnakList;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class Reference implements \Hashable, \Comparable, \Immutable, \Countable {
+class Reference implements Hashable, Comparable, Immutable, Countable {
 
 	/**
 	 * @var SnakList

--- a/src/Snak/SnakObject.php
+++ b/src/Snak/SnakObject.php
@@ -36,11 +36,11 @@ abstract class SnakObject implements Snak {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $propertyId ) {
-		if ( is_integer( $propertyId ) ) {
+		if ( is_int( $propertyId ) ) {
 			$propertyId = PropertyId::newFromNumber( $propertyId );
 		}
 
-		if ( !$propertyId instanceof EntityId ) {
+		if ( !( $propertyId instanceof EntityId ) ) {
 			throw new InvalidArgumentException( '$propertyId must be an instance of EntityId' );
 		}
 

--- a/src/Statement/StatementGuid.php
+++ b/src/Statement/StatementGuid.php
@@ -29,7 +29,7 @@ class StatementGuid implements Comparable {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $entityId, $guid ) {
-		if ( !$entityId instanceof EntityId ) {
+		if ( !( $entityId instanceof EntityId ) ) {
 			throw new InvalidArgumentException( '$entityId must be an instance of EntityId' );
 		}
 		if ( !is_string( $guid ) ) {

--- a/tests/fixtures/HashableObject.php
+++ b/tests/fixtures/HashableObject.php
@@ -2,11 +2,13 @@
 
 namespace Wikibase\DataModel\Fixtures;
 
+use Hashable;
+
 /**
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class HashableObject implements \Hashable {
+class HashableObject implements Hashable {
 
 	protected $var;
 

--- a/tests/unit/Internal/MapValueHasherTest.php
+++ b/tests/unit/Internal/MapValueHasherTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Tests\Internal;
 
+use ArrayObject;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Internal\MapValueHasher;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
@@ -40,7 +41,7 @@ class MapValueHasherTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals( $hash, $hasher->hash( $map1 ) );
 
-		$map4 = new \ArrayObject( $map0 );
+		$map4 = new ArrayObject( $map0 );
 		$this->assertEquals( $hash, $hasher->hash( $map4 ) );
 
 		$map2 = $map0;

--- a/tests/unit/Statement/StatementByGuidMapTest.php
+++ b/tests/unit/Statement/StatementByGuidMapTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Tests\Statement;
 
+use ArrayObject;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementByGuidMap;
@@ -116,12 +117,12 @@ class StatementByGuidMapTest extends \PHPUnit_Framework_TestCase {
 		) );
 	}
 
-	public function testCanConstructWithStatementIterable() {
-		$statementList = new \ArrayObject( array(
+	public function testCanConstructWithStatementTraversable() {
+		$traversable = new ArrayObject( array(
 			$this->newStatement( 1, 'some guid' )
 		) );
 
-		$statementMap = new StatementByGuidMap( $statementList );
+		$statementMap = new StatementByGuidMap( $traversable );
 
 		$this->assertTrue( $statementMap->hasStatementWithGuid( 'some guid' ) );
 	}

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -296,7 +296,7 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenTraversableWithNonStatements_constructorThrowsException() {
-		$traversable = new \ArrayObject( array(
+		$traversable = new ArrayObject( array(
 			$this->getStatementWithSnak( 1, 'foo' ),
 			new \stdClass(),
 			$this->getStatementWithSnak( 2, 'bar' ),


### PR DESCRIPTION
This patch was motivated by the removal of the last remaining full qualified class names. In addition, I included a few minor code style clean ups:
* Avoid the alias `is_integer`.
* Prefer `!( $var instanceof Class )` with brackets.
* Split long lines.