### PR TITLE
Remove no longer valid note in EntityId docs

### DIFF
--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -8,7 +8,6 @@ use Serializable;
 
 /**
  * @since 0.5
- * Constructor non-public since 1.0
  * Abstract since 2.0
  *
  * @license GPL-2.0+


### PR DESCRIPTION
https://github.com/wmde/WikibaseDataModel/pull/678 re-added the constructor so the note is no longer valid.

Or should this note rather be kept and a new one added saying "Constructor public since 6.2"?