### PR TITLE
Add equals to EntityDocument

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,8 @@
 * Removed `ReferenceList::removeDuplicates`
 * `ReferenceList` no longer derives from `SplObjectStorage`, though still implements `Countable`
 * Removed `HashableObjectStorage`
+* Added `EntityDocument::equals`
+* `Entity` no longer implements `Comparable`
 
 #### Other changes
 

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -2,8 +2,6 @@
 
 namespace Wikibase\DataModel\Entity;
 
-use Comparable;
-use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;
 use Wikibase\DataModel\Term\FingerprintHolder;
@@ -19,7 +17,7 @@ use Wikibase\DataModel\Term\TermList;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-abstract class Entity implements Comparable, FingerprintHolder, EntityDocument {
+abstract class Entity implements FingerprintHolder, EntityDocument {
 
 	/**
 	 * Sets the value for the label in a certain value.

--- a/src/Entity/EntityDocument.php
+++ b/src/Entity/EntityDocument.php
@@ -52,4 +52,16 @@ interface EntityDocument {
 	 */
 	public function isEmpty();
 
+	/**
+	 * Two entities are considered equal if they are of the same
+	 * type and have the same value. The value does not include
+	 * the id, so entities with the same value but different id
+	 * are considered equal.
+	 *
+	 * @param EntityDocument $entity
+	 *
+	 * @return bool
+	 */
+	public function equals( EntityDocument $entity );
+
 }

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -300,28 +300,23 @@ class Item extends Entity implements StatementListHolder {
 	}
 
 	/**
-	 * @see Comparable::equals
-	 *
-	 * Two items are considered equal if they are of the same
-	 * type and have the same value. The value does not include
-	 * the id, so entities with the same value but different id
-	 * are considered equal.
+	 * @see EntityDocument::equals
 	 *
 	 * @since 0.1
 	 *
-	 * @param mixed $target
+	 * @param EntityDocument $entity
 	 *
 	 * @return bool
 	 */
-	public function equals( $target ) {
-		if ( $this === $target ) {
+	public function equals( EntityDocument $entity ) {
+		if ( $this === $entity ) {
 			return true;
 		}
 
-		return $target instanceof self
-			&& $this->fingerprint->equals( $target->fingerprint )
-			&& $this->siteLinks->equals( $target->siteLinks )
-			&& $this->statements->equals( $target->statements );
+		return $entity instanceof self
+		       && $this->fingerprint->equals( $entity->fingerprint )
+		       && $this->siteLinks->equals( $entity->siteLinks )
+		       && $this->statements->equals( $entity->statements );
 	}
 
 }

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -190,28 +190,23 @@ class Property extends Entity implements StatementListHolder {
 	}
 
 	/**
-	 * @see Comparable::equals
-	 *
-	 * Two properties are considered equal if they are of the same
-	 * type and have the same value. The value does not include
-	 * the id, so entities with the same value but different id
-	 * are considered equal.
+	 * @see EntityDocument::equals
 	 *
 	 * @since 0.1
 	 *
-	 * @param mixed $target
+	 * @param EntityDocument $entity
 	 *
 	 * @return bool
 	 */
-	public function equals( $target ) {
-		if ( $this === $target ) {
+	public function equals( EntityDocument $entity ) {
+		if ( $this === $entity ) {
 			return true;
 		}
 
-		return $target instanceof self
-			&& $this->dataTypeId === $target->dataTypeId
-			&& $this->fingerprint->equals( $target->fingerprint )
-			&& $this->statements->equals( $target->statements );
+		return $entity instanceof self
+		       && $this->dataTypeId === $entity->dataTypeId
+		       && $this->fingerprint->equals( $entity->fingerprint )
+		       && $this->statements->equals( $entity->statements );
 	}
 
 	/**


### PR DESCRIPTION
This method is needed in EntityDocument to be able to compare two entities
where their type is not known. Entity now also doesn't implement
Comparable anymore.

The signature of the equals method has changed from mixed param type to
typehinting against EntityDocument.