### PR TITLE
Add missing parameters to EntityIdParsingException

### DIFF
--- a/src/Entity/DispatchingEntityIdParser.php
+++ b/src/Entity/DispatchingEntityIdParser.php
@@ -49,7 +49,7 @@ class DispatchingEntityIdParser implements EntityIdParser {
 			} catch ( InvalidArgumentException $ex ) {
 				// EntityId::splitSerialization performs some sanity checks which
 				// might result in an exception. Should this happen, re-throw the exception message
-				throw new EntityIdParsingException( $ex->getMessage() );
+				throw new EntityIdParsingException( $ex->getMessage(), 0, $ex );
 			}
 			if ( preg_match( $idPattern, $localId ) ) {
 				return $this->buildId( $idBuilder, $idSerialization );
@@ -84,7 +84,7 @@ class DispatchingEntityIdParser implements EntityIdParser {
 			return call_user_func( $idBuilder, $idSerialization );
 		} catch ( InvalidArgumentException $ex ) {
 			// Should not happen, but if it does, re-throw the original message
-			throw new EntityIdParsingException( $ex->getMessage() );
+			throw new EntityIdParsingException( $ex->getMessage(), 0, $ex );
 		}
 	}
 

--- a/src/Entity/ItemIdParser.php
+++ b/src/Entity/ItemIdParser.php
@@ -26,7 +26,7 @@ class ItemIdParser implements EntityIdParser {
 		try {
 			return new ItemId( $idSerialization );
 		} catch ( InvalidArgumentException $ex ) {
-			throw new EntityIdParsingException( $ex->getMessage() );
+			throw new EntityIdParsingException( $ex->getMessage(), 0, $ex );
 		}
 	}
 


### PR DESCRIPTION
Forwarding the original exception can be very helpful when debugging.