### PR TITLE
[WIP] Fix unexpected behavior of ReferenceList::removeReferenceHash

### DIFF
--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -337,15 +337,13 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $references->isEmpty() );
 	}
 
-	public function testRemoveReferenceHashDoesNotRemoveCopies() {
+	public function testRemoveReferenceHashRemovesCopies() {
 		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
 		$references = new ReferenceList( array( $reference, clone $reference ) );
 
 		$references->removeReferenceHash( $reference->getHash() );
 
-		$this->assertFalse( $references->isEmpty() );
-		$this->assertTrue( $references->hasReference( $reference ) );
-		$this->assertNotSame( $reference, $references->getReference( $reference->getHash() ) );
+		$this->assertTrue( $references->isEmpty() );
 	}
 
 	public function testRemoveReferenceHashUpdatesIndexes() {


### PR DESCRIPTION
@Benestar found these issues in #634. Actually fixing these is a breaking change, because this behavior was identical in 4.x and 5.x.