### PR TITLE
Simplify and clean up AliasGroupListTest assertions

### DIFF
--- a/tests/unit/Term/AliasGroupListTest.php
+++ b/tests/unit/Term/AliasGroupListTest.php
@@ -48,7 +48,7 @@ class AliasGroupListTest extends PHPUnit_Framework_TestCase {
 
 		$list = new AliasGroupList( $array );
 
-		$this->assertEquals( $array, iterator_to_array( $list ) );
+		$this->assertSame( $array, iterator_to_array( $list ) );
 	}
 
 	public function testGivenGroupsWithTheSameLanguage_onlyTheLastOnesAreRetained() {
@@ -85,7 +85,7 @@ class AliasGroupListTest extends PHPUnit_Framework_TestCase {
 		 */
 		foreach ( $list as $key => $aliasGroup ) {
 			$this->assertEquals( $group, $aliasGroup );
-			$this->assertEquals( $aliasGroup->getLanguageCode(), $key );
+			$this->assertSame( $aliasGroup->getLanguageCode(), $key );
 		}
 	}
 
@@ -159,7 +159,7 @@ class AliasGroupListTest extends PHPUnit_Framework_TestCase {
 
 		$list->removeByLanguage( 'en' );
 
-		$this->assertEquals( new AliasGroupList(), $list );
+		$this->assertTrue( $list->isEmpty() );
 	}
 
 	/**
@@ -172,20 +172,13 @@ class AliasGroupListTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenEmptyGroups_constructorRemovesThem() {
-		$enGroup = new AliasGroup( 'en', [ 'foo' ] );
-
 		$list = new AliasGroupList( [
 			new AliasGroup( 'de' ),
-			$enGroup,
-			new AliasGroup( 'en' ),
-			new AliasGroup( 'nl' ),
-		] );
-
-		$expectedList = new AliasGroupList( [
+			new AliasGroup( 'en', [ 'foo' ] ),
 			new AliasGroup( 'en' ),
 		] );
 
-		$this->assertEquals( $expectedList, $list );
+		$this->assertTrue( $list->isEmpty() );
 	}
 
 	public function testGivenEmptyGroup_setGroupRemovesGroup() {
@@ -193,12 +186,10 @@ class AliasGroupListTest extends PHPUnit_Framework_TestCase {
 			new AliasGroup( 'en', [ 'foo' ] ),
 		] );
 
-		$expectedList = new AliasGroupList();
-
 		$list->setGroup( new AliasGroup( 'en' ) );
 		$list->setGroup( new AliasGroup( 'de' ) );
 
-		$this->assertEquals( $expectedList, $list );
+		$this->assertEquals( new AliasGroupList(), $list );
 	}
 
 	public function testEmptyListEqualsEmptyList() {
@@ -333,7 +324,7 @@ class AliasGroupListTest extends PHPUnit_Framework_TestCase {
 
 		$list = new AliasGroupList( $array );
 
-		$this->assertEquals( $array, $list->toArray() );
+		$this->assertSame( $array, $list->toArray() );
 	}
 
 	public function testGivenEmptyList_getWithLanguagesReturnsEmptyList() {


### PR DESCRIPTION
- Use more strict `assertSame` whenever possible.
- ~~Use isEmpty when possible, instead of comparing objects.~~
- In `testGivenEmptyGroups_constructorRemovesThem` two objects were compared, but it was never checked if they are empty.
