### PR TITLE
Remove type checks from AliasGroup/TermList getters

### DIFF
--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -73,12 +73,9 @@ class AliasGroupList implements Countable, IteratorAggregate {
 	 * @param string $languageCode
 	 *
 	 * @return AliasGroup
-	 * @throws InvalidArgumentException
 	 * @throws OutOfBoundsException
 	 */
 	public function getByLanguage( $languageCode ) {
-		$this->assertIsLanguageCode( $languageCode );
-
 		if ( !array_key_exists( $languageCode, $this->groups ) ) {
 			throw new OutOfBoundsException( 'AliasGroup with languageCode "' . $languageCode . '" not found' );
 		}
@@ -99,17 +96,9 @@ class AliasGroupList implements Countable, IteratorAggregate {
 
 	/**
 	 * @param string $languageCode
-	 * @throws InvalidArgumentException
 	 */
 	public function removeByLanguage( $languageCode ) {
-		$this->assertIsLanguageCode( $languageCode );
 		unset( $this->groups[$languageCode] );
-	}
-
-	private function assertIsLanguageCode( $languageCode ) {
-		if ( !is_string( $languageCode ) || $languageCode === '' ) {
-			throw new InvalidArgumentException( '$languageCode must be a non-empty string' );
-		}
 	}
 
 	/**
@@ -185,7 +174,6 @@ class AliasGroupList implements Countable, IteratorAggregate {
 	 * @return boolean
 	 */
 	public function hasGroupForLanguage( $languageCode ) {
-		$this->assertIsLanguageCode( $languageCode );
 		return array_key_exists( $languageCode, $this->groups );
 	}
 

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -76,12 +76,9 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 	 * @param string $languageCode
 	 *
 	 * @return Term
-	 * @throws InvalidArgumentException
 	 * @throws OutOfBoundsException
 	 */
 	public function getByLanguage( $languageCode ) {
-		$this->assertIsLanguageCode( $languageCode );
-
 		if ( !array_key_exists( $languageCode, $this->terms ) ) {
 			throw new OutOfBoundsException( 'Term with languageCode "' . $languageCode . '" not found' );
 		}
@@ -100,20 +97,20 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 		return new self( array_intersect_key( $this->terms, array_flip( $languageCodes ) ) );
 	}
 
+	/**
+	 * @param string $languageCode
+	 */
 	public function removeByLanguage( $languageCode ) {
-		$this->assertIsLanguageCode( $languageCode );
 		unset( $this->terms[$languageCode] );
 	}
 
+	/**
+	 * @param string $languageCode
+	 *
+	 * @return bool
+	 */
 	public function hasTermForLanguage( $languageCode ) {
-		$this->assertIsLanguageCode( $languageCode );
 		return array_key_exists( $languageCode, $this->terms );
-	}
-
-	private function assertIsLanguageCode( $languageCode ) {
-		if ( !is_string( $languageCode ) || $languageCode === '' ) {
-			throw new InvalidArgumentException( '$languageCode must be a non-empty string' );
-		}
 	}
 
 	/**

--- a/tests/unit/Term/AliasGroupListTest.php
+++ b/tests/unit/Term/AliasGroupListTest.php
@@ -2,7 +2,7 @@
 
 namespace Wikibase\DataModel\Tests\Term;
 
-use InvalidArgumentException;
+use PHPUnit_Framework_TestCase;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;
 
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Term\AliasGroupList;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
+class AliasGroupListTest extends PHPUnit_Framework_TestCase {
 
 	public function testIsEmpty() {
 		$list = new AliasGroupList();
@@ -106,10 +106,10 @@ class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider invalidLanguageCodeProvider
-	 * @expectedException InvalidArgumentException
 	 */
 	public function testGivenInvalidLanguageCode_getByLanguageThrowsException( $languageCode ) {
 		$list = new AliasGroupList();
+		$this->setExpectedException( 'OutOfBoundsException' );
 		$list->getByLanguage( $languageCode );
 	}
 
@@ -162,11 +162,11 @@ class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider invalidLanguageCodeProvider
-	 * @expectedException InvalidArgumentException
 	 */
-	public function testGivenInvalidLanguageCode_removeByLanguageThrowsException( $languageCode ) {
-		$list = new AliasGroupList();
+	public function testGivenInvalidLanguageCode_removeByLanguageIsNoOp( $languageCode ) {
+		$list = new AliasGroupList( array( new AliasGroup( 'en', array( 'foo' ) ) ) );
 		$list->removeByLanguage( $languageCode );
+		$this->assertFalse( $list->isEmpty() );
 	}
 
 	public function testGivenEmptyGroups_constructorRemovesThem() {
@@ -273,11 +273,10 @@ class AliasGroupListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider invalidLanguageCodeProvider
-	 * @expectedException InvalidArgumentException
 	 */
-	public function testGivenInvalidLanguageCode_hasGroupForLanguageThrowsException( $languageCode ) {
+	public function testGivenInvalidLanguageCode_hasGroupForLanguageReturnsFalse( $languageCode ) {
 		$list = new AliasGroupList();
-		$list->hasGroupForLanguage( $languageCode );
+		$this->assertFalse( $list->hasGroupForLanguage( $languageCode ) );
 	}
 
 	public function invalidLanguageCodeProvider() {

--- a/tests/unit/Term/TermListTest.php
+++ b/tests/unit/Term/TermListTest.php
@@ -118,10 +118,10 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider invalidLanguageCodeProvider
-	 * @expectedException InvalidArgumentException
 	 */
 	public function testGivenInvalidLanguageCode_getByLanguageThrowsException( $languageCode ) {
 		$list = new TermList();
+		$this->setExpectedException( 'OutOfBoundsException' );
 		$list->getByLanguage( $languageCode );
 	}
 
@@ -150,11 +150,10 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider invalidLanguageCodeProvider
-	 * @expectedException InvalidArgumentException
 	 */
-	public function testGivenInvalidLanguageCode_hasTermForLanguageThrowsException( $languageCode ) {
+	public function testGivenInvalidLanguageCode_hasTermForLanguageReturnsFalse( $languageCode ) {
 		$list = new TermList();
-		$list->hasTermForLanguage( $languageCode );
+		$this->assertFalse( $list->hasTermForLanguage( $languageCode ) );
 	}
 
 	public function invalidLanguageCodeProvider() {
@@ -194,11 +193,11 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider invalidLanguageCodeProvider
-	 * @expectedException InvalidArgumentException
 	 */
-	public function testGivenInvalidLanguageCode_removeByLanguageThrowsException( $languageCode ) {
-		$list = new TermList();
+	public function testGivenInvalidLanguageCode_removeByLanguageDoesNoOp( $languageCode ) {
+		$list = new TermList( array( new Term( 'en', 'foo' ) ) );
 		$list->removeByLanguage( $languageCode );
+		$this->assertFalse( $list->isEmpty() );
 	}
 
 	public function testGivenTermForNewLanguage_setTermAddsTerm() {


### PR DESCRIPTION
This is about performance.

Why do I think these checks are not necessary? Because nothing unexpected happens when an array key is not found.
* When you provide an integer key or something else that can't be found in the array, all three methods have a well defined, expected behavior. These methods are not supposed to check if an array key is allowed to be in the array, this must be checked in the constructor/setter.
* On the other hand, when you provide some object that's then casted to string, and this string is then found in the array, why shouldn't that work?