### PR TITLE
Release notes 6.3.1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel release notes
 
+## Version 6.3.1 (2016-11-29)
+
+* Fixed `ItemId` and `PropertyId` to allow calling getNumericId on foreign entity ids.
+
 ## Version 6.3.0 (2016-11-03)
 
 * Added `RepositoryNameAssert` class


### PR DESCRIPTION
**Note this is not pull request onto master!**

https://github.com/wmde/WikibaseDataModel/pull/695 (https://github.com/wmde/WikibaseDataModel/pull/695/commits/00d2df05a79c6f7b83d74bb12dc7c69eb9820f3a) introduced a bug fix we would like to release as version 6.3.1.
As master is already preparing for the breaking release 7.0.0 I've created a branch https://github.com/wmde/WikibaseDataModel/tree/release631 which is the master as of 6.3.0, onto which I've cherry picked https://github.com/wmde/WikibaseDataModel/pull/677/commits/5344646f42b349a148c00c17114d10cd1e9f0c56 (not necessarily needed but added to have the same docs as master has; I might remove it if preferred), and the actual bug fix https://github.com/wmde/WikibaseDataModel/pull/695/commits/00d2df05a79c6f7b83d74bb12dc7c69eb9820f3a.

After release notes are merged onto 6.3.1 branch I will do the bug fix release and then add 6.3.1 release notes to the master branch as well (all other things to be released as 6.3.1 are already on master).