### PR TITLE
Allow calling getNumericId on foreign ItemIds and PropertyIds

### DIFF
--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -51,15 +51,11 @@ class ItemId extends EntityId implements Int32EntityId {
 	/**
 	 * @see Int32EntityId::getNumericId
 	 *
-	 * @throws RuntimeException if called on a foreign ID.
 	 * @return int Guaranteed to be a distinct integer in the range [1..2147483647].
 	 */
 	public function getNumericId() {
-		if ( $this->isForeign() ) {
-			throw new RuntimeException( 'getNumericId must not be called on foreign ItemIds' );
-		}
-
-		return (int)substr( $this->serialization, 1 );
+		$serializationParts = self::splitSerialization( $this->serialization );
+		return (int)substr( $serializationParts[2], 1 );
 	}
 
 	/**

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -51,15 +51,11 @@ class PropertyId extends EntityId implements Int32EntityId {
 	/**
 	 * @see Int32EntityId::getNumericId
 	 *
-	 * @throws RuntimeException if called on a foreign ID.
 	 * @return int Guaranteed to be a distinct integer in the range [1..2147483647].
 	 */
 	public function getNumericId() {
-		if ( $this->isForeign() ) {
-			throw new RuntimeException( 'getNumericId must not be called on foreign PropertyIds' );
-		}
-
-		return (int)substr( $this->serialization, 1 );
+		$serializationParts = self::splitSerialization( $this->serialization );
+		return (int)substr( $serializationParts[2], 1 );
 	}
 
 	/**

--- a/tests/unit/Entity/ItemIdTest.php
+++ b/tests/unit/Entity/ItemIdTest.php
@@ -81,6 +81,11 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame( 1, $id->getNumericId() );
 	}
 
+	public function testGetNumericId_foreignId() {
+		$id = new ItemId( 'foo:Q1' );
+		$this->assertSame( 1, $id->getNumericId() );
+	}
+
 	public function testGetEntityType() {
 		$id = new ItemId( 'Q1' );
 		$this->assertSame( 'item', $id->getEntityType() );
@@ -149,11 +154,6 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 			[ 2147483648 ],
 			[ '2147483648' ],
 		];
-	}
-
-	public function testGetNumericIdThrowsExceptionOnForeignIds() {
-		$this->setExpectedException( RuntimeException::class );
-		( new ItemId( 'foo:Q42' ) )->getNumericId();
 	}
 
 }

--- a/tests/unit/Entity/PropertyIdTest.php
+++ b/tests/unit/Entity/PropertyIdTest.php
@@ -81,6 +81,11 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame( 1, $id->getNumericId() );
 	}
 
+	public function testGetNumericId_foreignId() {
+		$id = new PropertyId( 'foo:P1' );
+		$this->assertSame( 1, $id->getNumericId() );
+	}
+
 	public function testGetEntityType() {
 		$id = new PropertyId( 'P1' );
 		$this->assertSame( 'property', $id->getEntityType() );
@@ -149,11 +154,6 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 			[ 2147483648 ],
 			[ '2147483648' ],
 		];
-	}
-
-	public function testGetNumericIdThrowsExceptionOnForeignIds() {
-		$this->setExpectedException( RuntimeException::class );
-		( new PropertyId( 'foo:P42' ) )->getNumericId();
 	}
 
 }


### PR DESCRIPTION
It seems that disallowing calling getNumericId on foreign ItemId
and PropertyId instances (ie. containing a prefix in their serializations)
was not right.
Although it definitely it should not be assumed that "Q1" and "foo:Q1"
refer to the same entity of type "item" and numeric part of id "1",
the actual code accessing data from the database (ie. accessing
numeric values from the DB) must make use of getNumericId to get
the numeric part of both "Q1" and "foo:Q1".

It should be the responsibility of the caller to make sure the
right database is accessed and that the number part of id makes
sense in the given context. ItemId/PropertyId should not really
know anything about this.