### PR TITLE
Add index parameter to StatementList::addStatement

### DIFF
--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -26,6 +26,7 @@ use Wikibase\DataModel\Snak\SnakList;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
+ * @author Thiemo Mättig
  */
 class StatementList implements IteratorAggregate, Comparable, Countable {
 
@@ -74,8 +75,23 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 		return $propertyIds;
 	}
 
-	public function addStatement( Statement $statement ) {
-		$this->statements[] = $statement;
+	/**
+	 * @since 1.0, setting an index is supported since 6.1
+	 * @see ReferenceList::addReference
+	 *
+	 * @param Statement $statement
+	 * @param int|null $index New position of the added statement, or null to append.
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function addStatement( Statement $statement, $index = null ) {
+		if ( $index === null ) {
+			$this->statements[] = $statement;
+		} elseif ( is_int( $index ) && $index >= 0 ) {
+			array_splice( $this->statements, $index, 0, array( $statement ) );
+		} else {
+			throw new InvalidArgumentException( '$index must be a non-negative integer or null' );
+		}
 	}
 
 	/**
@@ -91,7 +107,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 		$statement = new Statement( $mainSnak, $qualifiers, $references );
 		$statement->setGuid( $guid );
 
-		$this->addStatement( $statement );
+		$this->statements[] = $statement;
 	}
 
 	/**
@@ -139,7 +155,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 
 		foreach ( $this->statements as $statement ) {
 			if ( $statement->getPropertyId()->equals( $id ) ) {
-				$statementList->addStatement( $statement );
+				$statementList->statements[] = $statement;
 			}
 		}
 
@@ -159,7 +175,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 
 		foreach ( $this->statements as $statement ) {
 			if ( array_key_exists( $statement->getRank(), $acceptableRanks ) ) {
-				$statementList->addStatement( $statement );
+				$statementList->statements[] = $statement;
 			}
 		}
 
@@ -318,7 +334,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 
 		foreach ( $this->statements as $statement ) {
 			if ( $filter->statementMatches( $statement ) ) {
-				$statementList->addStatement( $statement );
+				$statementList->statements[] = $statement;
 			}
 		}
 

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -236,6 +236,42 @@ class StatementListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( new StatementList( $statement ), $list );
 	}
 
+	public function testGivenNegativeIndex_addStatementFails() {
+		$statement = new Statement( new PropertyNoValueSnak( 1 ) );
+		$list = new StatementList();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$list->addStatement( $statement, -1 );
+	}
+
+	public function testGivenLargeIndex_addStatementAppends() {
+		$statement = new Statement( new PropertyNoValueSnak( 1 ) );
+		$list = new StatementList();
+
+		$list->addStatement( $statement, 1000 );
+		$this->assertEquals( new StatementList( $statement ), $list );
+	}
+
+	public function testGivenZeroIndex_addStatementPrepends() {
+		$statement1 = new Statement( new PropertyNoValueSnak( 1 ) );
+		$statement2 = new Statement( new PropertyNoValueSnak( 2 ) );
+		$list = new StatementList( $statement2 );
+
+		$list->addStatement( $statement1, 0 );
+		$this->assertEquals( new StatementList( $statement1, $statement2 ), $list );
+	}
+
+	public function testGivenValidIndex_addStatementInserts() {
+		$statement1 = new Statement( new PropertyNoValueSnak( 1 ) );
+		$statement2 = new Statement( new PropertyNoValueSnak( 2 ) );
+		$statement3 = new Statement( new PropertyNoValueSnak( 3 ) );
+		$list = new StatementList( $statement1, $statement3 );
+
+		$list->addStatement( $statement2, 1 );
+		$this->assertEquals( new StatementList( $statement1, $statement2, $statement3 ), $list );
+		$this->assertSame( array( 0, 1, 2 ), array_keys( $list->toArray() ), 'array keys' );
+	}
+
 	public function testGivenGuidOfPresentStatement_statementIsRemoved() {
 		$statement1 = new Statement( $this->newSnak( 24, 'foo' ), null, null, 'foo' );
 		$statement2 = new Statement( $this->newSnak( 32, 'bar' ), null, null, 'bar' );


### PR DESCRIPTION
I'm proposing this as the most simple fix to get rid of StatementListHolder. This is currently not possible because there is no way to re-implement the index feature in ChangeOpStatement without having an `Entity::setStatements` or at least `StatementList:clean` method.
* Currently, ChangeOpStatement turns the StatementList into an array, does all the index stuff, recreates a new StatementList and calls setStatements. Main issue: We decided we want to get rid of this setter together with all "holder" interfaces. This now turned into a pressing issue because we do not want MediaInfo to implement the deprecated holder interface.
* ChangeOpStatement could, in theory, clean the StatementList (either with a `clear` method we do not want for good reasons, see #649, or by calling the existing `removeStatementsWithGuid` in a loop, which qualifies as a hack). The StatementList can then be re-filled by re-adding all statements in the new order. Again, this is more "a hack on top of a hack" than a clean solution.
* With the proposed index parameter ChangeOpStatement becomes almost trivial.

You may wonder why this is the only StatementList method that exposes this index. Don't be fooled: `toArray` exposes the indexes. Whatever a user wants to know about an index (e.g. find statements by index or query for an index by GUID, main snak or property ID), I propose to **not** implement all this as StatementList methods. Instead, let the user iterate the array. The only guarantee `toArray` must give then (and already gives, see #466) is that the array keys correctly reflect the indexes.

This new index parameter fits, in my opinion, perfectly fine in the overall contract of the class: It's thin wrapper around a numerically index array of statements, not ordered or grouped in any way.

This is identical to `ReferenceList::addReference`.

[Bug: T133853](http://phabricator.wikimedia.org/T133853/)