### PR TITLE
Test 4.x behavior of ReferenceList::addReference at index

### DIFF
--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -224,6 +224,24 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$this->assertCount( 1, $list );
 	}
 
+	public function testAddReferenceAtIndexMovesIdenticalObjects() {
+		$list = new ReferenceList();
+		$list->addNewReference( new PropertyNoValueSnak( 1 ) );
+		$reference = new Reference( array( new PropertyNoValueSnak( 2 ) ) );
+		$list->addReference( $reference );
+		$this->assertSame( 1, $list->indexOf( $reference ), 'pre condition' );
+
+		$list->addReference( $reference, 0 );
+
+		$this->assertCount( 2, $list, 'not added' );
+		$this->assertSame( 0, $list->indexOf( $reference ), 'can decrease index' );
+
+		$list->addReference( $reference, 2 );
+
+		$this->assertCount( 2, $list, 'not added' );
+		$this->assertSame( 0, $list->indexOf( $reference ), 'can not increase index' );
+	}
+
 	public function testAddReferenceAtIndexZero() {
 		$reference1 = new Reference( array( new PropertyNoValueSnak( 1 ) ) );
 		$reference2 = new Reference( array( new PropertyNoValueSnak( 2 ) ) );


### PR DESCRIPTION
I wrote this test in 4.4.0. It describes the behavior of version 4.4.0 and succeeds there. It failed in 5.0.1. It succeeds in 5.0.2.

The test does test multiple things:
* It checks if identical objects are ignored. This was broken in 5.0.1 and got fixed in 5.0.2 by #639.
* It checks if it's possible to move an existing reference to a lower index.
* It tries to move a reference to a higher index, but expects this to fail, because 4.x was not able to do this.