### PR TITLE
Remove reindexing feature from ReferenceList::addReference

### DIFF
--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -71,9 +71,15 @@ class ReferenceList implements Comparable, Countable, IteratorAggregate, Seriali
 			return;
 		}
 
+		$splHash = spl_object_hash( $reference );
+
+		if ( array_key_exists( $splHash, $this->references ) ) {
+			return;
+		}
+
 		if ( $index === null || $index >= count( $this->references ) ) {
 			// Append object to the end of the reference list.
-			$this->references[spl_object_hash( $reference )] = $reference;
+			$this->references[$splHash] = $reference;
 		} else {
 			$this->insertReferenceAtIndex( $reference, $index );
 		}
@@ -104,9 +110,11 @@ class ReferenceList implements Comparable, Countable, IteratorAggregate, Seriali
 			throw new InvalidArgumentException( '$index must be an integer' );
 		}
 
+		$splHash = spl_object_hash( $reference );
+
 		$this->references = array_merge(
 			array_slice( $this->references, 0, $index ),
-			[ spl_object_hash( $reference ) => $reference ],
+			[ $splHash => $reference ],
 			array_slice( $this->references, $index )
 		);
 	}

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -241,17 +241,31 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$list->addNewReference( new PropertyNoValueSnak( 1 ) );
 		$reference = new Reference( [ new PropertyNoValueSnak( 2 ) ] );
 		$list->addReference( $reference );
-		$this->assertSame( 1, $list->indexOf( $reference ), 'pre condition' );
+		$list->addNewReference( new PropertyNoValueSnak( 3 ) );
+
+		$this->assertSame(
+			1,
+			$list->indexOf( $reference ),
+			'pre-condition is that the element is at index 1'
+		);
 
 		$list->addReference( $reference, 0 );
 
-		$this->assertCount( 2, $list, 'not added' );
-		$this->assertSame( 0, $list->indexOf( $reference ), 'can decrease index' );
+		$this->assertCount( 3, $list, 'not added' );
+		$this->assertSame(
+			1,
+			$list->indexOf( $reference ),
+			'make sure calling addReference with a lower index did not changed it'
+		);
 
 		$list->addReference( $reference, 2 );
 
-		$this->assertCount( 2, $list, 'not added' );
-		$this->assertSame( 0, $list->indexOf( $reference ), 'can not increase index' );
+		$this->assertCount( 3, $list, 'not added' );
+		$this->assertSame(
+			1,
+			$list->indexOf( $reference ),
+			'make sure calling addReference with a higher index did not changed it'
+		);
 	}
 
 	public function testAddReferenceAtIndexZero() {


### PR DESCRIPTION
This behavior was inconsistent at least since 4.x, if not forever. I added these tests just recently in #641. They tested the current, but undocumented (and I believe unintentional) behavior: When adding the **same** reference a second time, it was possible to move it to a position with a smaller index, but not to a higher index. My first attempt was to fix the later. After reconsideration I'm now removing this reindexing feature entirely.

Technically breaking, but unused and therefore of no consequence in our relevant code bases.