### PR TITLE
Drop unused HashArray::removeDuplicates

### DIFF
--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -312,29 +312,6 @@ abstract class HashArray extends ArrayObject implements Hashable, Comparable {
 	}
 
 	/**
-	 * Removes duplicates bases on hash value.
-	 *
-	 * @since 0.3
-	 */
-	public function removeDuplicates() {
-		$knownHashes = [];
-
-		/**
-		 * @var Hashable $hashable
-		 */
-		foreach ( iterator_to_array( $this ) as $hashable ) {
-			$hash = $hashable->getHash();
-
-			if ( in_array( $hash, $knownHashes ) ) {
-				$this->removeByElementHash( $hash );
-			}
-			else {
-				$knownHashes[] = $hash;
-			}
-		}
-	}
-
-	/**
 	 * @see ArrayObject::append
 	 *
 	 * @param mixed $value

--- a/tests/unit/HashArray/HashArrayTest.php
+++ b/tests/unit/HashArray/HashArrayTest.php
@@ -45,61 +45,6 @@ abstract class HashArrayTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider instanceProvider
 	 * @param HashArray $array
 	 */
-	public function testHasElement( HashArray $array ) {
-		$array->removeDuplicates();
-
-		/**
-		 * @var Hashable $hashable
-		 */
-		foreach ( iterator_to_array( $array ) as $hashable ) {
-			$this->assertTrue( $array->hasElement( $hashable ) );
-			$this->assertTrue( $array->hasElementHash( $hashable->getHash() ) );
-			$array->removeElement( $hashable );
-			$this->assertFalse( $array->hasElement( $hashable ) );
-			$this->assertFalse( $array->hasElementHash( $hashable->getHash() ) );
-		}
-
-		$this->assertTrue( true );
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 * @param HashArray $array
-	 */
-	public function testRemoveElement( HashArray $array ) {
-		$array->removeDuplicates();
-
-		$elementCount = $array->count();
-
-		/**
-		 * @var Hashable $element
-		 */
-		foreach ( iterator_to_array( $array ) as $element ) {
-			$this->assertTrue( $array->hasElement( $element ) );
-
-			if ( $elementCount % 2 === 0 ) {
-				$array->removeElement( $element );
-			}
-			else {
-				$array->removeByElementHash( $element->getHash() );
-			}
-
-			$this->assertFalse( $array->hasElement( $element ) );
-			$this->assertEquals( --$elementCount, $array->count() );
-		}
-
-		$element = new PropertyNoValueSnak( 42 );
-
-		$array->removeElement( $element );
-		$array->removeByElementHash( $element->getHash() );
-
-		$this->assertTrue( true );
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 * @param HashArray $array
-	 */
 	public function testEquals( HashArray $array ) {
 		$this->assertTrue( $array->equals( $array ) );
 		$this->assertFalse( $array->equals( 42 ) );

--- a/tests/unit/HashArray/HashArrayWithDuplicatesTest.php
+++ b/tests/unit/HashArray/HashArrayWithDuplicatesTest.php
@@ -62,36 +62,6 @@ class HashArrayWithDuplicatesTest extends HashArrayTest {
 	 * @dataProvider instanceProvider
 	 * @param HashArray $array
 	 */
-	public function testRemoveDuplicates( HashArray $array ) {
-		$count = count( $array );
-		$duplicateCount = 0;
-		$hashes = [];
-
-		/**
-		 * @var Hashable $hashable
-		 */
-		foreach ( $array as $hashable ) {
-			if ( in_array( $hashable->getHash(), $hashes ) ) {
-				$duplicateCount++;
-			}
-			else {
-				$hashes[] = $hashable->getHash();
-			}
-		}
-
-		$array->removeDuplicates();
-
-		$this->assertEquals(
-			$count - $duplicateCount,
-			count( $array ),
-			'Count should decrease by the number of duplicates after removing duplicates'
-		);
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 * @param HashArray $array
-	 */
 	public function testGetHash( HashArray $array ) {
 		$hash = $array->getHash();
 

--- a/tests/unit/HashArray/HashArrayWithoutDuplicatesTest.php
+++ b/tests/unit/HashArray/HashArrayWithoutDuplicatesTest.php
@@ -2,8 +2,10 @@
 
 namespace Wikibase\DataModel\Tests\HashArray;
 
+use Hashable;
 use Wikibase\DataModel\Fixtures\HashArrayElement;
 use Wikibase\DataModel\HashArray;
+use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 
 /**
  * @covers Wikibase\DataModel\HashArray
@@ -80,15 +82,51 @@ class HashArrayWithoutDuplicatesTest extends HashArrayTest {
 	 * @dataProvider instanceProvider
 	 * @param HashArray $array
 	 */
-	public function testRemoveDuplicates( HashArray $array ) {
-		$count = count( $array );
-		$array->removeDuplicates();
+	public function testHasElement( HashArray $array ) {
+		/**
+		 * @var Hashable $hashable
+		 */
+		foreach ( iterator_to_array( $array ) as $hashable ) {
+			$this->assertTrue( $array->hasElement( $hashable ) );
+			$this->assertTrue( $array->hasElementHash( $hashable->getHash() ) );
+			$array->removeElement( $hashable );
+			$this->assertFalse( $array->hasElement( $hashable ) );
+			$this->assertFalse( $array->hasElementHash( $hashable->getHash() ) );
+		}
 
-		$this->assertCount(
-			$count,
-			$array,
-			'Count should be the same after removeDuplicates since there can be none'
-		);
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * @dataProvider instanceProvider
+	 * @param HashArray $array
+	 */
+	public function testRemoveElement( HashArray $array ) {
+		$elementCount = $array->count();
+
+		/**
+		 * @var Hashable $element
+		 */
+		foreach ( iterator_to_array( $array ) as $element ) {
+			$this->assertTrue( $array->hasElement( $element ) );
+
+			if ( $elementCount % 2 === 0 ) {
+				$array->removeElement( $element );
+			}
+			else {
+				$array->removeByElementHash( $element->getHash() );
+			}
+
+			$this->assertFalse( $array->hasElement( $element ) );
+			$this->assertEquals( --$elementCount, $array->count() );
+		}
+
+		$element = new PropertyNoValueSnak( 42 );
+
+		$array->removeElement( $element );
+		$array->removeByElementHash( $element->getHash() );
+
+		$this->assertTrue( true );
 	}
 
 	/**


### PR DESCRIPTION
This is split from #702 to make it easier to review.

Note that we already removed ReferenceList::removeDuplicates in 5.0.

The two testHasElement and testRemoveElement tests are moved without touching them, because they are not applicable to a test setup with duplicates.