### PR TITLE
Remove unused HashArray::rebuildIndices and indicesAreUpToDate

### DIFF
--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -335,49 +335,6 @@ abstract class HashArray extends ArrayObject implements Hashable, Comparable {
 	}
 
 	/**
-	 * Returns if the hash indices are up to date.
-	 * For an HashArray with immutable objects this should always be the case.
-	 * For one with mutable objects it's the responsibility of the mutating code
-	 * to keep the indices up to date (see class documentation) and thus possible
-	 * this has not been done since the last update, thus causing a state where
-	 * one or more indices are out of date.
-	 *
-	 * @since 0.4
-	 *
-	 * @return bool
-	 */
-	public function indicesAreUpToDate() {
-		foreach ( $this->offsetHashes as $hash => $offsets ) {
-			$offsets = (array)$offsets;
-
-			foreach ( $offsets as $offset ) {
-				/** @var Hashable[] $this */
-				if ( $this[$offset]->getHash() !== $hash ) {
-					return false;
-				}
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * Removes and adds all elements, ensuring the indices are up to date.
-	 *
-	 * @since 0.4
-	 */
-	public function rebuildIndices() {
-		$hashables = iterator_to_array( $this );
-
-		$this->offsetHashes = [];
-
-		foreach ( $hashables as $offset => $hashable ) {
-			$this->offsetUnset( $offset );
-			$this->offsetSet( $offset, $hashable );
-		}
-	}
-
-	/**
 	 * @see ArrayObject::append
 	 *
 	 * @param mixed $value

--- a/tests/unit/HashArray/HashArrayWithDuplicatesTest.php
+++ b/tests/unit/HashArray/HashArrayWithDuplicatesTest.php
@@ -4,7 +4,6 @@ namespace Wikibase\DataModel\Tests\HashArray;
 
 use Hashable;
 use Wikibase\DataModel\Fixtures\HashArrayElement;
-use Wikibase\DataModel\Fixtures\MutableHashable;
 use Wikibase\DataModel\HashArray;
 
 /**
@@ -115,26 +114,6 @@ class HashArrayWithDuplicatesTest extends HashArrayTest {
 			$array->getHash(),
 			'Hash should not be the same after adding an existing element again'
 		);
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 * @param HashArray $array
-	 */
-	public function testIndicesAreUpToDate( HashArray $array ) {
-		$this->assertInternalType( 'boolean', $array->indicesAreUpToDate() );
-
-		$mutable = new MutableHashable();
-
-		$array->addElement( $mutable );
-
-		$mutable->text = '~[,,_,,]:3';
-
-		$this->assertFalse( $array->indicesAreUpToDate() );
-
-		$array->rebuildIndices();
-
-		$this->assertTrue( $array->indicesAreUpToDate() );
 	}
 
 }

--- a/tests/unit/HashArray/HashArrayWithoutDuplicatesTest.php
+++ b/tests/unit/HashArray/HashArrayWithoutDuplicatesTest.php
@@ -3,7 +3,6 @@
 namespace Wikibase\DataModel\Tests\HashArray;
 
 use Wikibase\DataModel\Fixtures\HashArrayElement;
-use Wikibase\DataModel\Fixtures\MutableHashable;
 use Wikibase\DataModel\HashArray;
 
 /**
@@ -112,26 +111,6 @@ class HashArrayWithoutDuplicatesTest extends HashArrayTest {
 		} else {
 			$this->assertNotSame( $hash, $array->getHash() );
 		}
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 * @param HashArray $array
-	 */
-	public function testIndicesAreUpToDate( HashArray $array ) {
-		$this->assertInternalType( 'boolean', $array->indicesAreUpToDate() );
-
-		$mutable = new MutableHashable();
-
-		$array->addElement( $mutable );
-
-		$mutable->text = '~[,,_,,]:3';
-
-		$this->assertFalse( $array->indicesAreUpToDate() );
-
-		$array->rebuildIndices();
-
-		$this->assertTrue( $array->indicesAreUpToDate() );
 	}
 
 }


### PR DESCRIPTION
This is split from #702 to make it easier to review.