### PR TITLE
Fix ReferenceList not removing all reference with same hash

### DIFF
--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -117,7 +117,7 @@ class ReferenceList implements Comparable, Countable, IteratorAggregate, Seriali
 	}
 
 	/**
-	 * Returns the index of a reference or false if the reference could not be found.
+	 * Returns the index of the Reference object or false if the Reference could not be found.
 	 *
 	 * @since 0.5
 	 *
@@ -160,29 +160,31 @@ class ReferenceList implements Comparable, Countable, IteratorAggregate, Seriali
 	}
 
 	/**
-	 * Removes the reference with the provided hash if it exists in the list.
+	 * Looks for the first Reference object in this list with the provided hash.
+	 * Removes all occurences of that object.
 	 *
 	 * @since 0.3
 	 *
 	 * @param string $referenceHash	`
 	 */
 	public function removeReferenceHash( $referenceHash ) {
-		foreach ( $this->references as $index => $reference ) {
-			if ( $reference->getHash() === $referenceHash ) {
-				$this->removeReferenceAtIndex( $index );
+		$reference = $this->getReference( $referenceHash );
+
+		if ( $reference === null ) {
+			return;
+		}
+
+		foreach ( $this->references as $index => $ref ) {
+			if ( $ref === $reference ) {
+				unset( $this->references[$index] );
 			}
 		}
+
+		$this->references = array_values( $this->references );
 	}
 
 	/**
-	 * @param int $index
-	 */
-	private function removeReferenceAtIndex( $index ) {
-		array_splice( $this->references, $index, 1 );
-	}
-
-	/**
-	 * Returns the reference with the provided hash, or
+	 * Returns the first Reference object with the provided hash, or
 	 * null if there is no such reference in the list.
 	 *
 	 * @since 0.3

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -157,6 +157,26 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( true );
 	}
 
+	public function testRemoveReferenceRemovesIdenticalObjects() {
+		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
+		$references = new ReferenceList( array( $reference, $reference ) );
+
+		$references->removeReference( $reference );
+
+		$this->assertTrue( $references->isEmpty() );
+	}
+
+	public function testRemoveReferenceDoesNotRemoveCopies() {
+		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
+		$references = new ReferenceList( array( $reference, clone $reference ) );
+
+		$references->removeReference( $reference );
+
+		$this->assertFalse( $references->isEmpty() );
+		$this->assertTrue( $references->hasReference( $reference ) );
+		$this->assertNotSame( $reference, $references->getReference( $reference->getHash() ) );
+	}
+
 	public function testAddReferenceOnEmptyList() {
 		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
 
@@ -330,19 +350,34 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 0, count( $references ) );
 	}
 
-	public function testRemoveReferenceHash_occurrencesOfSameObjectGetRemoved() {
-		$reference = new Reference( array( new PropertyNoValueSnak( 42 ) ) );
-		$references = new ReferenceList( array(
-			$reference,
-			clone $reference,
-			$reference
-		) );
+	public function testRemoveReferenceHashRemovesIdenticalObjects() {
+		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
+		$references = new ReferenceList( array( $reference, $reference ) );
 
 		$references->removeReferenceHash( $reference->getHash() );
 
-		$this->assertTrue( $references->hasReferenceHash( $reference->getHash() ) );
-		$this->assertCount( 1, $references );
+		$this->assertTrue( $references->isEmpty() );
+	}
+
+	public function testRemoveReferenceHashDoesNotRemoveCopies() {
+		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
+		$references = new ReferenceList( array( $reference, clone $reference ) );
+
+		$references->removeReferenceHash( $reference->getHash() );
+
+		$this->assertFalse( $references->isEmpty() );
+		$this->assertTrue( $references->hasReference( $reference ) );
 		$this->assertNotSame( $reference, $references->getReference( $reference->getHash() ) );
+	}
+
+	public function testRemoveReferenceHashUpdatesIndexes() {
+		$reference1 = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
+		$reference2 = new Reference( array( new PropertyNoValueSnak( 2 ) ) );
+		$references = new ReferenceList( array( $reference1, $reference2 ) );
+
+		$references->removeReferenceHash( $reference1->getHash() );
+
+		$this->assertSame( 0, $references->indexOf( $reference2 ) );
 	}
 
 	public function testGivenOneSnak_addNewReferenceAddsSnak() {

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -330,6 +330,21 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 0, count( $references ) );
 	}
 
+	public function testRemoveReferenceHash_occurrencesOfSameObjectGetRemoved() {
+		$reference = new Reference( array( new PropertyNoValueSnak( 42 ) ) );
+		$references = new ReferenceList( array(
+			$reference,
+			clone $reference,
+			$reference
+		) );
+
+		$references->removeReferenceHash( $reference->getHash() );
+
+		$this->assertTrue( $references->hasReferenceHash( $reference->getHash() ) );
+		$this->assertCount( 1, $references );
+		$this->assertNotSame( $reference, $references->getReference( $reference->getHash() ) );
+	}
+
 	public function testGivenOneSnak_addNewReferenceAddsSnak() {
 		$references = new ReferenceList();
 		$snak = new PropertyNoValueSnak( 1 );


### PR DESCRIPTION
I'm actually very confused by this because as far as I can see the old implementation of this only removed the first reference with that hash in the list. [[1]](https://github.com/wmde/WikibaseDataModel/blob/4.4.0/src/ReferenceList.php#L192) However, without this patch, tests in Wikibase are broken because of this missing feature. [[2]](https://integration.wikimedia.org/ci/job/mwext-Wikibase-repo-tests-sqlite-hhvm/8473/consoleFull)

Anyways, it is very bad to change the array keys while iterating over it in a for loop so we need to fix that to use it in Wikibase and release a 5.0.1.