### PR TITLE
Use short array syntax in docs for consistency

### DIFF
--- a/docs/foreign-entity-ids.wiki
+++ b/docs/foreign-entity-ids.wiki
@@ -17,7 +17,7 @@ When receiving prefixed entities from another repository, prefixes are "chained"
 
 * When reading <code>d:Q5</code> from repository <code>foo</code>, it is turned into <code>foo:d:Q5</code>, meaning ''<code>Q5</code> at the repo that repo <code>foo</code> calls <code>d</code>''
 * The local repository may have mappings defined for the prefixes used by other wikis, e.g. <code>foo:d</code> would be known to be the same as the local prefix <code>wd</code> for Wikidata. Mappings are defined as a two-dimensional array, e.g. part of mapping definition for example mentioned here would look like below:
-<code> array( ... 'foo' => array( 'd' => 'wd' ), ... )</code>
+<code> [ ... 'foo' => [ 'd' => 'wd' ], ... ]</code>
 
 * When deserializing data from another repository, the name of the source repository is always added as a prefix, and then any known mappings are resolved: <code>d:Q5</code> from <code>foo</code> becomes <code>foo:d:Q5</code> and then <code>wd:Q5</code>.
 * If no mapping is known, the "chained" version of the ID (<code>foo:d:Q5</code>) is stored locally. If this kind of ID is sent to yet another repo, that may result in longer "chains" of prefixes, like <code>xyz:foo:d:Q5</code>.


### PR DESCRIPTION
As we already switched to short array syntax in this repository in https://github.com/wmde/WikibaseDataModel/pull/683