### PR TITLE
Fix regression when adding the same reference object twice

### DIFF
--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -44,6 +44,12 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$this->assertNotNull( $copy->getReference( $reference->getHash() ) );
 	}
 
+	public function testConstructorIgnoresIdenticalObjects() {
+		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
+		$list = new ReferenceList( array( $reference, $reference ) );
+		$this->assertCount( 1, $list );
+	}
+
 	public function testConstructorDoesNotIgnoreCopies() {
 		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
 		$list = new ReferenceList( array( $reference, clone $reference ) );
@@ -194,12 +200,28 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$this->assertSameReferenceOrder( $expectedList, $references );
 	}
 
+	public function testAddReferenceIgnoresIdenticalObjects() {
+		$list = new ReferenceList();
+		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
+		$list->addReference( $reference );
+		$list->addReference( $reference );
+		$this->assertCount( 1, $list );
+	}
+
 	public function testAddReferenceDoesNotIgnoreCopies() {
 		$list = new ReferenceList();
 		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
 		$list->addReference( $reference );
 		$list->addReference( clone $reference );
 		$this->assertCount( 2, $list );
+	}
+
+	public function testAddReferenceAtIndexIgnoresIdenticalObjects() {
+		$list = new ReferenceList();
+		$reference = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
+		$list->addReference( $reference, 0 );
+		$list->addReference( $reference, 0 );
+		$this->assertCount( 1, $list );
 	}
 
 	public function testAddReferenceAtIndexZero() {


### PR DESCRIPTION
~~This is really ugly performance-wise, and we should think about this twice before merging it.~~ Reworked to use `spl_object_hash()` to replicate the behavior of the previous, SPL object store based implementation.

Marked as a bug because it is a regression between 4.4.0 (the tests in this patch succeed with 4.4.0) and 5.0.0.