### PR TITLE
Copy copy methods to Item and Property

### DIFF
--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -319,4 +319,15 @@ class Item extends Entity implements StatementListHolder {
 			&& $this->statements->equals( $target->statements );
 	}
 
+	/**
+	 * @see EntityDocument::copy
+	 *
+	 * @since 0.1
+	 *
+	 * @return self
+	 */
+	public function copy() {
+		return unserialize( serialize( $this ) );
+	}
+
 }

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -251,4 +251,15 @@ class Property extends Entity implements StatementListHolder {
 		$this->statements = $statements;
 	}
 
+	/**
+	 * @see EntityDocument::copy
+	 *
+	 * @since 0.1
+	 *
+	 * @return self
+	 */
+	public function copy() {
+		return unserialize( serialize( $this ) );
+	}
+
 }


### PR DESCRIPTION
This acts as a baseline for a whole bunch of patches that all touch the same code, including #626, #630, #631 and #632. All these patches should become a bit easier to review with this baseline.

The `@since` tags are intentional, because both classes are guaranteed to have a `copy` method since 0.1