### PR TITLE
Avoid counting when not necesarry

### DIFF
--- a/src/Statement/ReferencedStatementFilter.php
+++ b/src/Statement/ReferencedStatementFilter.php
@@ -21,10 +21,10 @@ class ReferencedStatementFilter implements StatementFilter {
 	/**
 	 * @param Statement $statement
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function statementMatches( Statement $statement ) {
-		return count( $statement->getReferences() ) !== 0;
+		return !$statement->getReferences()->isEmpty();
 	}
 
 }

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -379,7 +379,7 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 			$references->removeReferenceHash( $hash );
 		}
 
-		$this->assertEquals( 0, count( $references ) );
+		$this->assertTrue( $references->isEmpty() );
 	}
 
 	public function testRemoveReferenceHashRemovesIdenticalObjects() {


### PR DESCRIPTION
I was doing a global search for older code that counts references, because we introduced the isEmpty method a while ago.