### PR TITLE
Block ByPropertyIdArray construction from object properties

### DIFF
--- a/src/ByPropertyIdArray.php
+++ b/src/ByPropertyIdArray.php
@@ -3,6 +3,7 @@
 namespace Wikibase\DataModel;
 
 use ArrayObject;
+use InvalidArgumentException;
 use OutOfBoundsException;
 use RuntimeException;
 use Traversable;
@@ -51,11 +52,18 @@ class ByPropertyIdArray extends ArrayObject {
 	private $byId = null;
 
 	/**
+	 * @deprecated since 5.0, use a DataModel Service instead
 	 * @see ArrayObject::__construct
 	 *
 	 * @param PropertyIdProvider[]|Traversable|null $input
+	 *
+	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $input = null ) {
+		if ( is_object( $input ) && !( $input instanceof Traversable ) ) {
+			throw new InvalidArgumentException( '$input must be an array, Traversable or null' );
+		}
+
 		parent::__construct( (array)$input );
 	}
 
@@ -411,6 +419,7 @@ class ByPropertyIdArray extends ArrayObject {
 	 * @param PropertyIdProvider $object
 	 * @param int|null $index Absolute index where to place the new object.
 	 *
+	 * @throws OutOfBoundsException
 	 * @throws RuntimeException
 	 */
 	public function addObjectAtIndex( $object, $index = null ) {

--- a/tests/unit/ByPropertyIdArrayTest.php
+++ b/tests/unit/ByPropertyIdArrayTest.php
@@ -4,8 +4,10 @@ namespace Wikibase\DataModel\Tests;
 
 use ArrayObject;
 use DataValues\StringValue;
+use PHPUnit_Framework_TestCase;
 use ReflectionClass;
 use ReflectionMethod;
+use stdClass;
 use Wikibase\DataModel\ByPropertyIdArray;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\PropertyIdProvider;
@@ -26,7 +28,21 @@ use Wikibase\DataModel\Statement\Statement;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author H. Snater < mediawiki@snater.com >
  */
-class ByPropertyIdArrayTest extends \PHPUnit_Framework_TestCase {
+class ByPropertyIdArrayTest extends PHPUnit_Framework_TestCase {
+
+	public function testGivenNull_constructorAssumesEmptyArray() {
+		$indexedArray = new ByPropertyIdArray( null );
+
+		$this->assertSame( 0, $indexedArray->count() );
+	}
+
+	public function testGivenNonTraversableObject_constructorDoesNotCastObjectToArray() {
+		$object = new stdClass();
+		$object->property = true;
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		new ByPropertyIdArray( $object );
+	}
 
 	public function testArrayObjectNotConstructedFromObject() {
 		$statement1 = new Statement( new PropertyNoValueSnak( 1 ) );


### PR DESCRIPTION
I keep running into this problem. When you pass a StatementList to this class, which is what it is build for, it iterates the **properties** of the StatementList object, not the statements.

I'm aware this is deprecated and should die entirely. That's why I'm going for the most simple fix I can think of.