### PR TITLE
Move HashArray::equals to SnakList::equals

### DIFF
--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -3,7 +3,6 @@
 namespace Wikibase\DataModel;
 
 use ArrayObject;
-use Comparable;
 use Hashable;
 use InvalidArgumentException;
 use Traversable;
@@ -26,7 +25,7 @@ use Traversable;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-abstract class HashArray extends ArrayObject implements Comparable {
+abstract class HashArray extends ArrayObject {
 
 	/**
 	 * Maps element hashes to their offsets.
@@ -229,26 +228,6 @@ abstract class HashArray extends ArrayObject implements Comparable {
 
 			parent::offsetUnset( $index );
 		}
-	}
-
-	/**
-	 * @see Comparable::equals
-	 *
-	 * The comparison is done purely value based, ignoring the order of the elements in the array.
-	 *
-	 * @since 0.3
-	 *
-	 * @param mixed $target
-	 *
-	 * @return bool
-	 */
-	public function equals( $target ) {
-		if ( $this === $target ) {
-			return true;
-		}
-
-		return $target instanceof self
-			&& $this->getHash() === $target->getHash();
 	}
 
 	/**

--- a/src/Snak/SnakList.php
+++ b/src/Snak/SnakList.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Snak;
 
+use Comparable;
 use Hashable;
 use InvalidArgumentException;
 use Traversable;
@@ -18,7 +19,7 @@ use Wikibase\DataModel\Internal\MapValueHasher;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Addshore
  */
-class SnakList extends HashArray implements Hashable {
+class SnakList extends HashArray implements Comparable, Hashable {
 
 	/**
 	 * @param Snak[]|Traversable $snaks
@@ -106,6 +107,26 @@ class SnakList extends HashArray implements Hashable {
 	 */
 	public function getSnak( $snakHash ) {
 		return $this->getByElementHash( $snakHash );
+	}
+
+	/**
+	 * @see Comparable::equals
+	 *
+	 * The comparison is done purely value based, ignoring the order of the elements in the array.
+	 *
+	 * @since 0.3
+	 *
+	 * @param mixed $target
+	 *
+	 * @return bool
+	 */
+	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
+		return $target instanceof self
+		&& $this->getHash() === $target->getHash();
 	}
 
 	/**

--- a/tests/unit/HashArray/HashArrayTest.php
+++ b/tests/unit/HashArray/HashArrayTest.php
@@ -2,8 +2,6 @@
 
 namespace Wikibase\DataModel\Tests\HashArray;
 
-use Wikibase\DataModel\HashArray;
-
 /**
  * @covers Wikibase\DataModel\HashArray
  *
@@ -37,15 +35,6 @@ abstract class HashArrayTest extends \PHPUnit_Framework_TestCase {
 		}
 
 		return $instances;
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 * @param HashArray $array
-	 */
-	public function testEquals( HashArray $array ) {
-		$this->assertTrue( $array->equals( $array ) );
-		$this->assertFalse( $array->equals( 42 ) );
 	}
 
 	/**

--- a/tests/unit/Snak/SnakListTest.php
+++ b/tests/unit/Snak/SnakListTest.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Tests\Snak;
 
+use Comparable;
 use DataValues\StringValue;
 use Hashable;
 use InvalidArgumentException;
@@ -292,6 +293,50 @@ class SnakListTest extends HashArrayTest {
 		} else {
 			$this->assertNotSame( $initialSnakList->getHash(), $snakList->getHash() );
 		}
+	}
+
+	public function testComparableInterface() {
+		$this->assertInstanceOf( Comparable::class, new SnakList() );
+	}
+
+	/**
+	 * @dataProvider equalsProvider
+	 */
+	public function testEquals( SnakList $list1, SnakList $list2, $expected ) {
+		$this->assertSame( $expected, $list1->equals( $list2 ) );
+	}
+
+	public function equalsProvider() {
+		$empty = new SnakList();
+		$oneSnak = new SnakList( [ new PropertyNoValueSnak( 1 ) ] );
+
+		return [
+			'empty object is equal to itself' => [
+				$empty,
+				$empty,
+				true
+			],
+			'non-empty object is equal to itself' => [
+				$oneSnak,
+				$oneSnak,
+				true
+			],
+			'different empty objects are equal' => [
+				$empty,
+				new SnakList(),
+				true
+			],
+			'different objects with same content are equal' => [
+				$oneSnak,
+				new SnakList( [ new PropertyNoValueSnak( 1 ) ] ),
+				true
+			],
+			'different objects with different content are not equal' => [
+				$oneSnak,
+				new SnakList( [ new PropertyNoValueSnak( 2 ) ] ),
+				false
+			],
+		];
 	}
 
 	public function testHashableInterface() {


### PR DESCRIPTION
This goes along with #714 (and will run into a merge conflict – feel free to merge whichever first, I will do the rebase). Both are split from #702 to make that big patch it easier to review later.

Note that I rewrote the tests entirely. This is also the main reason for this patch, to make sure SnakList is properly covered with tests before we are applying the big change in #702.