### PR TITLE
Add more regression tests for ReferenceList

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,21 +2,21 @@
 
 ## Version 5.0.0 (alpha)
 
-* Removed `Claims` class (deprecated since 1.0)
-* Removed `getClaims` and `setClaims` from `Entity`, `Item` and `Property` (deprecated since 1.0)
-* Removed `HashableObjectStorage` class (deprecated since 4.4)
-* Removed `ReferenceList::removeDuplicates`
-* `ReferenceList` no longer derives from `SplObjectStorage`
-    * Removed `attach`, `detach`, `contains`, `addAll`, `removeAll`,
-      `removeAllExcept`, `getInfo`, `setInfo` and `getHash`
-* `ReferenceList` no longer implements `Iterator`
-    * Removed `current`, `key`, `next`, `rewind` and `valid`
-* `ReferenceList` no longer implements `ArrayAccess`
-    * Removed `offsetExists`, `offsetGet`, `offsetSet` and `offsetUnset`
-* `ReferenceList` still implements `Countable`, `Traversable` and `Serializable`
-* `ReferenceList` now implements `IteratorAggregate`
-    * Method `getIterator` was added
-* `ReferenceList::addReference` now throws an `InvalidArgumentException` for negative indices
+* Removed `Claims` class (deprecated since 1.0).
+* Removed `getClaims` and `setClaims` methods from `Entity`, `Item` and `Property` (deprecated since
+  1.0).
+* Removed `HashableObjectStorage` class (deprecated since 4.4).
+* `ReferenceList` no longer derives from `SplObjectStorage`.
+    * Removed `addAll`, `attach`, `contains`, `detach`, `getHash`, `getInfo`, `removeAll`,
+      `removeAllExcept` and `setInfo` methods.
+* `ReferenceList` no longer implements `ArrayAccess`.
+    * Removed `offsetExists`, `offsetGet`, `offsetSet` and `offsetUnset` methods.
+* `ReferenceList` no longer implements `Iterator`.
+    * Removed `current`, `key`, `next`, `rewind` and `valid` methods.
+* `ReferenceList` now implements `IteratorAggregate`.
+    * Added `getIterator` method.
+* Removed `ReferenceList::removeDuplicates`.
+* `ReferenceList::addReference` now throws an `InvalidArgumentException` for negative indices.
 * `Entity` no longer implements `Comparable`
 * Added `EntityDocument::equals`
 

--- a/src/Entity/EntityDocument.php
+++ b/src/Entity/EntityDocument.php
@@ -8,10 +8,11 @@ use InvalidArgumentException;
  * Minimal interface for all objects that represent an entity.
  * All entities have an EntityId and an entity type.
  *
- * @since 0.8.2, modified in 3.0
+ * @since 0.8.2
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Bene* < benestar.wikimedia@gmail.com >
  */
 interface EntityDocument {
 

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel\Tests;
 
 use Hashable;
 use InvalidArgumentException;
+use PHPUnit_Framework_TestCase;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\ReferenceList;
@@ -21,7 +22,7 @@ use Wikibase\DataModel\Snak\SnakList;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Mättig
  */
-class ReferenceListTest extends \PHPUnit_Framework_TestCase {
+class ReferenceListTest extends PHPUnit_Framework_TestCase {
 
 	public function instanceProvider() {
 		$instances = array();
@@ -84,9 +85,20 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetIterator_isTraversable() {
+		$references = new ReferenceList();
+		$references->addNewReference( new PropertyNoValueSnak( 1 ) );
+		$iterator = $references->getIterator();
+
+		$this->assertInstanceOf( 'Traversable', $iterator );
+		$this->assertCount( 1, $iterator );
+		foreach ( $references as $reference ) {
+			$this->assertInstanceOf( 'Wikibase\DataModel\Reference', $reference );
+		}
+	}
+
 	/**
 	 * @dataProvider instanceProvider
-	 * @param ReferenceList $array
 	 */
 	public function testHasReferenceBeforeRemoveButNotAfter( ReferenceList $array ) {
 		if ( $array->count() === 0 ) {
@@ -120,7 +132,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param ReferenceList $array
 	 */
 	public function testRemoveReference( ReferenceList $array ) {
 		$elementCount = count( $array );
@@ -225,7 +236,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param ReferenceList $array
 	 */
 	public function testIndexOf( ReferenceList $array ) {
 		$this->assertFalse( $array->indexOf( new Reference() ) );
@@ -248,7 +258,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param ReferenceList $array
 	 */
 	public function testEquals( ReferenceList $array ) {
 		$this->assertTrue( $array->equals( $array ) );
@@ -257,24 +266,21 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param ReferenceList $array
 	 */
-	public function testGetHashReturnsString( ReferenceList $array ) {
+	public function testGetValueHashReturnsString( ReferenceList $array ) {
 		$this->assertInternalType( 'string', $array->getValueHash() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param ReferenceList $array
 	 */
-	public function testGetHashValueIsTheSameForClone( ReferenceList $array ) {
+	public function testGetValueHashIsTheSameForClone( ReferenceList $array ) {
 		$copy = unserialize( serialize( $array ) );
 		$this->assertEquals( $array->getValueHash(), $copy->getValueHash() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param ReferenceList $references
 	 */
 	public function testHasReferenceHash( ReferenceList $references ) {
 		$this->assertFalse( $references->hasReferenceHash( '~=[,,_,,]:3' ) );
@@ -289,7 +295,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param ReferenceList $references
 	 */
 	public function testGetReference( ReferenceList $references ) {
 		$this->assertNull( $references->getReference( '~=[,,_,,]:3' ) );
@@ -304,7 +309,6 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param ReferenceList $references
 	 */
 	public function testRemoveReferenceHash( ReferenceList $references ) {
 		$references->removeReferenceHash( '~=[,,_,,]:3' );
@@ -362,6 +366,11 @@ class ReferenceListTest extends \PHPUnit_Framework_TestCase {
 
 		$this->setExpectedException( 'InvalidArgumentException' );
 		$references->addNewReference( new PropertyNoValueSnak( 1 ), null );
+	}
+
+	public function testSerializationStability() {
+		$references = new ReferenceList();
+		$this->assertSame( 'a:0:{}', $references->serialize() );
 	}
 
 	public function testSerializeRoundtrip() {


### PR DESCRIPTION
This is split from #621:
* This adds a few more regression tests.
* This rearranges the release notes. The only substantial change is that I removed the "still implements" line.

[Bug: T125636](https://phabricator.wikimedia.org/T125636)