### PR TITLE
Use assertSame for Statement::getPropertyId

### DIFF
--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -259,7 +259,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetPropertyId( Statement $statement ) {
-		$this->assertEquals(
+		$this->assertSame(
 			$statement->getMainSnak()->getPropertyId(),
 			$statement->getPropertyId()
 		);


### PR DESCRIPTION
This is actually supposed to return the same object, not just an equal one. Not that critical because the returned object is immutable anyway, but still.