### PR TITLE
Implement __clone to fully support deep cloning

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,7 @@
 
 ## Version 5.1 (dev)
 
+* `Item::copy` and `Property::copy` do not clone immutable objects any more, saving time and memory
 * Deprecated `FingerprintHolder` and `StatementListHolder`
 
 ## Version 5.0.2 (2016-02-23)

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -301,7 +301,7 @@ abstract class Entity implements FingerprintHolder, EntityDocument {
 	}
 
 	/**
-	 * Returns a deep copy of the entity.
+	 * @see EntityDocument::copy
 	 *
 	 * @since 0.1
 	 *

--- a/src/Entity/EntityDocument.php
+++ b/src/Entity/EntityDocument.php
@@ -70,6 +70,9 @@ interface EntityDocument extends Comparable {
 
 	/**
 	 * Returns a deep clone of the entity. The clone must be equal in all details, including the id.
+	 * No change done to the clone is allowed to interfere with the original object. Only properties
+	 * containing immutable objects are allowed to (and should) reference the original object.
+	 *
 	 * Since EntityDocuments are not immutable (at least the id can be set) the method is not
 	 * allowed to return $this.
 	 *

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -327,7 +327,19 @@ class Item extends Entity implements StatementListHolder {
 	 * @return self
 	 */
 	public function copy() {
-		return unserialize( serialize( $this ) );
+		return clone $this;
+	}
+
+	/**
+	 * @see http://php.net/manual/en/language.oop5.cloning.php
+	 *
+	 * @since 5.1
+	 */
+	public function __clone() {
+		$this->fingerprint = clone $this->fingerprint;
+		// SiteLinkList is mutable, but SiteLink is not. No deeper cloning necesarry.
+		$this->siteLinks = clone $this->siteLinks;
+		$this->statements = clone $this->statements;
 	}
 
 }

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -259,7 +259,17 @@ class Property extends Entity implements StatementListHolder {
 	 * @return self
 	 */
 	public function copy() {
-		return unserialize( serialize( $this ) );
+		return clone $this;
+	}
+
+	/**
+	 * @see http://php.net/manual/en/language.oop5.cloning.php
+	 *
+	 * @since 5.1
+	 */
+	public function __clone() {
+		$this->fingerprint = clone $this->fingerprint;
+		$this->statements = clone $this->statements;
 	}
 
 }

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -298,4 +298,14 @@ class Statement implements Hashable, Comparable, PropertyIdProvider {
 			&& $this->references->equals( $target->references );
 	}
 
+	/**
+	 * @see http://php.net/manual/en/language.oop5.cloning.php
+	 *
+	 * @since 5.1
+	 */
+	public function __clone() {
+		$this->qualifiers = clone $this->qualifiers;
+		$this->references = clone $this->references;
+	}
+
 }

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -325,4 +325,15 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 		return $statementList;
 	}
 
+	/**
+	 * @see http://php.net/manual/en/language.oop5.cloning.php
+	 *
+	 * @since 5.1
+	 */
+	public function __clone() {
+		foreach ( $this->statements as &$statement ) {
+			$statement = clone $statement;
+		}
+	}
+
 }

--- a/src/Term/Fingerprint.php
+++ b/src/Term/Fingerprint.php
@@ -278,4 +278,17 @@ class Fingerprint implements Comparable, LabelsProvider, DescriptionsProvider, A
 		$this->aliasGroups = $groups;
 	}
 
+	/**
+	 * @see http://php.net/manual/en/language.oop5.cloning.php
+	 *
+	 * @since 5.1
+	 */
+	public function __clone() {
+		// TermList is mutable, but Term is not. No deeper cloning necesarry.
+		$this->labels = clone $this->labels;
+		$this->descriptions = clone $this->descriptions;
+		// AliasGroupList is mutable, but AliasGroup is not. No deeper cloning necesarry.
+		$this->aliasGroups = clone $this->aliasGroups;
+	}
+
 }


### PR DESCRIPTION
Alternative to #625. Personally I prefer this one. It's the native PHP way of copying/(deep)cloning objects.

I'm not totally happy with the test because it's so long.