### PR TITLE
Remove "@group …Test" tags for individual tests

### DIFF
--- a/tests/unit/ByPropertyIdArrayTest.php
+++ b/tests/unit/ByPropertyIdArrayTest.php
@@ -22,7 +22,6 @@ use Wikibase\DataModel\Statement\Statement;
  *
  * @group Wikibase
  * @group WikibaseDataModel
- * @group ByPropertyIdArrayTest
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/unit/Entity/EntityIdTest.php
+++ b/tests/unit/Entity/EntityIdTest.php
@@ -13,7 +13,6 @@ use Wikibase\DataModel\Entity\PropertyId;
  *
  * @group Wikibase
  * @group WikibaseDataModel
- * @group EntityIdTest
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/unit/Entity/EntityIdValueTest.php
+++ b/tests/unit/Entity/EntityIdValueTest.php
@@ -12,7 +12,6 @@ use Wikibase\DataModel\Entity\PropertyId;
  *
  * @group Wikibase
  * @group WikibaseDataModel
- * @group EntityIdTest
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/unit/Entity/ItemIdTest.php
+++ b/tests/unit/Entity/ItemIdTest.php
@@ -11,7 +11,6 @@ use Wikibase\DataModel\Entity\ItemId;
  *
  * @group Wikibase
  * @group WikibaseDataModel
- * @group EntityIdTest
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -22,7 +22,6 @@ use Wikibase\DataModel\Term\TermList;
  * @group Wikibase
  * @group WikibaseItem
  * @group WikibaseDataModel
- * @group WikibaseItemTest
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/unit/Entity/PropertyIdTest.php
+++ b/tests/unit/Entity/PropertyIdTest.php
@@ -11,7 +11,6 @@ use Wikibase\DataModel\Entity\PropertyId;
  *
  * @group Wikibase
  * @group WikibaseDataModel
- * @group EntityIdTest
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -22,7 +22,6 @@ use Wikibase\DataModel\Term\TermList;
  * @group Wikibase
  * @group WikibaseProperty
  * @group WikibaseDataModel
- * @group PropertyTest
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/unit/Statement/StatementGuidTest.php
+++ b/tests/unit/Statement/StatementGuidTest.php
@@ -12,7 +12,6 @@ use Wikibase\DataModel\Entity\ItemId;
  *
  * @group Wikibase
  * @group WikibaseDataModel
- * @group ClaimGuidTest
  *
  * @license GPL-2.0+
  * @author Addshore


### PR DESCRIPTION
Multiple arguments to remove these:
* It's easy to run a single …Test.php file or a single directory of tests. These `@group` tags are not needed to do this.
* What these tags do is, in essence, repeating either the class or the directory name. We tend to forget this when renaming or moving files. A good amount is already outdated.
* Some of these `@group` tags are the result of copy pasting and do not belong to the file they are in.