### PR TITLE
Add functions to assert a value is a valid repository name, or an array indexed by valid repository names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
 	},
 	"require": {
 		"php": ">=5.5.0",
-		"data-values/data-values": "~0.1|~1.0"
+		"data-values/data-values": "~0.1|~1.0",
+		"wikimedia/assert": "~0.2.2"
 	},
 	"require-dev": {
 		"ockcyp/covers-validator": "~0.4.0",

--- a/src/Assert/RepositoryNameAssert.php
+++ b/src/Assert/RepositoryNameAssert.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Wikibase\DataModel\Assert;
+
+use Wikimedia\Assert\Assert;
+use Wikimedia\Assert\ParameterAssertionException;
+
+/**
+ * Provides functions to assure values are allowable repository
+ * names in Wikibase.
+ *
+ * @see docs/foreign-entity-ids.wiki
+ * @see Wikimedia\Assert\Assert
+ *
+ * @since 6.3
+ *
+ * @license GPL-2.0+
+ */
+class RepositoryNameAssert {
+
+	/**
+	 * @param string $value The actual value of the parameter
+	 * @param string $name The name of the parameter being checked
+	 *
+	 * @throws ParameterAssertionException If $value is not a valid repository name.
+	 */
+	public static function assertParameterIsValidRepositoryName( $value, $name ) {
+		if ( !self::isValidRepositoryName( $value ) ) {
+			throw new ParameterAssertionException( $name, 'must be a string not including colons' );
+		}
+	}
+
+	/**
+	 * @param array $values The actual value of the parameter. If this is not an array,
+	 *        a ParameterTypeException is thrown.
+	 * @param string $name The name of the parameter being checked
+	 *
+	 * @throws ParameterAssertionException If any element of $values is not
+	 *         a valid repository name.
+	 */
+	public static function assertParameterKeysAreValidRepositoryNames( $values, $name ) {
+		Assert::parameterType( 'array', $values, $name );
+		// TODO: change to Assert::parameterKeyType when the new version of the library is released
+		Assert::parameterElementType( 'string', array_keys( $values ), "array_keys( $name )" );
+
+		foreach ( array_keys( $values ) as $key ) {
+			if ( !self::isValidRepositoryName( $key ) ) {
+				throw new ParameterAssertionException(
+					"array_keys( $name )",
+					'must not contain strings including colons'
+				);
+			}
+		}
+	}
+
+	/**
+	 * @param string $value
+	 * @return bool
+	 */
+	private static function isValidRepositoryName($value ) {
+		return is_string( $value ) && strpos( $value, ':' ) === false;
+	}
+
+}

--- a/tests/unit/Assert/RepositoryNameAssertTest.php
+++ b/tests/unit/Assert/RepositoryNameAssertTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Wikibase\DataModel\Tests\Assert;
+
+use Wikibase\DataModel\Assert\RepositoryNameAssert;
+use Wikimedia\Assert\ParameterAssertionException;
+
+/**
+ * @covers Wikibase\DataModel\Assert\RepositoryNameAssert
+ *
+ * @license GPL-2.0+
+ */
+class RepositoryNameAssertTest extends \PHPUnit_Framework_TestCase {
+
+	public function provideInvalidRepositoryNames() {
+		return [
+			[ 'fo:o' ],
+			[ 'foo:' ],
+			[ ':foo' ],
+			[ ':' ],
+			[ 123 ],
+			[ null ],
+			[ false ],
+			[ [ 'foo' ] ],
+		];
+	}
+
+	/**
+	 * @dataProvider provideInvalidRepositoryNames
+	 */
+	public function testGivenInvalidValue_assertParameterIsValidRepositoryNameFails( $value ) {
+		$this->setExpectedException( ParameterAssertionException::class );
+		RepositoryNameAssert::assertParameterIsValidRepositoryName( $value, 'test' );
+	}
+
+	public function provideValidRepositoryNames() {
+		return [
+			[ '' ],
+			[ 'foo' ],
+			[ '123' ],
+		];
+	}
+
+	/**
+	 * @dataProvider provideValidRepositoryNames
+	 */
+	public function testGivenValidValue_assertParameterIsValidRepositoryNamePasses( $value ) {
+		RepositoryNameAssert::assertParameterIsValidRepositoryName( $value, 'test' );
+	}
+
+	public function provideInvalidRepositoryNameIndexedArrays() {
+		return [
+			[ 'foo' ],
+			[ [ 0 => 'foo' ] ],
+			[ [ 'fo:0' => 'bar' ] ],
+			[ [ 'foo:' => 'bar' ] ],
+			[ [ ':foo' => 'bar' ] ],
+		];
+	}
+
+	/**
+	 * @dataProvider provideInvalidRepositoryNameIndexedArrays
+	 */
+	public function testGivenInvalidValue_assertParameterKeysAreValidRepositoryNamesFails( $values ) {
+		$this->setExpectedException( ParameterAssertionException::class );
+		RepositoryNameAssert::assertParameterKeysAreValidRepositoryNames( $values, 'test' );
+	}
+
+	public function provideValidRepositoryNameIndexedArrays() {
+		return [
+			[ [ 'foo' => 'bar' ] ],
+			[ [ '' => 'bar' ] ],
+			[ [ '' => 'bar', 'foo' => 'baz' ] ],
+			[ [] ],
+		];
+	}
+
+	/**
+	 * @dataProvider provideValidRepositoryNameIndexedArrays
+	 */
+	public function testGivenValidValue_assertParameterKeysAreValidRepositoryNamesPasses( array $values ) {
+		RepositoryNameAssert::assertParameterKeysAreValidRepositoryNames( $values, 'test' );
+	}
+
+}


### PR DESCRIPTION
This is re-submission of https://github.com/wmde/WikibaseDataModelServices/pull/155, as it has been suggested it better fits in here.

Background (repeated): similar checks are done in https://github.com/wmde/WikibaseDataModelServices/pull/150,  https://github.com/wmde/WikibaseDataModelServices/pull/150, https://gerrit.wikimedia.org/r/#/c/314682/, https://github.com/wmde/WikibaseDataModelServices/pull/146, https://github.com/wmde/WikibaseDataModelServices/pull/149. It makes sense to have dedicated function(s) for such things. and not duplicate validation code. It would also make it easier to only have to adjust validation code in one place if there are more restrictions added on repository names etc.

Few little things changed here compared to https://github.com/wmde/WikibaseDataModelServices/pull/155:
 - moved to DM component (obviously),
 - class has been renamed,
 - public functions got renamed.

Open questions:
 - should those rather be global functions instead of pretending this code is object-oriented?
 - should this code rather go to `RepositoryName` value object instead of introducing more static code?
 - names....

Ping @brightbyte @jakobw @JeroenDeDauw 