### PR TITLE
Avoid PHPUnit deprecation warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
 		"wikimedia/assert": "~0.2.2"
 	},
 	"require-dev": {
+		"phpunit/phpunit": "~4.8",
 		"ockcyp/covers-validator": "~0.4.0",
 		"squizlabs/php_codesniffer": "~2.3",
 		"phpmd/phpmd": "~2.3"
@@ -47,17 +48,17 @@
 	},
 	"scripts": {
 		"test": [
-			"composer validate --no-interaction",
-			"phpunit",
+			"@validate --no-interaction",
+			"vendor/bin/phpunit",
 			"vendor/bin/covers-validator"
 		],
 		"cs": [
-			"composer phpcs",
-			"composer phpmd"
+			"@phpcs",
+			"@phpmd"
 		],
 		"ci": [
-			"composer test",
-			"composer cs"
+			"@test",
+			"@cs"
 		],
 		"phpcs": [
 			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp"


### PR DESCRIPTION
Recent versions of PHPUnit deprecated some stuff
that we can't get rid off since that would mean
using new stuff only available in versions of PHPUnit
that do not support PHP 5.5.

Yay for supporting legacy PHP /o\