### PR TITLE
Remove all @SuppressWarnings tags

### DIFF
--- a/phpmd.xml
+++ b/phpmd.xml
@@ -11,6 +11,7 @@
     <rule ref="rulesets/codesize.xml/TooManyPublicMethods">
         <properties>
             <property name="ignorepattern" value="(^(set|get|test))i" />
+            <property name="maxmethods" value="16" />
         </properties>
     </rule>
 

--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -28,7 +28,6 @@ use Wikibase\DataModel\Internal\MapValueHasher;
  * the first such element.
  *
  * @since 0.1
- * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -17,7 +17,6 @@ use Wikibase\DataModel\Snak\Snak;
  *
  * @since 0.1
  * Does not implement References anymore since 2.0
- * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >


### PR DESCRIPTION
I strongly believe that such tags are a code smell that's worse than the benefit of the partly suppressed check. If the TooManyPublicMethods count is to high, either increase it or add exclude-pattern lines to the phpmd.xml file.