### PR TITLE
Changed how "forgeign repository name" is stored in entity ids

### DIFF
--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -3,6 +3,7 @@
 namespace Wikibase\DataModel\Entity;
 
 use Comparable;
+use InvalidArgumentException;
 use Serializable;
 
 /**
@@ -17,6 +18,30 @@ abstract class EntityId implements Comparable, Serializable {
 
 	protected $serialization;
 
+	const PATTERN = '/^:?(\w+:)*[^:]+\z/';
+
+	/**
+	 * @param string $serialization
+	 */
+	public function __construct( $serialization ) {
+		self::assertValidSerialization( $serialization );
+		$this->serialization = self::normalizeIdSerialization( $serialization );
+	}
+
+	private static function assertValidSerialization( $serialization ) {
+		if ( !is_string( $serialization ) ) {
+			throw new InvalidArgumentException( '$serialization must be a string' );
+		}
+
+		if ( $serialization === '' ) {
+			throw new InvalidArgumentException( '$serialization must not be an empty string' );
+		}
+
+		if ( !preg_match( self::PATTERN, $serialization ) ) {
+			throw new InvalidArgumentException( '$serialization must match ' . self::PATTERN );
+		}
+	}
+
 	/**
 	 * @return string
 	 */
@@ -27,6 +52,92 @@ abstract class EntityId implements Comparable, Serializable {
 	 */
 	public function getSerialization() {
 		return $this->serialization;
+	}
+
+	/**
+	 * Returns an array with 3 elements: the foreign repository name as the first element, the local ID as the last
+	 * element and everything that is in between as the second element.
+	 *
+	 * EntityId::joinSerialization can be used to restore the original serialization from the parts returned.
+	 *
+	 * @param string $serialization
+	 * @return string[] Array containing the serialization split into 3 parts.
+	 */
+	public static function splitSerialization( $serialization ) {
+		self::assertValidSerialization( $serialization );
+
+		$parts = explode( ':', self::normalizeIdSerialization( $serialization ) );
+		$localPart = array_pop( $parts );
+		$repoName = array_shift( $parts );
+		$prefixRemainder = implode( ':', $parts );
+
+		return array(
+			is_string( $repoName ) ? $repoName : '',
+			$prefixRemainder,
+			$localPart
+		);
+	}
+
+	/**
+	 * Builds an ID serialization from the parts returned by EntityId::splitSerialization.
+	 *
+	 * @param string[] $parts
+	 * @return string
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public static function joinSerialization( array $parts ) {
+		if ( end( $parts ) === '' ) {
+			throw new InvalidArgumentException( 'The last element of $parts must not be empty.' );
+		}
+
+		return implode(
+			':',
+			array_filter( $parts, function( $part ) {
+				return $part !== '';
+			} )
+		);
+	}
+
+	/**
+	 * Returns '' for local IDs and the foreign repository name for foreign IDs. For chained IDs (e.g. foo:bar:Q42) it
+	 * will return only the first part.
+	 *
+	 * @return string
+	 */
+	public function getRepoName() {
+		$parts = self::splitSerialization( $this->serialization );
+
+		return $parts[0];
+	}
+
+	/**
+	 * Returns the serialization without the first repository prefix.
+	 *
+	 * @return string
+	 */
+	public function getLocalPart() {
+		$parts = self::splitSerialization( $this->serialization );
+
+		return self::joinSerialization( array( '', $parts[1], $parts[2] ) );
+	}
+
+	/**
+	 * Returns true iff EntityId::getRepoName returns a non-empty string.
+	 *
+	 * @return bool
+	 */
+	public function isForeign() {
+		// not actually using EntityId::getRepoName for performance reasons
+		return strpos( $this->serialization, ':' ) > 0;
+	}
+
+	/**
+	 * @param string $id
+	 * @return string
+	 */
+	private static function normalizeIdSerialization( $id ) {
+		return ltrim( $id, ':' );
 	}
 
 	/**

--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -3,7 +3,6 @@
 namespace Wikibase\DataModel\Entity;
 
 use Comparable;
-use InvalidArgumentException;
 use Serializable;
 
 /**
@@ -17,30 +16,7 @@ use Serializable;
 abstract class EntityId implements Comparable, Serializable {
 
 	protected $serialization;
-
-	const PATTERN = '/^:?(\w+:)*[^:]+\z/';
-
-	/**
-	 * @param string $serialization
-	 */
-	public function __construct( $serialization ) {
-		self::assertValidSerialization( $serialization );
-		$this->serialization = self::normalizeIdSerialization( $serialization );
-	}
-
-	private static function assertValidSerialization( $serialization ) {
-		if ( !is_string( $serialization ) ) {
-			throw new InvalidArgumentException( '$serialization must be a string' );
-		}
-
-		if ( $serialization === '' ) {
-			throw new InvalidArgumentException( '$serialization must not be an empty string' );
-		}
-
-		if ( !preg_match( self::PATTERN, $serialization ) ) {
-			throw new InvalidArgumentException( '$serialization must match ' . self::PATTERN );
-		}
-	}
+	protected $repositoryName;
 
 	/**
 	 * @return string
@@ -51,52 +27,20 @@ abstract class EntityId implements Comparable, Serializable {
 	 * @return string
 	 */
 	public function getSerialization() {
+		if ( $this->isForeign() ) {
+			return $this->repositoryName . ':' . $this->serialization;
+		}
+
 		return $this->serialization;
 	}
 
 	/**
-	 * Returns an array with 3 elements: the foreign repository name as the first element, the local ID as the last
-	 * element and everything that is in between as the second element.
+	 * Returns the serialization without the first repository prefix.
 	 *
-	 * EntityId::joinSerialization can be used to restore the original serialization from the parts returned.
-	 *
-	 * @param string $serialization
-	 * @return string[] Array containing the serialization split into 3 parts.
-	 */
-	public static function splitSerialization( $serialization ) {
-		self::assertValidSerialization( $serialization );
-
-		$parts = explode( ':', self::normalizeIdSerialization( $serialization ) );
-		$localPart = array_pop( $parts );
-		$repoName = array_shift( $parts );
-		$prefixRemainder = implode( ':', $parts );
-
-		return array(
-			is_string( $repoName ) ? $repoName : '',
-			$prefixRemainder,
-			$localPart
-		);
-	}
-
-	/**
-	 * Builds an ID serialization from the parts returned by EntityId::splitSerialization.
-	 *
-	 * @param string[] $parts
 	 * @return string
-	 *
-	 * @throws InvalidArgumentException
 	 */
-	public static function joinSerialization( array $parts ) {
-		if ( end( $parts ) === '' ) {
-			throw new InvalidArgumentException( 'The last element of $parts must not be empty.' );
-		}
-
-		return implode(
-			':',
-			array_filter( $parts, function( $part ) {
-				return $part !== '';
-			} )
-		);
+	public function getLocalPart() {
+		return $this->serialization;
 	}
 
 	/**
@@ -106,38 +50,14 @@ abstract class EntityId implements Comparable, Serializable {
 	 * @return string
 	 */
 	public function getRepoName() {
-		$parts = self::splitSerialization( $this->serialization );
-
-		return $parts[0];
+		return $this->repositoryName;
 	}
 
 	/**
-	 * Returns the serialization without the first repository prefix.
-	 *
-	 * @return string
-	 */
-	public function getLocalPart() {
-		$parts = self::splitSerialization( $this->serialization );
-
-		return self::joinSerialization( array( '', $parts[1], $parts[2] ) );
-	}
-
-	/**
-	 * Returns true iff EntityId::getRepoName returns a non-empty string.
-	 *
 	 * @return bool
 	 */
 	public function isForeign() {
-		// not actually using EntityId::getRepoName for performance reasons
-		return strpos( $this->serialization, ':' ) > 0;
-	}
-
-	/**
-	 * @param string $id
-	 * @return string
-	 */
-	private static function normalizeIdSerialization( $id ) {
-		return ltrim( $id, ':' );
+		return $this->repositoryName !== '';
 	}
 
 	/**
@@ -148,7 +68,7 @@ abstract class EntityId implements Comparable, Serializable {
 	 * @return string
 	 */
 	public function __toString() {
-		return $this->serialization;
+		return $this->getSerialization();
 	}
 
 	/**
@@ -166,7 +86,8 @@ abstract class EntityId implements Comparable, Serializable {
 		}
 
 		return $target instanceof self
-			&& $target->serialization === $this->serialization;
+			&& $target->serialization === $this->serialization
+			&& $target->repositoryName === $this->repositoryName;
 	}
 
 }

--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -20,29 +20,31 @@ class ItemId extends EntityId implements Int32EntityId {
 
 	/**
 	 * @param string $idSerialization
+	 * @param string $repositoryName
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function __construct( $idSerialization ) {
-		$serializationParts = self::splitSerialization( $idSerialization );
-		$localId = strtoupper( $serializationParts[2] );
-		$this->assertValidIdFormat( $localId );
-		parent::__construct( self::joinSerialization(
-			array( $serializationParts[0], $serializationParts[1], $localId ) )
-		);
-	}
-
-	private function assertValidIdFormat( $idSerialization ) {
+	public function __construct( $idSerialization, $repositoryName = '' ) {
 		if ( !is_string( $idSerialization ) ) {
 			throw new InvalidArgumentException( '$idSerialization must be a string' );
 		}
 
-		if ( !preg_match( self::PATTERN, $idSerialization ) ) {
+		$parts = explode( ':', $idSerialization );
+		$localId = end( $parts );
+		$this->assertValidIdFormat( $localId );
+		$parts[count( $parts ) - 1] = strtoupper( $parts[count( $parts ) - 1] );
+
+		$this->serialization = implode( ':', $parts );
+		$this->repositoryName = $repositoryName;
+	}
+
+	private function assertValidIdFormat( $localId ) {
+		if ( !preg_match( self::PATTERN, $localId ) ) {
 			throw new InvalidArgumentException( '$idSerialization must match ' . self::PATTERN );
 		}
 
-		if ( strlen( $idSerialization ) > 10
-			&& substr( $idSerialization, 1 ) > Int32EntityId::MAX
+		if ( strlen( $localId ) > 10
+			&& substr( $localId, 1 ) > Int32EntityId::MAX
 		) {
 			throw new InvalidArgumentException( '$idSerialization can not exceed '
 				. Int32EntityId::MAX );
@@ -75,7 +77,13 @@ class ItemId extends EntityId implements Int32EntityId {
 	 * @return string
 	 */
 	public function serialize() {
-		return json_encode( array( 'item', $this->getSerialization() ) );
+		$data = [ 'item', $this->serialization ];
+
+		if ( $this->isForeign() ) {
+			$data[] = $this->repositoryName;
+		}
+
+		return json_encode( $data );
 	}
 
 	/**
@@ -84,7 +92,7 @@ class ItemId extends EntityId implements Int32EntityId {
 	 * @param string $serialized
 	 */
 	public function unserialize( $serialized ) {
-		list( , $this->serialization ) = json_decode( $serialized );
+		list( , $this->serialization, $this->repositoryName ) = array_merge( json_decode( $serialized ), [ '' ] );
 	}
 
 	/**

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -3,6 +3,7 @@
 namespace Wikibase\DataModel\Entity;
 
 use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * @since 0.5
@@ -23,8 +24,12 @@ class PropertyId extends EntityId implements Int32EntityId {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $idSerialization ) {
-		$this->assertValidIdFormat( $idSerialization );
-		$this->serialization = strtoupper( $idSerialization );
+		$serializationParts = self::splitSerialization( $idSerialization );
+		$localId = strtoupper( $serializationParts[2] );
+		$this->assertValidIdFormat( $localId );
+		parent::__construct( self::joinSerialization(
+			array( $serializationParts[0], $serializationParts[1], $localId ) )
+		);
 	}
 
 	private function assertValidIdFormat( $idSerialization ) {
@@ -46,9 +51,15 @@ class PropertyId extends EntityId implements Int32EntityId {
 
 	/**
 	 * @return int
+	 *
+	 * @throws RuntimeException if called on a foreign ID.
 	 */
 	public function getNumericId() {
-		return (int)substr( $this->serialization, 1 );
+		if ( $this->isForeign() ) {
+			throw new RuntimeException( 'getNumericId must not be called on foreign PropertyIds' );
+		}
+
+		return (int)substr( $this->getSerialization(), 1 );
 	}
 
 	/**
@@ -64,7 +75,7 @@ class PropertyId extends EntityId implements Int32EntityId {
 	 * @return string
 	 */
 	public function serialize() {
-		return json_encode( array( 'property', $this->serialization ) );
+		return json_encode( array( 'property', $this->getSerialization() ) );
 	}
 
 	/**

--- a/tests/unit/Entity/EntityIdTest.php
+++ b/tests/unit/Entity/EntityIdTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Tests\Entity;
 
+use ReflectionClass;
 use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\PropertyId;
@@ -24,11 +25,14 @@ class EntityIdTest extends \PHPUnit_Framework_TestCase {
 	public function instanceProvider() {
 		$ids = array();
 
-		$ids[] = array( new ItemId( 'Q1' ) );
-		$ids[] = array( new ItemId( 'Q42' ) );
-		$ids[] = array( new ItemId( 'Q31337' ) );
-		$ids[] = array( new ItemId( 'Q2147483647' ) );
-		$ids[] = array( new PropertyId( 'P101010' ) );
+		$ids[] = array( new ItemId( 'Q1' ), '' );
+		$ids[] = array( new ItemId( 'Q42' ), '' );
+		$ids[] = array( new ItemId( 'Q31337' ), '' );
+		$ids[] = array( new ItemId( 'Q2147483647' ), '' );
+		$ids[] = array( new ItemId( ':Q2147483647' ), '' );
+		$ids[] = array( new ItemId( 'foo:Q2147483647' ), 'foo' );
+		$ids[] = array( new PropertyId( 'P101010' ), '' );
+		$ids[] = array( new PropertyId( 'foo:bar:P101010' ), 'foo' );
 
 		return $ids;
 	}
@@ -79,6 +83,115 @@ class EntityIdTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testReturnTypeOfToString( EntityId $id ) {
 		$this->assertInternalType( 'string', $id->__toString() );
+	}
+
+	public function testIsForeign() {
+		$this->assertFalse( ( new ItemId( 'Q42' ) )->isForeign() );
+		$this->assertFalse( ( new ItemId( ':Q42' ) )->isForeign() );
+		$this->assertTrue( ( new ItemId( 'foo:Q42' ) )->isForeign() );
+		$this->assertFalse( ( new PropertyId( ':P42' ) )->isForeign() );
+		$this->assertTrue( ( new PropertyId( 'foo:P42' ) )->isForeign() );
+	}
+
+	/**
+	 * @dataProvider instanceProvider
+	 */
+	public function testGetRepoName( EntityId $id, $repoName ) {
+		$this->assertSame( $repoName, $id->getRepoName() );
+	}
+
+	public function serializationSplitProvider() {
+		return array(
+			array( 'Q42', array( '', '', 'Q42' ) ),
+			array( 'foo:Q42', array( 'foo', '', 'Q42' ) ),
+			array( '0:Q42', array( '0', '', 'Q42' ) ),
+			array( 'foo:bar:baz:Q42', array( 'foo', 'bar:baz', 'Q42' ) ),
+		);
+	}
+
+	/**
+	 * @dataProvider serializationSplitProvider
+	 */
+	public function testSplitSerialization( $serialization, $split ) {
+		$this->assertSame( $split, EntityId::splitSerialization( $serialization ) );
+	}
+
+	/**
+	 * @dataProvider invalidSerializationProvider
+	 */
+	public function testSplitSerializationFails_GivenInvalidSerialization( $serialization ) {
+		$this->setExpectedException( 'InvalidArgumentException' );
+		EntityId::splitSerialization( $serialization );
+	}
+
+	/**
+	 * @dataProvider serializationSplitProvider
+	 */
+	public function testJoinSerialization( $serialization, $split ) {
+		$this->assertSame( $serialization, EntityId::joinSerialization( $split ) );
+	}
+
+	/**
+	 * @dataProvider invalidJoinSerializationDataProvider
+	 */
+	public function testJoinSerializationFails_GivenEmptyId( $parts ) {
+		$this->setExpectedException( 'InvalidArgumentException' );
+		EntityId::joinSerialization( $parts );
+	}
+
+	public function invalidJoinSerializationDataProvider() {
+		return array(
+			array( array( 'Q42', '', '' ) ),
+			array( array( '', 'Q42', '' ) ),
+			array( array( 'foo', 'Q42', '' ) ),
+		);
+	}
+
+	public function testGivenNotNormalizedSerialization_splitSerializationReturnsNormalizedParts() {
+		$this->assertSame( array( '', '', 'Q42' ), EntityId::splitSerialization( ':Q42' ) );
+		$this->assertSame( array( 'foo', 'bar', 'Q42' ), EntityId::splitSerialization( ':foo:bar:Q42' ) );
+	}
+
+	public function localPartDataProvider() {
+		return array(
+			array( 'Q42', 'Q42' ),
+			array( ':Q42', 'Q42' ),
+			array( 'foo:Q42', 'Q42' ),
+			array( 'foo:bar:Q42', 'bar:Q42' ),
+		);
+	}
+
+	/**
+	 * @dataProvider localPartDataProvider
+	 */
+	public function testGetLocalPart( $serialization, $localPart ) {
+		$id = new ItemId( $serialization );
+		$this->assertSame( $localPart, $id->getLocalPart() );
+	}
+
+	public function invalidSerializationProvider() {
+		return array(
+			array( 's p a c e s:Q42' ),
+			array( '::Q42' ),
+			array( '' ),
+			array( ':' ),
+			array( 42 ),
+			array( null ),
+		);
+	}
+
+	/**
+	 * @dataProvider invalidSerializationProvider
+	 */
+	public function testConstructor( $serialization ) {
+		$this->setExpectedException( 'InvalidArgumentException' );
+
+		$mock = $this->getMockBuilder( EntityId::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$constructor = ( new ReflectionClass( EntityId::class ) )->getConstructor();
+		$constructor->invoke( $mock, $serialization );
 	}
 
 }

--- a/tests/unit/Entity/ItemIdTest.php
+++ b/tests/unit/Entity/ItemIdTest.php
@@ -38,10 +38,6 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 			array( 'q31337', 'Q31337' ),
 			array( 'Q31337', 'Q31337' ),
 			array( 'Q42', 'Q42' ),
-			array( ':Q42', 'Q42' ),
-			array( 'foo:Q42', 'foo:Q42' ),
-			array( 'foo:bar:q42', 'foo:bar:Q42' ),
-			array( 'Q42', 'Q42' ),
 			array( 'Q2147483647', 'Q2147483647' ),
 		);
 	}
