### PR TITLE
Add NumericEntityId interface

### DIFF
--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class ItemId extends EntityId {
+class ItemId extends EntityId implements NumericEntityId {
 
 	/**
 	 * @since 0.5
@@ -38,6 +38,8 @@ class ItemId extends EntityId {
 	}
 
 	/**
+	 * @since 0.5
+	 *
 	 * @return int
 	 */
 	public function getNumericId() {

--- a/src/Entity/NumericEntityId.php
+++ b/src/Entity/NumericEntityId.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Wikibase\DataModel\Entity;
+
+/**
+ * Interface for EntityIds that can be converted to numbers, and back from the entity type and the
+ * number. Entity types that do not meet this criteria (e.g. when page titles or file names are used
+ * as IDs) should not implement this interface. Never return a fallback value like 0 that's the same
+ * for different IDs!
+ *
+ * Entity types are not required and not guaranteed to implement this interface. Use the full string
+ * serialization whenever you can and avoid using numeric IDs.
+ *
+ * @since 6.1
+ *
+ * @see EntityId::getSerialization
+ */
+interface NumericEntityId {
+
+	/**
+	 * @since 6.1
+	 *
+	 * @return int|float Numeric representation of the EntityId as a positive integer number in the
+	 *  [1..PHP_INT_MAX] range. A float when exceeding this range (e.g. when exceeding 2,147,483,647
+	 *  on a 32 bit system).
+	 */
+	public function getNumericId();
+
+}

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class PropertyId extends EntityId {
+class PropertyId extends EntityId implements NumericEntityId {
 
 	/**
 	 * @since 0.5
@@ -38,6 +38,8 @@ class PropertyId extends EntityId {
 	}
 
 	/**
+	 * @since 0.5
+	 *
 	 * @return int
 	 */
 	public function getNumericId() {


### PR DESCRIPTION
It's important that this interface is not added to EntityId. Not all entities can be expressed as numeric ids. This patch does not change this. What it does is basically a nice alternative for an `method_exists` check. Right now we call `getNumericId` 39 times in production and 26 times in tests. It will take us months to get rid of all these. This patch here may help us get moving.

For discussion, mainly with @brightbyte and @adrianheine.

[Bug: T135650](https://phabricator.wikimedia.org/T135650)