### PR TITLE
Add clear to list classes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,6 +11,7 @@
 * Removed `HashArray::indicesAreUpToDate`
 * Removed `HashArray::removeDuplicates`
 * Removed `$acceptDuplicates` feature from `HashArray`
+* Added `clear` to `TermList`, `AliasGroupList` and `StatementList`
 
 ## Version 6.3.1 (2016-11-30)
 

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -342,6 +342,15 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	/**
+	 * Removes all statements from this list.
+	 *
+	 * @since 6.0
+	 */
+	public function clear() {
+		$this->statements = [];
+	}
+
+	/**
 	 * @see http://php.net/manual/en/language.oop5.cloning.php
 	 *
 	 * @since 5.1

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -204,4 +204,13 @@ class AliasGroupList implements Countable, IteratorAggregate {
 		return $array;
 	}
 
+	/**
+	 * Removes all alias groups from this list.
+	 *
+	 * @since 6.0
+	 */
+	public function clear() {
+		$this->groups = [];
+	}
+
 }

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -187,4 +187,13 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 			&& $this->terms[$term->getLanguageCode()]->equals( $term );
 	}
 
+	/**
+	 * Removes all terms from this list.
+	 *
+	 * @since 6.0
+	 */
+	public function clear() {
+		$this->terms = [];
+	}
+
 }

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -702,4 +702,14 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testClear() {
+		$statement1 = $this->getStatement( 'P1', null );
+		$statement2 = $this->getStatement( 'P2', null );
+		$statements = new StatementList( $statement1, $statement2 );
+
+		$statements->clear();
+
+		$this->assertEquals( new StatementList(), $statements );
+	}
+
 }

--- a/tests/unit/Term/AliasGroupListTest.php
+++ b/tests/unit/Term/AliasGroupListTest.php
@@ -383,4 +383,14 @@ class AliasGroupListTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( $expected, $list->toTextArray() );
 	}
 
+	public function testClear() {
+		$list = new AliasGroupList();
+		$list->setAliasesForLanguage( 'en', [ 'foo', 'baz' ] );
+		$list->setAliasesForLanguage( 'de', [ 'bar' ] );
+
+		$list->clear();
+
+		$this->assertEquals( new AliasGroupList(), $list );
+	}
+
 }

--- a/tests/unit/Term/TermListTest.php
+++ b/tests/unit/Term/TermListTest.php
@@ -396,4 +396,14 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testClear() {
+		$list = new TermList();
+		$list->setTextForLanguage( 'en', 'foo' );
+		$list->setTextForLanguage( 'de', 'bar' );
+
+		$list->clear();
+
+		$this->assertEquals( new TermList(), $list );
+	}
+
 }


### PR DESCRIPTION
This is needed as a replacement for users of the holder interfaces to remove all elements from one of the given list classes.

[Bug: T128363](https://phabricator.wikimedia.org/T128363)