@@ -110,7 +106,6 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 			array( '["",""]', '' ),
 			array( '["",2]', 2 ),
 			array( '["",null]', null ),
-			array( '', null ),
 		);
 	}
 
@@ -153,7 +148,12 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetNumericIdThrowsExceptionOnForeignIds() {
 		$this->setExpectedException( 'RuntimeException' );
-		( new ItemId( 'foo:Q42' ) )->getNumericId();
+		( new ItemId( 'Q42', 'foo' ) )->getNumericId();
+	}
+
+	public function testIsEqual() {
+		$this->assertTrue( ( new ItemId( 'Q1' ) )->equals( new ItemId( 'Q1' ) ) );
+		$this->assertFalse( ( new ItemId( 'Q1' ) )->equals( new ItemId( 'Q2' ) ) );
 	}
 
 }

--- a/tests/unit/Entity/ItemIdTest.php
+++ b/tests/unit/Entity/ItemIdTest.php
@@ -21,24 +21,28 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider idSerializationProvider
 	 */
-	public function testCanConstructId( $idSerialization ) {
+	public function testCanConstructId( $idSerialization, $normalizedIdSerialization ) {
 		$id = new ItemId( $idSerialization );
 
 		$this->assertEquals(
-			strtoupper( $idSerialization ),
+			$normalizedIdSerialization,
 			$id->getSerialization()
 		);
 	}
 
 	public function idSerializationProvider() {
 		return array(
-			array( 'q1' ),
-			array( 'q100' ),
-			array( 'q1337' ),
-			array( 'q31337' ),
-			array( 'Q31337' ),
-			array( 'Q42' ),
-			array( 'Q2147483647' ),
+			array( 'q1', 'Q1' ),
+			array( 'q100', 'Q100' ),
+			array( 'q1337', 'Q1337' ),
+			array( 'q31337', 'Q31337' ),
+			array( 'Q31337', 'Q31337' ),
+			array( 'Q42', 'Q42' ),
+			array( ':Q42', 'Q42' ),
+			array( 'foo:Q42', 'foo:Q42' ),
+			array( 'foo:bar:q42', 'foo:bar:Q42' ),
+			array( 'Q42', 'Q42' ),
+			array( 'Q2147483647', 'Q2147483647' ),
 		);
 	}
 
@@ -145,6 +149,11 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 			array( 2147483648 ),
 			array( '2147483648' ),
 		);
