### PR TITLE
Don't use numeric IDs for internal PHP serialization.

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,7 +7,6 @@
     <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
 
     <rule ref="Generic.Classes" />
-    <rule ref="Generic.CodeAnalysis" />
     <rule ref="Generic.ControlStructures" />
 
     <rule ref="Generic.Files.ByteOrderMark" />

--- a/src/Snak/PropertyValueSnak.php
+++ b/src/Snak/PropertyValueSnak.php
@@ -53,7 +53,7 @@ class PropertyValueSnak extends SnakObject {
 	 * @return string
 	 */
 	public function serialize() {
-		return serialize( [ $this->propertyId->getNumericId(), $this->dataValue ] );
+		return serialize( [ $this->propertyId->getSerialization(), $this->dataValue ] );
 	}
 
 	/**
@@ -64,8 +64,8 @@ class PropertyValueSnak extends SnakObject {
 	 * @param string $serialized
 	 */
 	public function unserialize( $serialized ) {
-		list( $numericId, $dataValue ) = unserialize( $serialized );
-		$this->__construct( $numericId, $dataValue );
+		list( $propertyId, $dataValue ) = unserialize( $serialized );
+		$this->__construct( self::newPropertyId( $propertyId ), $dataValue );
 	}
 
 	/**

--- a/src/Snak/PropertyValueSnak.php
+++ b/src/Snak/PropertyValueSnak.php
@@ -48,7 +48,7 @@ class PropertyValueSnak extends SnakObject {
 	/**
 	 * @see Serializable::serialize
 	 *
-	 * @since 0.1
+	 * @since 7.0
 	 *
 	 * @return string
 	 */
@@ -64,8 +64,14 @@ class PropertyValueSnak extends SnakObject {
 	 * @param string $serialized
 	 */
 	public function unserialize( $serialized ) {
-		list( $propertyId, $dataValue ) = unserialize( $serialized );
-		$this->__construct( self::newPropertyId( $propertyId ), $dataValue );
+		list( $propertyId, $this->dataValue ) = unserialize( $serialized );
+
+		if ( is_string( $propertyId ) ) {
+			$this->propertyId = new PropertyId( $propertyId );
+		} else {
+			// Backwards compatibility with the previous serialization format
+			$this->propertyId = PropertyId::newFromNumber( $propertyId );
+		}
 	}
 
 	/**

--- a/src/Snak/SnakObject.php
+++ b/src/Snak/SnakObject.php
@@ -102,7 +102,7 @@ abstract class SnakObject implements Snak {
 	 * @return string
 	 */
 	public function serialize() {
-		return serialize( $this->propertyId->getSerialization() );
+		return $this->propertyId->getSerialization();
 	}
 
 	/**
@@ -113,19 +113,31 @@ abstract class SnakObject implements Snak {
 	 * @param string $serialized
 	 */
 	public function unserialize( $serialized ) {
-		$this->propertyId = self::newPropertyId( unserialize( $serialized ) );
+		$this->propertyId = self::newPropertyId( $serialized );
 	}
 
 	/**
-	 * @param mixed $unserialized
+	 * @param string $serialized
 	 *
 	 * @return PropertyId
 	 */
-	protected static function newPropertyId( $unserialized ) {
+	protected static function newPropertyId( $serialized ) {
+		if ( is_int( $serialized ) ) {
+			// numeric id, already unserialized
+			return PropertyId::newFromNumber( $serialized );
+		}
+
+		try {
+			// full ID, as a string, not serialized
+			return new PropertyId( $serialized );
+		} catch ( InvalidArgumentException $ex ) {
+			// noop
+		}
+
+		$unserialized = unserialize( $serialized );
 		if ( is_int( $unserialized ) ) {
+			// numeric id, not previously unserialized
 			return PropertyId::newFromNumber( $unserialized );
-		} elseif ( is_string( $unserialized ) ) {
-			return new PropertyId( $unserialized );
 		} else {
 			throw new InvalidArgumentException( 'unexpected property ID serialization' );
 		}

--- a/src/Snak/SnakObject.php
+++ b/src/Snak/SnakObject.php
@@ -97,7 +97,7 @@ abstract class SnakObject implements Snak {
 	/**
 	 * @see Serializable::serialize
 	 *
-	 * @since 0.1
+	 * @since 7.0
 	 *
 	 * @return string
 	 */
@@ -113,33 +113,11 @@ abstract class SnakObject implements Snak {
 	 * @param string $serialized
 	 */
 	public function unserialize( $serialized ) {
-		$this->propertyId = self::newPropertyId( $serialized );
-	}
-
-	/**
-	 * @param string $serialized
-	 *
-	 * @return PropertyId
-	 */
-	protected static function newPropertyId( $serialized ) {
-		if ( is_int( $serialized ) ) {
-			// numeric id, already unserialized
-			return PropertyId::newFromNumber( $serialized );
-		}
-
 		try {
-			// full ID, as a string, not serialized
-			return new PropertyId( $serialized );
+			$this->propertyId = new PropertyId( $serialized );
 		} catch ( InvalidArgumentException $ex ) {
-			// noop
-		}
-
-		$unserialized = unserialize( $serialized );
-		if ( is_int( $unserialized ) ) {
-			// numeric id, not previously unserialized
-			return PropertyId::newFromNumber( $unserialized );
-		} else {
-			throw new InvalidArgumentException( 'unexpected property ID serialization' );
+			// Backwards compatibility with the previous serialization format
+			$this->propertyId = PropertyId::newFromNumber( unserialize( $serialized ) );
 		}
 	}
 

--- a/src/Snak/SnakObject.php
+++ b/src/Snak/SnakObject.php
@@ -126,8 +126,6 @@ abstract class SnakObject implements Snak {
 			return PropertyId::newFromNumber( $unserialized );
 		} elseif ( is_string( $unserialized ) ) {
 			return new PropertyId( $unserialized );
-		} elseif ( $unserialized instanceof PropertyId ) {
-			return $unserialized;
 		} else {
 			throw new InvalidArgumentException( 'unexpected property ID serialization' );
 		}

--- a/src/Snak/SnakObject.php
+++ b/src/Snak/SnakObject.php
@@ -102,7 +102,7 @@ abstract class SnakObject implements Snak {
 	 * @return string
 	 */
 	public function serialize() {
-		return serialize( $this->propertyId->getNumericId() );
+		return serialize( $this->propertyId->getSerialization() );
 	}
 
 	/**
@@ -113,7 +113,24 @@ abstract class SnakObject implements Snak {
 	 * @param string $serialized
 	 */
 	public function unserialize( $serialized ) {
-		$this->propertyId = PropertyId::newFromNumber( unserialize( $serialized ) );
+		$this->propertyId = self::newPropertyId( unserialize( $serialized ) );
+	}
+
+	/**
+	 * @param mixed $unserialized
+	 *
+	 * @return PropertyId
+	 */
+	protected static function newPropertyId( $unserialized ) {
+		if ( is_int( $unserialized ) ) {
+			return PropertyId::newFromNumber( $unserialized );
+		} elseif ( is_string( $unserialized ) ) {
+			return new PropertyId( $unserialized );
+		} elseif ( $unserialized instanceof PropertyId ) {
+			return $unserialized;
+		} else {
+			throw new InvalidArgumentException( 'unexpected property ID serialization' );
+		}
 	}
 
 }

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -489,8 +489,8 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$list->addNewReference( new PropertyNoValueSnak( 1 ) );
 		$this->assertSame(
 			"a:1:{i:0;O:28:\"Wikibase\\DataModel\\Reference\":1:{s:35:\"\x00Wikibase\\DataModel\\"
-			. "Reference\x00snaks\";C:32:\"Wikibase\\DataModel\\Snak\\SnakList\":107:{a:2:{s:4:\""
-			. 'data";a:1:{i:0;C:43:"Wikibase\\DataModel\\Snak\\PropertyNoValueSnak":9:{s:2:"P1";}}s:5'
+			. "Reference\x00snaks\";C:32:\"Wikibase\\DataModel\\Snak\\SnakList\":100:{a:2:{s:4:\""
+			. 'data";a:1:{i:0;C:43:"Wikibase\\DataModel\\Snak\\PropertyNoValueSnak":2:{P1}}s:5'
 			. ':"index";i:0;}}}}',
 			$list->serialize()
 		);

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -489,8 +489,8 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 		$list->addNewReference( new PropertyNoValueSnak( 1 ) );
 		$this->assertSame(
 			"a:1:{i:0;O:28:\"Wikibase\\DataModel\\Reference\":1:{s:35:\"\x00Wikibase\\DataModel\\"
-			. "Reference\x00snaks\";C:32:\"Wikibase\\DataModel\\Snak\\SnakList\":102:{a:2:{s:4:\""
-			. 'data";a:1:{i:0;C:43:"Wikibase\\DataModel\\Snak\\PropertyNoValueSnak":4:{i:1;}}s:5'
+			. "Reference\x00snaks\";C:32:\"Wikibase\\DataModel\\Snak\\SnakList\":107:{a:2:{s:4:\""
+			. 'data";a:1:{i:0;C:43:"Wikibase\\DataModel\\Snak\\PropertyNoValueSnak":9:{s:2:"P1";}}s:5'
 			. ':"index";i:0;}}}}',
 			$list->serialize()
 		);

--- a/tests/unit/Snak/DerivedPropertyValueSnakTest.php
+++ b/tests/unit/Snak/DerivedPropertyValueSnakTest.php
@@ -89,7 +89,7 @@ class DerivedPropertyValueSnakTest extends PHPUnit_Framework_TestCase {
 		$hash = $snak->getHash();
 
 		// @codingStandardsIgnoreStart
-		$expected = sha1( 'C:48:"Wikibase\DataModel\Snak\DerivedPropertyValueSnak":53:{a:2:{i:0;i:1;i:1;C:22:"DataValues\StringValue":1:{a}}}' );
+		$expected = sha1( 'C:48:"Wikibase\DataModel\Snak\DerivedPropertyValueSnak":58:{a:2:{i:0;s:2:"P1";i:1;C:22:"DataValues\StringValue":1:{a}}}' );
 		// @codingStandardsIgnoreEnd
 		$this->assertSame( $expected, $hash );
 	}
@@ -129,7 +129,7 @@ class DerivedPropertyValueSnakTest extends PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals(
-			'a:2:{i:0;i:9001;i:1;C:22:"DataValues\StringValue":2:{bc}}',
+			'a:2:{i:0;s:5:"P9001";i:1;C:22:"DataValues\StringValue":2:{bc}}',
 			$snak->serialize()
 		);
 	}

--- a/tests/unit/Snak/PropertyNoValueSnakTest.php
+++ b/tests/unit/Snak/PropertyNoValueSnakTest.php
@@ -76,7 +76,7 @@ class PropertyNoValueSnakTest extends PHPUnit_Framework_TestCase {
 		$snak = new PropertyNoValueSnak( new PropertyId( 'P1' ) );
 		$hash = $snak->getHash();
 
-		$expected = sha1( 'C:43:"Wikibase\DataModel\Snak\PropertyNoValueSnak":4:{i:1;}' );
+		$expected = sha1( 'C:43:"Wikibase\DataModel\Snak\PropertyNoValueSnak":9:{s:2:"P1";}' );
 		$this->assertSame( $expected, $hash );
 	}
 
@@ -110,15 +110,51 @@ class PropertyNoValueSnakTest extends PHPUnit_Framework_TestCase {
 		];
 	}
 
-	public function testSerialize() {
-		$snak = new PropertyNoValueSnak( new PropertyId( 'P1' ) );
-		$this->assertSame( 'i:1;', $snak->serialize() );
+	public function provideDataToSerialize() {
+		$p2 = new PropertyId( 'P2' );
+		$p2foo = new PropertyId( 'foo:P2' );
+
+		return [
+			'string' => [
+				's:2:"P2";',
+				new PropertyNoValueSnak( $p2 ),
+			],
+			'foreign' => [
+				's:6:"foo:P2";',
+				new PropertyNoValueSnak( $p2foo ),
+			],
+		];
 	}
 
-	public function testUnserialize() {
+	/**
+	 * @dataProvider provideDataToSerialize
+	 */
+	public function testSerialize( $expected, Snak $snak ) {
+		$serialized = $snak->serialize();
+		$this->assertSame( $expected, $serialized );
+
+		$snak2 = new PropertyNoValueSnak( new PropertyId( 'P1' ) );
+		$snak2->unserialize( $serialized );
+		$this->assertTrue( $snak->equals( $snak2 ), 'round trip' );
+	}
+
+	public function provideDataToUnserialize() {
+		$p2 = new PropertyId( 'P2' );
+		$p2foo = new PropertyId( 'foo:P2' );
+
+		return [
+			'legacy' => [ new PropertyNoValueSnak( $p2 ), 'i:2;' ],
+			'current' => [ new PropertyNoValueSnak( $p2 ), 's:2:"P2";' ],
+			'foreign' => [ new PropertyNoValueSnak( $p2foo ), 's:6:"foo:P2";' ],
+		];
+	}
+
+	/**
+	 * @dataProvider provideDataToUnserialize
+	 */
+	public function testUnserialize( $expected, $serialized ) {
 		$snak = new PropertyNoValueSnak( new PropertyId( 'P1' ) );
-		$snak->unserialize( 'i:2;' );
-		$expected = new PropertyNoValueSnak( new PropertyId( 'P2' ) );
+		$snak->unserialize( $serialized );
 		$this->assertTrue( $snak->equals( $expected ) );
 	}
 

--- a/tests/unit/Snak/PropertyNoValueSnakTest.php
+++ b/tests/unit/Snak/PropertyNoValueSnakTest.php
@@ -76,7 +76,7 @@ class PropertyNoValueSnakTest extends PHPUnit_Framework_TestCase {
 		$snak = new PropertyNoValueSnak( new PropertyId( 'P1' ) );
 		$hash = $snak->getHash();
 
-		$expected = sha1( 'C:43:"Wikibase\DataModel\Snak\PropertyNoValueSnak":9:{s:2:"P1";}' );
+		$expected = sha1( 'C:43:"Wikibase\DataModel\Snak\PropertyNoValueSnak":2:{P1}' );
 		$this->assertSame( $expected, $hash );
 	}
 
@@ -116,11 +116,11 @@ class PropertyNoValueSnakTest extends PHPUnit_Framework_TestCase {
 
 		return [
 			'string' => [
-				's:2:"P2";',
+				'P2',
 				new PropertyNoValueSnak( $p2 ),
 			],
 			'foreign' => [
-				's:6:"foo:P2";',
+				'foo:P2',
 				new PropertyNoValueSnak( $p2foo ),
 			],
 		];
@@ -144,8 +144,8 @@ class PropertyNoValueSnakTest extends PHPUnit_Framework_TestCase {
 
 		return [
 			'legacy' => [ new PropertyNoValueSnak( $p2 ), 'i:2;' ],
-			'current' => [ new PropertyNoValueSnak( $p2 ), 's:2:"P2";' ],
-			'foreign' => [ new PropertyNoValueSnak( $p2foo ), 's:6:"foo:P2";' ],
+			'current' => [ new PropertyNoValueSnak( $p2 ), 'P2' ],
+			'foreign' => [ new PropertyNoValueSnak( $p2foo ), 'foo:P2' ],
 		];
 	}
 

--- a/tests/unit/Snak/PropertySomeValueSnakTest.php
+++ b/tests/unit/Snak/PropertySomeValueSnakTest.php
@@ -76,7 +76,7 @@ class PropertySomeValueSnakTest extends PHPUnit_Framework_TestCase {
 		$snak = new PropertySomeValueSnak( new PropertyId( 'P1' ) );
 		$hash = $snak->getHash();
 
-		$expected = sha1( 'C:45:"Wikibase\DataModel\Snak\PropertySomeValueSnak":4:{i:1;}' );
+		$expected = sha1( 'C:45:"Wikibase\DataModel\Snak\PropertySomeValueSnak":9:{s:2:"P1";}' );
 		$this->assertSame( $expected, $hash );
 	}
 
@@ -110,15 +110,51 @@ class PropertySomeValueSnakTest extends PHPUnit_Framework_TestCase {
 		];
 	}
 
-	public function testSerialize() {
-		$snak = new PropertySomeValueSnak( new PropertyId( 'P1' ) );
-		$this->assertSame( 'i:1;', $snak->serialize() );
+	public function provideDataToSerialize() {
+		$p2 = new PropertyId( 'P2' );
+		$p2foo = new PropertyId( 'foo:P2' );
+
+		return [
+			'string' => [
+				's:2:"P2";',
+				new PropertySomeValueSnak( $p2 ),
+			],
+			'foreign' => [
+				's:6:"foo:P2";',
+				new PropertySomeValueSnak( $p2foo ),
+			],
+		];
 	}
 
-	public function testUnserialize() {
+	/**
+	 * @dataProvider provideDataToSerialize
+	 */
+	public function testSerialize( $expected, Snak $snak ) {
+		$serialized = $snak->serialize();
+		$this->assertSame( $expected, $serialized );
+
+		$snak2 = new PropertySomeValueSnak( new PropertyId( 'P1' ) );
+		$snak2->unserialize( $serialized );
+		$this->assertTrue( $snak->equals( $snak2 ), 'round trip' );
+	}
+
+	public function provideDataToUnserialize() {
+		$p2 = new PropertyId( 'P2' );
+		$p2foo = new PropertyId( 'foo:P2' );
+
+		return [
+			'legacy' => [ new PropertySomeValueSnak( $p2 ), 'i:2;' ],
+			'current' => [ new PropertySomeValueSnak( $p2 ), 's:2:"P2";' ],
+			'foreign' => [ new PropertySomeValueSnak( $p2foo ), 's:6:"foo:P2";' ],
+		];
+	}
+
+	/**
+	 * @dataProvider provideDataToUnserialize
+	 */
+	public function testUnserialize( $expected, $serialized ) {
 		$snak = new PropertySomeValueSnak( new PropertyId( 'P1' ) );
-		$snak->unserialize( 'i:2;' );
-		$expected = new PropertySomeValueSnak( new PropertyId( 'P2' ) );
+		$snak->unserialize( $serialized );
 		$this->assertTrue( $snak->equals( $expected ) );
 	}
 

--- a/tests/unit/Snak/PropertySomeValueSnakTest.php
+++ b/tests/unit/Snak/PropertySomeValueSnakTest.php
@@ -76,7 +76,7 @@ class PropertySomeValueSnakTest extends PHPUnit_Framework_TestCase {
 		$snak = new PropertySomeValueSnak( new PropertyId( 'P1' ) );
 		$hash = $snak->getHash();
 
-		$expected = sha1( 'C:45:"Wikibase\DataModel\Snak\PropertySomeValueSnak":9:{s:2:"P1";}' );
+		$expected = sha1( 'C:45:"Wikibase\DataModel\Snak\PropertySomeValueSnak":2:{P1}' );
 		$this->assertSame( $expected, $hash );
 	}
 
@@ -116,11 +116,11 @@ class PropertySomeValueSnakTest extends PHPUnit_Framework_TestCase {
 
 		return [
 			'string' => [
-				's:2:"P2";',
+				'P2',
 				new PropertySomeValueSnak( $p2 ),
 			],
 			'foreign' => [
-				's:6:"foo:P2";',
+				'foo:P2',
 				new PropertySomeValueSnak( $p2foo ),
 			],
 		];
@@ -144,8 +144,8 @@ class PropertySomeValueSnakTest extends PHPUnit_Framework_TestCase {
 
 		return [
 			'legacy' => [ new PropertySomeValueSnak( $p2 ), 'i:2;' ],
-			'current' => [ new PropertySomeValueSnak( $p2 ), 's:2:"P2";' ],
-			'foreign' => [ new PropertySomeValueSnak( $p2foo ), 's:6:"foo:P2";' ],
+			'current' => [ new PropertySomeValueSnak( $p2 ), 'P2' ],
+			'foreign' => [ new PropertySomeValueSnak( $p2foo ), 'foo:P2' ],
 		];
 	}
 


### PR DESCRIPTION
This changes Snak serialization to use the full string representation of property IDs.

NOTE: serialize/unserialize is used mainly when cloning Statements.
NOTE: it's unclear if this completely fixes T157442
NOTE: this changes snak hashes, and consequently reference hashes! This may break reference update/removal!

[Bug: T157442](https://phabricator.wikimedia.org/T157442)