### PR TITLE
Remove clear from Entity, Item and Property

### DIFF
--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -311,18 +311,6 @@ class Item implements EntityDocument, FingerprintHolder, StatementListHolder,
 	}
 
 	/**
-	 * Removes all content from the Item.
-	 * The id is not part of the content.
-	 *
-	 * @since 0.1
-	 */
-	public function clear() {
-		$this->fingerprint = new Fingerprint();
-		$this->siteLinks = new SiteLinkList();
-		$this->statements = new StatementList();
-	}
-
-	/**
 	 * @since 1.0
 	 *
 	 * @return StatementList

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -264,17 +264,6 @@ class Property implements EntityDocument, FingerprintHolder, StatementListHolder
 	}
 
 	/**
-	 * Removes all content from the Property.
-	 * The id and the type are not part of the content.
-	 *
-	 * @since 0.1
-	 */
-	public function clear() {
-		$this->fingerprint = new Fingerprint();
-		$this->statements = new StatementList();
-	}
-
-	/**
 	 * @since 1.1
 	 *
 	 * @return StatementList

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -231,23 +231,6 @@ class ItemTest extends PHPUnit_Framework_TestCase {
 		return $statement;
 	}
 
-	public function testClearRemovesAllButId() {
-		$item = new Item( new ItemId( 'Q42' ) );
-		$item->getFingerprint()->setLabel( 'en', 'foo' );
-		$item->getSiteLinkList()->addNewSiteLink( 'enwiki', 'Foo' );
-		$item->getStatements()->addStatement( $this->newStatement() );
-
-		$item->clear();
-
-		$this->assertEquals( new ItemId( 'Q42' ), $item->getId() );
-		$this->assertTrue( $item->getFingerprint()->isEmpty() );
-		$this->assertTrue( $item->getLabels()->isEmpty() );
-		$this->assertTrue( $item->getDescriptions()->isEmpty() );
-		$this->assertTrue( $item->getAliasGroups()->isEmpty() );
-		$this->assertTrue( $item->getSiteLinkList()->isEmpty() );
-		$this->assertTrue( $item->getStatements()->isEmpty() );
-	}
-
 	public function testEmptyConstructor() {
 		$item = new Item();
 
@@ -279,13 +262,6 @@ class ItemTest extends PHPUnit_Framework_TestCase {
 		$item->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
 
 		$item->setStatements( new StatementList() );
-		$this->assertTrue( $item->getStatements()->isEmpty() );
-	}
-
-	public function testGetStatementsReturnsCorrectTypeAfterClear() {
-		$item = new Item();
-		$item->clear();
-
 		$this->assertTrue( $item->getStatements()->isEmpty() );
 	}
 

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -112,18 +112,6 @@ class PropertyTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse( $property->isEmpty() );
 	}
 
-	public function testClearRemovesAllButId() {
-		$property = Property::newFromType( 'string' );
-		$property->setId( 42 );
-		$property->getFingerprint()->setLabel( 'en', 'foo' );
-		$property->getStatements()->addNewStatement( new PropertyNoValueSnak( 1 ) );
-
-		$property->clear();
-
-		$this->assertEquals( new PropertyId( 'P42' ), $property->getId() );
-		$this->assertTrue( $property->isEmpty() );
-	}
-
 	public function testGetStatementsReturnsEmptyListForEmptyProperty() {
 		$property = Property::newFromType( 'string' );
 


### PR DESCRIPTION
New instances should be created instead of clearing an existing Entity.
The only real usecase for this seems to be the clear=true parameter in the
wbeditentity api module.

Property::clear even had a bug in that it didn't clear the statements but
only the fingerprint.