+	}
+
+	public function testGetNumericIdThrowsExceptionOnForeignIds() {
+		$this->setExpectedException( 'RuntimeException' );
+		( new ItemId( 'foo:Q42' ) )->getNumericId();
 	}
 
 }

--- a/tests/unit/Entity/PropertyIdTest.php
+++ b/tests/unit/Entity/PropertyIdTest.php
@@ -38,9 +38,6 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 			array( 'p31337', 'P31337' ),
 			array( 'P31337', 'P31337' ),
 			array( 'P42', 'P42' ),
-			array( ':P42', 'P42' ),
-			array( 'foo:P42', 'foo:P42' ),
-			array( 'foo:bar:p42', 'foo:bar:P42' ),
 			array( 'P2147483647', 'P2147483647' ),
 		);
 	}
@@ -109,7 +106,6 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 			array( '["",""]', '' ),
 			array( '["",2]', 2 ),
 			array( '["",null]', null ),
-			array( '', null ),
 		);
 	}
 
@@ -152,7 +148,7 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetNumericIdThrowsExceptionOnForeignIds() {
 		$this->setExpectedException( 'RuntimeException' );
-		( new PropertyId( 'foo:P42' ) )->getNumericId();
+		( new PropertyId( 'P42', 'foo' ) )->getNumericId();
 	}
 
 }

