### PR TITLE
Cleanup phpcs.xml file

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -28,17 +28,14 @@
     <rule ref="Generic.Functions.FunctionCallArgumentSpacing" />
     <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
 
-    <rule ref="Generic.Metrics.NestingLevel">
-        <properties>
-            <property name="nestingLevel" value="3" />
-            <property name="absoluteNestingLevel" value="3" />
-        </properties>
-    </rule>
-
     <rule ref="Generic.Metrics.CyclomaticComplexity">
         <properties>
             <property name="complexity" value="10" />
-            <property name="absoluteComplexity" value="10" />
+        </properties>
+    </rule>
+    <rule ref="Generic.Metrics.NestingLevel">
+        <properties>
+            <property name="nestingLevel" value="3" />
         </properties>
     </rule>
 
@@ -79,9 +76,8 @@
     <rule ref="Squiz.Functions.GlobalFunction" />
     <rule ref="Squiz.Scope" />
 
-    <rule ref="Squiz.Strings.DoubleQuoteUsage" />
-    <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
-        <severity>0</severity>
+    <rule ref="Squiz.Strings.DoubleQuoteUsage">
+        <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar" />
     </rule>
 
     <rule ref="Squiz.WhiteSpace.CastSpacing" />


### PR DESCRIPTION
The changes in this patch are for ease and consistency in the phpcs.xml file, but do not change the actual rules.
* Remove not needed "absolute" lines. These lines do not add anything because we are reporting warnings as errors anyway.
* Swap the two metrics rules so they are in alphabetic order.
* Use exclude instead of setting severity to 0. See https://gerrit.wikimedia.org/r/260731 for an explanation.