### PR TITLE
Use current lower limits for PHPCS and MD

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,7 @@
 
 	<rule ref="Generic.Files.LineLength">
 		<properties>
-			<property name="lineLimit" value="120" />
+			<property name="lineLimit" value="116" />
 		</properties>
 	</rule>
 

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -8,10 +8,15 @@
         <exclude name="ExcessiveClassComplexity" />
         <exclude name="TooManyPublicMethods" />
     </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
+        <properties>
+            <property name="maximum" value="57" />
+        </properties>
+    </rule>
     <rule ref="rulesets/codesize.xml/TooManyPublicMethods">
         <properties>
             <property name="ignorepattern" value="(^(set|get|test))i" />
-            <property name="maxmethods" value="16" />
+            <property name="maxmethods" value="14" />
         </properties>
     </rule>
 


### PR DESCRIPTION
This uses the current limits of the actual code base for all numeric PHPCS and PHPMD rules. This does have two effects. First, now the rule sets reflect the actual state of the code.

Second, whenever a commit introduces code that's more complex than what's currently in this component, we will be aware of that. In most cases we will simply raise the limit in the same commit. So this is not about blocking such commits. It should be allowed to raise these limits if it makes sense. This is about awareness.

Also see https://github.com/wmde/WikibaseDataModelServices/pull/101.
