### PR TITLE
Get rid of unused removeDuplicates method

### DIFF
--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -255,29 +255,6 @@ class ReferenceList extends SplObjectStorage implements Comparable {
 	}
 
 	/**
-	 * Removes duplicates bases on hash value.
-	 *
-	 * @since 0.2
-	 */
-	public function removeDuplicates() {
-		$knownHashes = array();
-
-		/**
-		 * @var Hashable $hashable
-		 */
-		foreach ( iterator_to_array( $this ) as $hashable ) {
-			$hash = $hashable->getHash();
-
-			if ( in_array( $hash, $knownHashes ) ) {
-				$this->detach( $hashable );
-			}
-			else {
-				$knownHashes[] = $hash;
-			}
-		}
-	}
-
-	/**
 	 * The hash is purely valuer based. Order of the elements in the array is not held into account.
 	 *
 	 * @since 0.3

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -382,31 +382,4 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $references->valid(), 'pre condition' );
 	}
 
-	public function testRemoveDuplicates_noDuplicatesPresent() {
-		$list = new ReferenceList();
-
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 1 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 2 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 3 ) ) ) );
-
-		$list->removeDuplicates();
-
-		$this->assertEquals( 3, count( $list ) );
-	}
-
-	public function testRemoveDuplicates_duplicatesGetRemoved() {
-		$list = new ReferenceList();
-
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 1 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 2 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 3 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 1 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 2 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 4 ) ) ) );
-
-		$list->removeDuplicates();
-
-		$this->assertEquals( 4, count( $list ) );
-	}
-
 }


### PR DESCRIPTION
There is no single usage of this method in our whole code base.
Furthermore, if no duplicates should be allowed, a different data
structure should be used.