### PR TITLE
Add type hints to EntityIdValue

### DIFF
--- a/src/Entity/EntityIdValue.php
+++ b/src/Entity/EntityIdValue.php
@@ -137,16 +137,12 @@ class EntityIdValue extends DataValueObject {
 	 *
 	 * @since 0.5
 	 *
-	 * @param mixed $data
+	 * @param array $data
 	 *
 	 * @throws IllegalValueException
 	 * @return self
 	 */
-	public static function newFromArray( $data ) {
-		if ( !is_array( $data ) ) {
-			throw new IllegalValueException( '$data must be an array' );
-		}
-
+	public static function newFromArray( array $data ) {
 		if ( array_key_exists( 'entity-type', $data ) && array_key_exists( 'numeric-id', $data ) ) {
 			return self::newIdFromTypeAndNumber( $data['entity-type'], $data['numeric-id'] );
 		} elseif ( array_key_exists( 'id', $data ) ) {

--- a/tests/unit/Entity/EntityIdValueTest.php
+++ b/tests/unit/Entity/EntityIdValueTest.php
@@ -146,10 +146,6 @@ class EntityIdValueTest extends PHPUnit_Framework_TestCase {
 
 	public function invalidArrayProvider() {
 		return [
-			[ null ],
-
-			[ 'foo' ],
-
 			[ [] ],
 
 			'newFromArray can not deserialize' => [ [


### PR DESCRIPTION
`newFromArray` is not in an interfaces, but assumed to be there when called from `DataValueDeserializer`. No other assumption is made about the parameter. Having the strict type hint is not different from the manual check-and-throw.
