### PR TITLE
Add interfaces to Item and Property

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,9 +4,13 @@
 
 * Removed `Entity` class (deprecated since 1.0)
 * `Item` and `Property` no longer extend `Entity`
-    * Removed `getLabel`, `getLabels`, `getDescription`, `getDescriptions`, `getAliases`,
-      `getAllAliases`, `setLabels`, `setDescriptions`, `addAliases`, `setAllAliases`,
+    * Removed `getLabel`, `getDescription`, `getAliases`, `getAllAliases`,
+      `setLabels`, `setDescriptions`, `addAliases`, `setAllAliases`,
       `removeLabel`, `removeDescription` and `removeAliases` methods
+* `Item` and `Property` now implement `LabelsProvider`, `DescriptionsProvider` and `AliasesProvider`
+* `Item::getLabels` and `Property::getLabels` now return a `TermList`
+* `Item::getDescriptions` and `Property::getDescriptions` now return a `TermList`
+* Added `Item::getAliasGroups` and `Property::getAliasGroups`
 * `TermList` and `AliasGroupList` no longer throw an `InvalidArgumentException` for invalid language codes.
     * `getByLangauge` now throws an `OutOfBoundsException`.
     * `removeByLanguage` does nothing for invalid values.

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -8,8 +8,13 @@ use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\SiteLinkList;
 use Wikibase\DataModel\Statement\StatementList;
 use Wikibase\DataModel\Statement\StatementListHolder;
+use Wikibase\DataModel\Term\AliasesProvider;
+use Wikibase\DataModel\Term\AliasGroupList;
+use Wikibase\DataModel\Term\DescriptionsProvider;
 use Wikibase\DataModel\Term\Fingerprint;
 use Wikibase\DataModel\Term\FingerprintHolder;
+use Wikibase\DataModel\Term\LabelsProvider;
+use Wikibase\DataModel\Term\TermList;
 
 /**
  * Represents a single Wikibase item.
@@ -19,8 +24,10 @@ use Wikibase\DataModel\Term\FingerprintHolder;
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Bene* < benestar.wikimedia@gmail.com >
  */
