### PR TITLE
Add EntityDocument::copy

### DIFF
--- a/src/Entity/EntityDocument.php
+++ b/src/Entity/EntityDocument.php
@@ -65,4 +65,15 @@ interface EntityDocument {
 	 */
 	public function equals( EntityDocument $entity );
 
+	/**
+	 * Returns a deep clone of the entity. The clone must be equal in all details, including the id.
+	 * Since EntityDocuments are not immutable (at least the id can be set) the method is not
+	 * allowed to return $this.
+	 *
+	 * @since 5.0
+	 *
+	 * @return self
+	 */
+	public function copy();
+
 }


### PR DESCRIPTION
We may not need this at all when we make use of the `clone` keyword and PHP's magic `__clone` methods instead, see http://php.net/manual/en/language.oop5.cloning.php. I will upload a separate patch for this alternative proposal.