### PR TITLE
More tests for ItemId/PropertyId::unserialize

### DIFF
--- a/tests/unit/Entity/ItemIdTest.php
+++ b/tests/unit/Entity/ItemIdTest.php
@@ -84,10 +84,27 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame( '["item","Q1"]', $id->serialize() );
 	}
 
-	public function testUnserialize() {
+	/**
+	 * @dataProvider serializationProvider
+	 */
+	public function testUnserialize( $json, $expected ) {
 		$id = new ItemId( 'Q1' );
-		$id->unserialize( '["item","Q2"]' );
-		$this->assertSame( 'Q2', $id->getSerialization() );
+		$id->unserialize( $json );
+		$this->assertSame( $expected, $id->getSerialization() );
+	}
+
+	public function serializationProvider() {
+		return array(
+			array( '["item","Q2"]', 'Q2' ),
+
+			// All these cases are kind of an injection vector and allow constructing invalid ids.
+			array( '["string","Q2"]', 'Q2' ),
+			array( '["","string"]', 'string' ),
+			array( '["",""]', '' ),
+			array( '["",2]', 2 ),
+			array( '["",null]', null ),
+			array( '', null ),
+		);
 	}
 
 	/**

--- a/tests/unit/Entity/PropertyIdTest.php
+++ b/tests/unit/Entity/PropertyIdTest.php
@@ -84,10 +84,27 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame( '["property","P1"]', $id->serialize() );
 	}
 
-	public function testUnserialize() {
+	/**
+	 * @dataProvider serializationProvider
+	 */
+	public function testUnserialize( $json, $expected ) {
 		$id = new PropertyId( 'P1' );
-		$id->unserialize( '["property","P2"]' );
-		$this->assertSame( 'P2', $id->getSerialization() );
+		$id->unserialize( $json );
+		$this->assertSame( $expected, $id->getSerialization() );
+	}
+
+	public function serializationProvider() {
+		return array(
+			array( '["property","P2"]', 'P2' ),
+
+			// All these cases are kind of an injection vector and allow constructing invalid ids.
+			array( '["string","P2"]', 'P2' ),
+			array( '["","string"]', 'string' ),
+			array( '["",""]', '' ),
+			array( '["",2]', 2 ),
+			array( '["",null]', null ),
+			array( '', null ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
I find it odd that this method can be misused to inject unsupported stuff into the object. But I do not think this is relevant. As far as I know we are not using this code in production.

I'm adding tests to make this behaviour more obvious. If you think this should be fixed somehow, please tell me, and I will create an other patch. However, please merge this patch as it is because this here does not count as a change, while an actual fix will be a breaking change.