### PR TITLE
Do not allow self-redirects

### DIFF
--- a/src/Entity/EntityRedirect.php
+++ b/src/Entity/EntityRedirect.php
@@ -37,6 +37,10 @@ class EntityRedirect {
 			);
 		}
 
+		if ( $entityId->equals( $targetId ) ) {
+			throw new InvalidArgumentException( 'An entity can not redirect to itself' );
+		}
+
 		$this->entityId = $entityId;
 		$this->targetId = $targetId;
 	}

--- a/tests/unit/Entity/EntityRedirectTest.php
+++ b/tests/unit/Entity/EntityRedirectTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Tests\Entity;
 
+use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\EntityRedirect;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\PropertyId;
@@ -34,6 +35,23 @@ class EntityRedirectTest extends \PHPUnit_Framework_TestCase {
 		$targetId = new PropertyId( 'P345' );
 
 		new EntityRedirect( $entityId, $targetId );
+	}
+
+	/**
+	 * @dataProvider selfRedirectProvider
+	 */
+	public function testConstruction_selfRedirect( EntityId $entityId, EntityId $targetId ) {
+		$this->setExpectedException( 'InvalidArgumentException' );
+		new EntityRedirect( $entityId, $targetId );
+	}
+
+	public function selfRedirectProvider() {
+		$entityId = new ItemId( 'Q1' );
+
+		return array(
+			'same object' => array( $entityId, $entityId ),
+			'different objects' => array( $entityId, new ItemId( 'Q1' ) ),
+		);
 	}
 
 	public function equalsProvider() {


### PR DESCRIPTION
I consider this a bug. But note that this is a pretty critical breaking change too. We must make sure no self-redirect exists before we deploy this on wikidata.org. Otherwise bad things happen, the worst being that you can not even revert edits that turned an entity into a self-redirect.