--- a/tests/unit/Entity/PropertyIdTest.php
+++ b/tests/unit/Entity/PropertyIdTest.php
@@ -21,24 +21,27 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider idSerializationProvider
 	 */
-	public function testCanConstructId( $idSerialization ) {
+	public function testCanConstructId( $idSerialization, $normalizedIdSerialization ) {
 		$id = new PropertyId( $idSerialization );
 
 		$this->assertEquals(
-			strtoupper( $idSerialization ),
+			$normalizedIdSerialization,
 			$id->getSerialization()
 		);
 	}
 
 	public function idSerializationProvider() {
 		return array(
-			array( 'p1' ),
-			array( 'p100' ),
-			array( 'p1337' ),
-			array( 'p31337' ),
-			array( 'P31337' ),
-			array( 'P42' ),
-			array( 'P2147483647' ),
+			array( 'p1', 'P1' ),
+			array( 'p100', 'P100' ),
+			array( 'p1337', 'P1337' ),
+			array( 'p31337', 'P31337' ),
+			array( 'P31337', 'P31337' ),
+			array( 'P42', 'P42' ),
+			array( ':P42', 'P42' ),
+			array( 'foo:P42', 'foo:P42' ),
+			array( 'foo:bar:p42', 'foo:bar:P42' ),
+			array( 'P2147483647', 'P2147483647' ),
 		);
 	}
 
@@ -145,6 +148,11 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 			array( 2147483648 ),
 			array( '2147483648' ),
 		);
+	}
+
+	public function testGetNumericIdThrowsExceptionOnForeignIds() {
+		$this->setExpectedException( 'RuntimeException' );
+		( new PropertyId( 'foo:P42' ) )->getNumericId();
 	}
 
 }


### PR DESCRIPTION
Follow up to #678

I'd have submitted this as a PR into the original, though as that one is coming from a fork, I'd be a PR against that fork... So if you want to see my changes against the existing PR, see only the second commit.
## 

This removes the addition of static code to EntityId and pushes the responsibility of parsing serializations out of the class.

I did not touch various other issues and have created a number of small ones, so this leaves the code in a state, that while it works, still needs some work before it is mergeable. That includes making names consistent again and adding some edge case tests.

The first constructor argument contains what the existing getter has named the "local part", which can also include prefixes defined on other sites. It's not immedidately clear to me why we need this here, so I'd be nice if someone could explain that. Should this not already have been resolved by the time the id is constructed?
