### PR TITLE
Revert unnecessary breaking change to Item::equals

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,8 +17,7 @@
     * Added `getIterator` method.
 * Removed `ReferenceList::removeDuplicates`.
 * `ReferenceList::addReference` now throws an `InvalidArgumentException` for negative indices.
-* `Entity` no longer implements `Comparable`
-* Added `EntityDocument::equals`
+* `EntityDocument` now implements `Comparable`.
 
 ## Version 4.4.0 (2016-01-20)
 

--- a/src/Entity/EntityDocument.php
+++ b/src/Entity/EntityDocument.php
@@ -54,4 +54,18 @@ interface EntityDocument extends Comparable {
 	 */
 	public function isEmpty();
 
+	/**
+	 * @see Comparable::equals
+	 *
+	 * Two entities are considered equal if they are of the same
+	 * type and have the same value. The value does not include
+	 * the id, so entities with the same value but different id
+	 * are considered equal.
+	 *
+	 * @param mixed $target
+	 *
+	 * @return bool
+	 */
+	public function equals( $target );
+
 }

--- a/src/Entity/EntityDocument.php
+++ b/src/Entity/EntityDocument.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Entity;
 
+use Comparable;
 use InvalidArgumentException;
 
 /**
@@ -14,7 +15,7 @@ use InvalidArgumentException;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
-interface EntityDocument {
+interface EntityDocument extends Comparable {
 
 	/**
 	 * Returns the id of the entity or null if it does not have one.
@@ -52,17 +53,5 @@ interface EntityDocument {
 	 * @return bool
 	 */
 	public function isEmpty();
-
-	/**
-	 * Two entities are considered equal if they are of the same
-	 * type and have the same value. The value does not include
-	 * the id, so entities with the same value but different id
-	 * are considered equal.
-	 *
-	 * @param EntityDocument $entity
-	 *
-	 * @return bool
-	 */
-	public function equals( EntityDocument $entity );
 
 }

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -300,12 +300,7 @@ class Item extends Entity implements StatementListHolder {
 	}
 
 	/**
-	 * @see Comparable::equals
-	 *
-	 * Two items are considered equal if they are of the same
-	 * type and have the same value. The value does not include
-	 * the id, so entities with the same value but different id
-	 * are considered equal.
+	 * @see EntityDocument::equals
 	 *
 	 * @since 0.1
 	 *

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -300,23 +300,28 @@ class Item extends Entity implements StatementListHolder {
 	}
 
 	/**
-	 * @see EntityDocument::equals
+	 * @see Comparable::equals
+	 *
+	 * Two items are considered equal if they are of the same
+	 * type and have the same value. The value does not include
+	 * the id, so entities with the same value but different id
+	 * are considered equal.
 	 *
 	 * @since 0.1
 	 *
-	 * @param EntityDocument $entity
+	 * @param mixed $target
 	 *
 	 * @return bool
 	 */
-	public function equals( EntityDocument $entity ) {
-		if ( $this === $entity ) {
+	public function equals( $target ) {
+		if ( $this === $target ) {
 			return true;
 		}
 
-		return $entity instanceof self
-		       && $this->fingerprint->equals( $entity->fingerprint )
-		       && $this->siteLinks->equals( $entity->siteLinks )
-		       && $this->statements->equals( $entity->statements );
+		return $target instanceof self
+			&& $this->fingerprint->equals( $target->fingerprint )
+			&& $this->siteLinks->equals( $target->siteLinks )
+			&& $this->statements->equals( $target->statements );
 	}
 
 }

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -190,23 +190,28 @@ class Property extends Entity implements StatementListHolder {
 	}
 
 	/**
-	 * @see EntityDocument::equals
+	 * @see Comparable::equals
+	 *
+	 * Two properties are considered equal if they are of the same
+	 * type and have the same value. The value does not include
+	 * the id, so entities with the same value but different id
+	 * are considered equal.
 	 *
 	 * @since 0.1
 	 *
-	 * @param EntityDocument $entity
+	 * @param mixed $target
 	 *
 	 * @return bool
 	 */
-	public function equals( EntityDocument $entity ) {
-		if ( $this === $entity ) {
+	public function equals( $target ) {
+		if ( $this === $target ) {
 			return true;
 		}
 
-		return $entity instanceof self
-		       && $this->dataTypeId === $entity->dataTypeId
-		       && $this->fingerprint->equals( $entity->fingerprint )
-		       && $this->statements->equals( $entity->statements );
+		return $target instanceof self
+			&& $this->dataTypeId === $target->dataTypeId
+			&& $this->fingerprint->equals( $target->fingerprint )
+			&& $this->statements->equals( $target->statements );
 	}
 
 	/**

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -190,12 +190,7 @@ class Property extends Entity implements StatementListHolder {
 	}
 
 	/**
-	 * @see Comparable::equals
-	 *
-	 * Two properties are considered equal if they are of the same
-	 * type and have the same value. The value does not include
-	 * the id, so entities with the same value but different id
-	 * are considered equal.
+	 * @see EntityDocument::equals
 	 *
 	 * @since 0.1
 	 *


### PR DESCRIPTION
This mostly reverts the unnecessary breaking changes in #615. The title of that pull request was "Add equals to EntityDocument", and this is mostly what this patch now does, when you compare the code with the previous 4.4 release: The `Comparable` interface moves from the deprecated abstract base class `Entity` up to the `EntityDocument` interface. That's all.

This patch also cleans up the release notes (extensively updated in 2df96fa988c199ebec318f55150f1b22dd3eedf6, thanks a lot for that, @Benestar) and adds some missing regression tests (I tried and these tests run with 4.4).

[Bug: T125636](https://phabricator.wikimedia.org/T125636)