### PR TITLE
Move Hashable interface from HashArray to SnakList

### DIFF
--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -7,7 +7,6 @@ use Comparable;
 use Hashable;
 use InvalidArgumentException;
 use Traversable;
-use Wikibase\DataModel\Internal\MapValueHasher;
 
 /**
  * Generic array object with lookups based on hashes of the elements.
@@ -27,7 +26,7 @@ use Wikibase\DataModel\Internal\MapValueHasher;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-abstract class HashArray extends ArrayObject implements Hashable, Comparable {
+abstract class HashArray extends ArrayObject implements Comparable {
 
 	/**
 	 * Maps element hashes to their offsets.
@@ -230,20 +229,6 @@ abstract class HashArray extends ArrayObject implements Hashable, Comparable {
 
 			parent::offsetUnset( $index );
 		}
-	}
-
-	/**
-	 * @see Hashable::getHash
-	 *
-	 * The hash is purely valuer based. Order of the elements in the array is not held into account.
-	 *
-	 * @since 0.1
-	 *
-	 * @return string
-	 */
-	public function getHash() {
-		$hasher = new MapValueHasher();
-		return $hasher->hash( $this );
 	}
 
 	/**

--- a/src/Snak/SnakList.php
+++ b/src/Snak/SnakList.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Snak;
 
+use Hashable;
 use Wikibase\DataModel\HashArray;
 use Wikibase\DataModel\Internal\MapValueHasher;
 
@@ -15,7 +16,7 @@ use Wikibase\DataModel\Internal\MapValueHasher;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Addshore
  */
-class SnakList extends HashArray {
+class SnakList extends HashArray implements Hashable {
 
 	/**
 	 * @see GenericArrayObject::getObjectType
@@ -93,7 +94,9 @@ class SnakList extends HashArray {
 	/**
 	 * @see HashArray::getHash
 	 *
-	 * @since 0.5
+	 * The hash is purely value based. Order of the elements in the array is not held into account.
+	 *
+	 * @since 0.1
 	 *
 	 * @return string
 	 */

--- a/tests/unit/HashArray/HashArrayWithoutDuplicatesTest.php
+++ b/tests/unit/HashArray/HashArrayWithoutDuplicatesTest.php
@@ -129,26 +129,4 @@ class HashArrayWithoutDuplicatesTest extends HashArrayTest {
 		$this->assertTrue( true );
 	}
 
-	/**
-	 * @dataProvider instanceProvider
-	 * @param HashArray $array
-	 */
-	public function testGetHash( HashArray $array ) {
-		$hash = $array->getHash();
-
-		$this->assertSame( $hash, $array->getHash() );
-
-		$elements = $this->elementInstancesProvider();
-		$element = array_shift( $elements );
-		$element = $element[0][0];
-
-		$array->addElement( $element );
-
-		if ( $array->hasElement( $element ) ) {
-			$this->assertSame( $hash, $array->getHash() );
-		} else {
-			$this->assertNotSame( $hash, $array->getHash() );
-		}
-	}
-
 }


### PR DESCRIPTION
This goes along with #713 (and will run into a merge conflict – feel free to merge whichever first, I will do the rebase). Both are split from #702 to make that big patch it easier to review later.

Note that I rewrote the tests entirely. This is also the main reason for this patch, to make sure SnakList is properly covered with tests before we are applying the big change in #702.