-class Item implements EntityDocument, FingerprintHolder, StatementListHolder {
+class Item implements EntityDocument, FingerprintHolder, StatementListHolder,
+	LabelsProvider, DescriptionsProvider, AliasesProvider {
 
 	const ENTITY_TYPE = 'item';
 
@@ -111,6 +118,39 @@ class Item implements EntityDocument, FingerprintHolder, StatementListHolder {
 	 */
 	public function setFingerprint( Fingerprint $fingerprint ) {
 		$this->fingerprint = $fingerprint;
+	}
+
+	/**
+	 * @see LabelsProvider::getLabels
+	 *
+	 * @since 6.0
+	 *
+	 * @return TermList
+	 */
+	public function getLabels() {
+		return $this->fingerprint->getLabels();
+	}
+
+	/**
+	 * @see DescriptionsProvider::getDescriptions
+	 *
+	 * @since 6.0
+	 *
+	 * @return TermList
+	 */
+	public function getDescriptions() {
+		return $this->fingerprint->getDescriptions();
+	}
+
+	/**
+	 * @see AliasesProvider::getAliasGroups
+	 *
+	 * @since 6.0
+	 *
+	 * @return AliasGroupList
+	 */
+	public function getAliasGroups() {
+		return $this->fingerprint->getAliasGroups();
 	}
 
 	/**

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -5,8 +5,13 @@ namespace Wikibase\DataModel\Entity;
 use InvalidArgumentException;
 use Wikibase\DataModel\Statement\StatementList;
 use Wikibase\DataModel\Statement\StatementListHolder;
+use Wikibase\DataModel\Term\AliasesProvider;
+use Wikibase\DataModel\Term\AliasGroupList;
+use Wikibase\DataModel\Term\DescriptionsProvider;
 use Wikibase\DataModel\Term\Fingerprint;
 use Wikibase\DataModel\Term\FingerprintHolder;
+use Wikibase\DataModel\Term\LabelsProvider;
+use Wikibase\DataModel\Term\TermList;
 
 /**
  * Represents a single Wikibase property.
@@ -16,8 +21,10 @@ use Wikibase\DataModel\Term\FingerprintHolder;
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Bene* < benestar.wikimedia@gmail.com >
  */
-class Property implements EntityDocument, FingerprintHolder, StatementListHolder {
+class Property implements EntityDocument, FingerprintHolder, StatementListHolder,
+	LabelsProvider, DescriptionsProvider, AliasesProvider {
 
 	const ENTITY_TYPE = 'property';
 
@@ -109,6 +116,39 @@ class Property implements EntityDocument, FingerprintHolder, StatementListHolder
 	 */
 	public function setFingerprint( Fingerprint $fingerprint ) {
 		$this->fingerprint = $fingerprint;
+	}
+
+	/**
+	 * @see LabelsProvider::getLabels
+	 *
+	 * @since 6.0
+	 *
+	 * @return TermList
+	 */
+	public function getLabels() {
+		return $this->fingerprint->getLabels();
+	}
+
+	/**
+	 * @see DescriptionsProvider::getDescriptions
+	 *
+	 * @since 6.0
+	 *
+	 * @return TermList
+	 */
+	public function getDescriptions() {
+		return $this->fingerprint->getDescriptions();
+	}
+
+	/**
+	 * @see AliasesProvider::getAliasGroups
+	 *
+	 * @since 6.0
+	 *
+	 * @return AliasGroupList
+	 */
+	public function getAliasGroups() {
+		return $this->fingerprint->getAliasGroups();
 	}
 
 	/**

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -241,6 +241,9 @@ class ItemTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals( new ItemId( 'Q42' ), $item->getId() );
 		$this->assertTrue( $item->getFingerprint()->isEmpty() );
+		$this->assertTrue( $item->getLabels()->isEmpty() );
+		$this->assertTrue( $item->getDescriptions()->isEmpty() );
+		$this->assertTrue( $item->getAliasGroups()->isEmpty() );
 		$this->assertTrue( $item->getSiteLinkList()->isEmpty() );
 		$this->assertTrue( $item->getStatements()->isEmpty() );
 	}
@@ -250,6 +253,9 @@ class ItemTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertNull( $item->getId() );
 		$this->assertTrue( $item->getFingerprint()->isEmpty() );
+		$this->assertTrue( $item->getLabels()->isEmpty() );
+		$this->assertTrue( $item->getDescriptions()->isEmpty() );
+		$this->assertTrue( $item->getAliasGroups()->isEmpty() );
 		$this->assertTrue( $item->getSiteLinkList()->isEmpty() );
 		$this->assertTrue( $item->getStatements()->isEmpty() );
 	}
@@ -718,6 +724,69 @@ class ItemTest extends PHPUnit_Framework_TestCase {
 		$newFingerprint = $entity->getFingerprint();
 
 		$this->assertSame( $fingerprint, $newFingerprint );
+	}
+
+	public function testGetLabels() {
+		$item = new Item();
+		$item->setLabel( 'en', 'foo' );
+
+		$this->assertEquals(
+			new TermList( array(
+				new Term( 'en', 'foo' )
+			) ),
+			$item->getLabels()
+		);
+	}
+
+	public function testGetDescriptions() {
+		$item = new Item();
+		$item->setDescription( 'en', 'foo bar' );
+
+		$this->assertEquals(
+			new TermList( array(
+				new Term( 'en', 'foo bar' )
+			) ),
+			$item->getDescriptions()
+		);
+	}
+
+	public function testGetAliasGroups() {
+		$item = new Item();
+		$item->setAliases( 'en', array( 'foo', 'bar' ) );
+
+		$this->assertEquals(
+			new AliasGroupList( array(
+				new AliasGroup( 'en', array( 'foo', 'bar' ) )
+			) ),
+			$item->getAliasGroups()
+		);
+	}
+
+	public function testGetLabels_sameListAsFingerprint() {
+		$item = new Item();
+
+		$this->assertSame(
+			$item->getFingerprint()->getLabels(),
+			$item->getLabels()
+		);
+	}
+
+	public function testGetDescriptions_sameListAsFingerprint() {
+		$item = new Item();
+
+		$this->assertSame(
+			$item->getFingerprint()->getDescriptions(),
+			$item->getDescriptions()
+		);
+	}
+
+	public function testGetAliasGroups_sameListAsFingerprint() {
+		$item = new Item();
+
+		$this->assertSame(
+			$item->getFingerprint()->getAliasGroups(),
+			$item->getAliasGroups()
+		);
 	}
 
 }

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -578,4 +578,67 @@ class PropertyTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame( $fingerprint, $newFingerprint );
 	}
 
+	public function testGetLabels() {
+		$property = Property::newFromType( 'string' );
+		$property->setLabel( 'en', 'foo' );
+
+		$this->assertEquals(
+			new TermList( array(
+				new Term( 'en', 'foo' )
+			) ),
+			$property->getLabels()
+		);
+	}
+
+	public function testGetDescriptions() {
+		$property = Property::newFromType( 'string' );
+		$property->setDescription( 'en', 'foo bar' );
+
+		$this->assertEquals(
+			new TermList( array(
+				new Term( 'en', 'foo bar' )
+			) ),
+			$property->getDescriptions()
+		);
+	}
+
+	public function testGetAliasGroups() {
+		$property = Property::newFromType( 'string' );
+		$property->setAliases( 'en', array( 'foo', 'bar' ) );
+
+		$this->assertEquals(
+			new AliasGroupList( array(
+				new AliasGroup( 'en', array( 'foo', 'bar' ) )
+			) ),
+			$property->getAliasGroups()
+		);
+	}
+
+	public function testGetLabels_sameListAsFingerprint() {
+		$property = Property::newFromType( 'string' );
+
+		$this->assertSame(
+			$property->getFingerprint()->getLabels(),
+			$property->getLabels()
+		);
+	}
+
+	public function testGetDescriptions_sameListAsFingerprint() {
+		$property = Property::newFromType( 'string' );
+
+		$this->assertSame(
+			$property->getFingerprint()->getDescriptions(),
+			$property->getDescriptions()
+		);
+	}
+
+	public function testGetAliasGroups_sameListAsFingerprint() {
+		$property = Property::newFromType( 'string' );
+
+		$this->assertSame(
+			$property->getFingerprint()->getAliasGroups(),
+			$property->getAliasGroups()
+		);
+	}
+
 }


### PR DESCRIPTION
With this patch applied, Item and Property implement the term related
interfaces LabelsProvider, DescriptionsProvider and AliasesProvider.

Note that the signature of getLabels and getDescriptions changed and those
methods now return TermList objects instead of plain arrays.

Depends on #631 

**Note that this shouldn't be merged before we are sure the next release will be 6.0.0**

Bug: [T126152](https://phabricator.wikimedia.org/T126152)