### PR TITLE
Simplify ReferenceList::unserialize

### DIFF
--- a/src/Entity/EntityIdValue.php
+++ b/src/Entity/EntityIdValue.php
@@ -52,12 +52,12 @@ class EntityIdValue extends DataValueObject {
 	 *
 	 * @since 0.5
 	 *
-	 * @param string $value
+	 * @param string $serialized
 	 *
 	 * @throws IllegalValueException
 	 */
-	public function unserialize( $value ) {
-		list( $entityType, $numericId ) = json_decode( $value );
+	public function unserialize( $serialized ) {
+		list( $entityType, $numericId ) = json_decode( $serialized );
 
 		try {
 			$entityId = LegacyIdInterpreter::newIdFromTypeAndNumber( $entityType, $numericId );

--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -63,10 +63,10 @@ class ItemId extends EntityId {
 	/**
 	 * @see Serializable::unserialize
 	 *
-	 * @param string $value
+	 * @param string $serialized
 	 */
-	public function unserialize( $value ) {
-		list( , $this->serialization ) = json_decode( $value );
+	public function unserialize( $serialized ) {
+		list( , $this->serialization ) = json_decode( $serialized );
 	}
 
 	/**

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -63,10 +63,10 @@ class PropertyId extends EntityId {
 	/**
 	 * @see Serializable::unserialize
 	 *
-	 * @param string $value
+	 * @param string $serialized
 	 */
-	public function unserialize( $value ) {
-		list( , $this->serialization ) = json_decode( $value );
+	public function unserialize( $serialized ) {
+		list( , $this->serialization ) = json_decode( $serialized );
 	}
 
 	/**

--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -454,10 +454,10 @@ abstract class HashArray extends ArrayObject implements Hashable, Comparable {
 	/**
 	 * @see Serializable::unserialize
 	 *
-	 * @param string $serialization
+	 * @param string $serialized
 	 */
-	public function unserialize( $serialization ) {
-		$serializationData = unserialize( $serialization );
+	public function unserialize( $serialized ) {
+		$serializationData = unserialize( $serialized );
 
 		foreach ( $serializationData['data'] as $offset => $value ) {
 			// Just set the element, bypassing checks and offset resolving,

--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -217,10 +217,10 @@ class ReferenceList implements Comparable, Countable, IteratorAggregate, Seriali
 	 *
 	 * @since 2.1
 	 *
-	 * @param string $data
+	 * @param string $serialized
 	 */
-	public function unserialize( $data ) {
-		$this->__construct( unserialize( $data ) );
+	public function unserialize( $serialized ) {
+		$this->references = unserialize( $serialized );
 	}
 
 	/**


### PR DESCRIPTION
Follow up to  #597.

Originally, this patch changed `ItemId::unserialize` and `PropertyId::unserialize` to throw exceptions and call the constructor. But I was not sure if …

1. … this is relevant in production. As far as I can tell this is unused.
2. … this should not be done because these methods should be as fast as possible and not do any checks.

I reworked this patch completely because I realized these `unserialize` methods are not intended to be called manually. The should only be called internally when using PHP's `unserialize( $string )`. This should be as fast as possible.