### PR TITLE
Refactor ReferenceList

### DIFF
--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -382,4 +382,31 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $references->valid(), 'pre condition' );
 	}
 
+	public function testRemoveDuplicates_noDuplicatesPresent() {
+		$list = new ReferenceList();
+
+		$list->attach( new Reference( array( new PropertyNoValueSnak( 1 ) ) ) );
+		$list->attach( new Reference( array( new PropertyNoValueSnak( 2 ) ) ) );
+		$list->attach( new Reference( array( new PropertyNoValueSnak( 3 ) ) ) );
+
+		$list->removeDuplicates();
+
+		$this->assertEquals( 3, count( $list ) );
+	}
+
+	public function testRemoveDuplicates_duplicatesGetRemoved() {
+		$list = new ReferenceList();
+
+		$list->attach( new Reference( array( new PropertyNoValueSnak( 1 ) ) ) );
+		$list->attach( new Reference( array( new PropertyNoValueSnak( 2 ) ) ) );
+		$list->attach( new Reference( array( new PropertyNoValueSnak( 3 ) ) ) );
+		$list->attach( new Reference( array( new PropertyNoValueSnak( 1 ) ) ) );
+		$list->attach( new Reference( array( new PropertyNoValueSnak( 2 ) ) ) );
+		$list->attach( new Reference( array( new PropertyNoValueSnak( 4 ) ) ) );
+
+		$list->removeDuplicates();
+
+		$this->assertEquals( 4, count( $list ) );
+	}
+
 }

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -372,41 +372,4 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $references->isEmpty() );
 	}
 
-	public function testGivenNonEmptyListWithForwardedIterator_isNotEmpty() {
-		$references = new ReferenceList();
-		$references->addNewReference( new PropertyNoValueSnak( 1 ) );
-		$references->next();
-
-		$this->assertFalse( $references->valid(), 'post condition' );
-		$this->assertFalse( $references->isEmpty() );
-		$this->assertFalse( $references->valid(), 'pre condition' );
-	}
-
-	public function testRemoveDuplicates_noDuplicatesPresent() {
-		$list = new ReferenceList();
-
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 1 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 2 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 3 ) ) ) );
-
-		$list->removeDuplicates();
-
-		$this->assertEquals( 3, count( $list ) );
-	}
-
-	public function testRemoveDuplicates_duplicatesGetRemoved() {
-		$list = new ReferenceList();
-
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 1 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 2 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 3 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 1 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 2 ) ) ) );
-		$list->attach( new Reference( array( new PropertyNoValueSnak( 4 ) ) ) );
-
-		$list->removeDuplicates();
-
-		$this->assertEquals( 4, count( $list ) );
-	}
-
 }


### PR DESCRIPTION
This removes the inheritance between ReferenceList and SplObjectStorage
and replaces it with a native array. To make the change as minimal as
possible, the Countable interface and the IteratorAggregate interface are
now implemented by ReferenceList so that it can be used almost the same as
before (like iterating over it and calling count() on it).