### PR TITLE
Add Int32EntityId

### DIFF
--- a/src/Entity/Int32EntityId.php
+++ b/src/Entity/Int32EntityId.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Wikibase\DataModel\Entity;
+
+/**
+ * Interface for EntityIds that can be converted to a unique, positive, signed 32 bit integer in the
+ * range [1..2147483647], and back from the entity type and the number. When an ID can not be
+ * represented as an unique integer, an InvalidArgumentException must be thrown on construction
+ * time. For example, when "Q1" and "Q01" have the same integer representation, only one should be
+ * allowed.
+ *
+ * Entity types that do not meet this criteria should not implement this interface.
+ *
+ * Entity types are not required and not guaranteed to implement this interface. Use the full string
+ * serialization whenever you can and avoid using numeric IDs.
+ *
+ * @since 6.1
+ *
+ * @license GPL-2.0+
+ * @author Thiemo Mättig
+ */
+interface Int32EntityId {
+
+	const MAX = 2147483647;
+
+	/**
+	 * @since 6.1
+	 *
+	 * @return int Guaranteed to be a unique integer in the range [1..2147483647].
+	 */
+	public function getNumericId();
+
+}

--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -10,12 +10,12 @@ use InvalidArgumentException;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class ItemId extends EntityId {
+class ItemId extends EntityId implements Int32EntityId {
 
 	/**
 	 * @since 0.5
 	 */
-	const PATTERN = '/^Q[1-9]\d*\z/i';
+	const PATTERN = '/^Q[1-9]\d{0,9}\z/i';
 
 	/**
 	 * @param string $idSerialization
@@ -29,11 +29,18 @@ class ItemId extends EntityId {
 
 	private function assertValidIdFormat( $idSerialization ) {
 		if ( !is_string( $idSerialization ) ) {
-			throw new InvalidArgumentException( '$idSerialization must be a string; got ' . gettype( $idSerialization ) );
+			throw new InvalidArgumentException( '$idSerialization must be a string' );
 		}
 
 		if ( !preg_match( self::PATTERN, $idSerialization ) ) {
 			throw new InvalidArgumentException( '$idSerialization must match ' . self::PATTERN );
+		}
+
+		if ( strlen( $idSerialization ) > 10
+			&& substr( $idSerialization, 1 ) > Int32EntityId::MAX
+		) {
+			throw new InvalidArgumentException( '$idSerialization can not exceed '
+				. Int32EntityId::MAX );
 		}
 	}
 

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -10,12 +10,12 @@ use InvalidArgumentException;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class PropertyId extends EntityId {
+class PropertyId extends EntityId implements Int32EntityId {
 
 	/**
 	 * @since 0.5
 	 */
-	const PATTERN = '/^P[1-9]\d*\z/i';
+	const PATTERN = '/^P[1-9]\d{0,9}\z/i';
 
 	/**
 	 * @param string $idSerialization
@@ -29,11 +29,18 @@ class PropertyId extends EntityId {
 
 	private function assertValidIdFormat( $idSerialization ) {
 		if ( !is_string( $idSerialization ) ) {
-			throw new InvalidArgumentException( '$idSerialization must be a string; got ' . gettype( $idSerialization ) );
+			throw new InvalidArgumentException( '$idSerialization must be a string' );
 		}
 
 		if ( !preg_match( self::PATTERN, $idSerialization ) ) {
 			throw new InvalidArgumentException( '$idSerialization must match ' . self::PATTERN );
+		}
+
+		if ( strlen( $idSerialization ) > 10
+			&& substr( $idSerialization, 1 ) > Int32EntityId::MAX
+		) {
+			throw new InvalidArgumentException( '$idSerialization can not exceed '
+				. Int32EntityId::MAX );
 		}
 	}
 

--- a/tests/unit/Entity/EntityIdTest.php
+++ b/tests/unit/Entity/EntityIdTest.php
@@ -27,7 +27,7 @@ class EntityIdTest extends \PHPUnit_Framework_TestCase {
 		$ids[] = array( new ItemId( 'Q1' ) );
 		$ids[] = array( new ItemId( 'Q42' ) );
 		$ids[] = array( new ItemId( 'Q31337' ) );
-		$ids[] = array( new ItemId( 'Q2147483648' ) );
+		$ids[] = array( new ItemId( 'Q2147483647' ) );
 		$ids[] = array( new PropertyId( 'P101010' ) );
 
 		return $ids;

--- a/tests/unit/Entity/EntityIdValueTest.php
+++ b/tests/unit/Entity/EntityIdValueTest.php
@@ -40,8 +40,7 @@ class EntityIdValueTest extends PHPUnit_Framework_TestCase {
 			new ItemId( 'Q1' ),
 			new ItemId( 'Q42' ),
 			new ItemId( 'Q31337' ),
-			// Check for 32-bit integer overflow on 32-bit PHP systems.
-			new ItemId( 'Q2147483648' ),
+			new ItemId( 'Q2147483647' ),
 			new PropertyId( 'P1' ),
 			new PropertyId( 'P42' ),
 			new PropertyId( 'P31337' ),

--- a/tests/unit/Entity/ItemIdTest.php
+++ b/tests/unit/Entity/ItemIdTest.php
@@ -38,7 +38,7 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 			array( 'q31337' ),
 			array( 'Q31337' ),
 			array( 'Q42' ),
-			array( 'Q2147483648' ),
+			array( 'Q2147483647' ),
 		);
 	}
 
@@ -67,6 +67,8 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 			array( '0' ),
 			array( 0 ),
 			array( 1 ),
+			array( 'Q2147483648' ),
+			array( 'Q99999999999' ),
 		);
 	}
 
@@ -122,8 +124,8 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 			array( '42' ),
 			array( 42.0 ),
 			// Check for 32-bit integer overflow on 32-bit PHP systems.
-			array( 2147483648 ),
-			array( '2147483648' ),
+			array( 2147483647 ),
+			array( '2147483647' ),
 		);
 	}
 
@@ -140,7 +142,8 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 			array( 'Q1' ),
 			array( '42.1' ),
 			array( 42.1 ),
-			array( 2147483648.1 ),
+			array( 2147483648 ),
+			array( '2147483648' ),
 		);
 	}
 

--- a/tests/unit/Entity/PropertyIdTest.php
+++ b/tests/unit/Entity/PropertyIdTest.php
@@ -38,7 +38,7 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 			array( 'p31337' ),
 			array( 'P31337' ),
 			array( 'P42' ),
-			array( 'P2147483648' ),
+			array( 'P2147483647' ),
 		);
 	}
 
@@ -67,6 +67,8 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 			array( '0' ),
 			array( 0 ),
 			array( 1 ),
+			array( 'P2147483648' ),
+			array( 'P99999999999' ),
 		);
 	}
 
@@ -122,8 +124,8 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 			array( '42' ),
 			array( 42.0 ),
 			// Check for 32-bit integer overflow on 32-bit PHP systems.
-			array( 2147483648 ),
-			array( '2147483648' ),
+			array( 2147483647 ),
+			array( '2147483647' ),
 		);
 	}
 
@@ -140,7 +142,8 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 			array( 'P1' ),
 			array( '42.1' ),
 			array( 42.1 ),
-			array( 2147483648.1 ),
+			array( 2147483648 ),
+			array( '2147483648' ),
 		);
 	}
 


### PR DESCRIPTION
Alternative proposal for [T135650](https://phabricator.wikimedia.org/T135650). The main difference to #667 is that this here is a breaking change while #667 is not. #667 will require consumers to do the int32 check, while this patch requires the same int32 check on construction time.

[Bug: T135650](https://phabricator.wikimedia.org/T135650)