### PR TITLE
Add support for repo prefixes in DispatchingEntityIdParser

### DIFF
--- a/src/Entity/DispatchingEntityIdParser.php
+++ b/src/Entity/DispatchingEntityIdParser.php
@@ -44,7 +44,14 @@ class DispatchingEntityIdParser implements EntityIdParser {
 		}
 
 		foreach ( $this->idBuilders as $idPattern => $idBuilder ) {
-			if ( preg_match( $idPattern, $idSerialization ) ) {
+			try {
+				list( , , $localId ) = EntityId::splitSerialization( $idSerialization );
+			} catch ( InvalidArgumentException $ex ) {
+				// EntityId::splitSerialization performs some sanity checks which
+				// might result in an exception. Should this happen, re-throw the exception message
+				throw new EntityIdParsingException( $ex->getMessage() );
+			}
+			if ( preg_match( $idPattern, $localId ) ) {
 				return $this->buildId( $idBuilder, $idSerialization );
 			}
 		}

--- a/tests/unit/Entity/DispatchingEntityIdParserTest.php
+++ b/tests/unit/Entity/DispatchingEntityIdParserTest.php
@@ -37,6 +37,10 @@ class DispatchingEntityIdParserTest extends \PHPUnit_Framework_TestCase {
 			array( 'Q1337', new ItemId( 'Q1337' ) ),
 			array( 'p1', new PropertyId( 'p1' ) ),
 			array( 'P100000', new PropertyId( 'P100000' ) ),
+			array( 'foo:Q1337', new ItemId( 'foo:Q1337' ) ),
+			array( 'foo:P123', new PropertyId( 'foo:P123' ) ),
+			array( 'foo:bar:Q1337', new ItemId( 'foo:bar:Q1337' ) ),
+			array( ':Q1337', new ItemId( ':Q1337' ) ),
 		);
 	}
 
@@ -59,6 +63,11 @@ class DispatchingEntityIdParserTest extends \PHPUnit_Framework_TestCase {
 			array( '' ),
 			array( 'q0' ),
 			array( '1p' ),
+			array( 'foo:' ),
+			array( 'foo:bar:' ),
+			array( '::Q1337' ),
+			array( ':' ),
+			array( 'q:0' ),
 		);
 	}
 


### PR DESCRIPTION
~~This includes code from https://github.com/wmde/WikibaseDataModel/pull/678 and should only be merged after `EntityId` handles foreign IDs.~~