### PR TITLE
Rework test for ReferenceList::indexOf using identity

### DIFF
--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -110,7 +110,7 @@ class ReferenceList implements Comparable, Countable, IteratorAggregate, Seriali
 	 *
 	 * @param Reference $reference
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function hasReference( Reference $reference ) {
 		return $this->hasReferenceHash( $reference->getHash() );
@@ -123,7 +123,7 @@ class ReferenceList implements Comparable, Countable, IteratorAggregate, Seriali
 	 *
 	 * @param Reference $reference
 	 *
-	 * @return int|boolean
+	 * @return int|bool
 	 */
 	public function indexOf( Reference $reference ) {
 		foreach ( $this->references as $index => $ref ) {
@@ -153,7 +153,7 @@ class ReferenceList implements Comparable, Countable, IteratorAggregate, Seriali
 	 *
 	 * @param string $referenceHash
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function hasReferenceHash( $referenceHash ) {
 		return $this->getReference( $referenceHash ) !== null;

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -236,14 +236,15 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
-	public function testIndexOf_falseForMissingReferences() {
-		$referenceList = new ReferenceList();
-		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
+	public function testIndexOf_checksForIdentity() {
+		$reference1 = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
+		$reference2 = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
+		$referenceList = new ReferenceList( array( $reference1 ) );
 
-		$referenceList->addNewReference( new PropertyNoValueSnak( 1 ) );
-
-		$this->assertFalse( $referenceList->indexOf( new Reference() ) );
-		$this->assertFalse( $referenceList->indexOf( $reference ) );
+		$this->assertNotSame( $reference1, $reference2, 'post condition' );
+		$this->assertTrue( $reference1->equals( $reference2 ), 'post condition' );
+		$this->assertSame( 0, $referenceList->indexOf( $reference1 ), 'identity' );
+		$this->assertFalse( $referenceList->indexOf( $reference2 ), 'not equality' );
 	}
 
 	/**


### PR DESCRIPTION
The braking change to the indexOf method was introduced in #609 and reverted in #617. The test was added in #617 but did not mentioned what it is testing: identity vs. equality.

[Bug: T125636](https://phabricator.wikimedia.org/T125636)