### PR TITLE
[WIP] ReferenceList should never contain any duplicates

### DIFF
--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -50,10 +50,10 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$this->assertCount( 1, $list );
 	}
 
-	public function testConstructorDoesNotIgnoreCopies() {
+	public function testConstructorIgnoresCopies() {
 		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
 		$list = new ReferenceList( array( $reference, clone $reference ) );
-		$this->assertCount( 2, $list );
+		$this->assertCount( 1, $list );
 	}
 
 	/**
@@ -208,12 +208,12 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$this->assertCount( 1, $list );
 	}
 
-	public function testAddReferenceDoesNotIgnoreCopies() {
+	public function testAddReferenceIgnoresCopies() {
 		$list = new ReferenceList();
 		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
 		$list->addReference( $reference );
 		$list->addReference( clone $reference );
-		$this->assertCount( 2, $list );
+		$this->assertCount( 1, $list );
 	}
 
 	public function testAddReferenceAtIndexIgnoresIdenticalObjects() {
@@ -373,15 +373,13 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $references->isEmpty() );
 	}
 
-	public function testRemoveReferenceHashDoesNotRemoveCopies() {
+	public function testRemoveReferenceHashRemovesCopies() {
 		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
 		$references = new ReferenceList( array( $reference, clone $reference ) );
 
 		$references->removeReferenceHash( $reference->getHash() );
 
-		$this->assertFalse( $references->isEmpty() );
-		$this->assertTrue( $references->hasReference( $reference ) );
-		$this->assertNotSame( $reference, $references->getReference( $reference->getHash() ) );
+		$this->assertTrue( $references->isEmpty() );
 	}
 
 	public function testRemoveReferenceHashUpdatesIndexes() {
@@ -426,20 +424,20 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $references->hasReference( new Reference( $snaks ) ) );
 	}
 
-	public function testAddNewReferenceDoesNotIgnoreIdenticalObjects() {
+	public function testAddNewReferenceIgnoresIdenticalObjects() {
 		$list = new ReferenceList();
 		$snak = new PropertyNoValueSnak( 1 );
 		$list->addNewReference( $snak );
 		$list->addNewReference( $snak );
-		$this->assertCount( 2, $list );
+		$this->assertCount( 1, $list );
 	}
 
-	public function testAddNewReferenceDoesNotIgnoreCopies() {
+	public function testAddNewReferenceIgnoresCopies() {
 		$list = new ReferenceList();
 		$snak = new PropertyNoValueSnak( 1 );
 		$list->addNewReference( $snak );
 		$list->addNewReference( clone $snak );
-		$this->assertCount( 2, $list );
+		$this->assertCount( 1, $list );
 	}
 
 	public function testGivenNoneSnak_addNewReferenceThrowsException() {


### PR DESCRIPTION
This patch is not about ignoring identical objects (that was #639), but about ignoring references with the same hash. The tests describe the proposed behavior.

We discussed this with @lydiapintscher and @Benestar and came to the conclusion that the current behavior is most probably what we want. Users may run into this when they try to save an identical reference as an intermediate step. So **do not merge** this. However, I would like to have this open for a while to gather opinions.
