### PR TITLE
Rework native EntityId(Value) serializations

### DIFF
--- a/src/Entity/EntityIdValue.php
+++ b/src/Entity/EntityIdValue.php
@@ -30,10 +30,7 @@ class EntityIdValue extends DataValueObject {
 	 * @return string
 	 */
 	public function serialize() {
-		return json_encode( [
-			$this->entityId->getEntityType(),
-			$this->getNumericId()
-		] );
+		return serialize( $this->entityId );
 	}
 
 	/**
@@ -58,7 +55,14 @@ class EntityIdValue extends DataValueObject {
 	 * @throws IllegalValueException
 	 */
 	public function unserialize( $serialized ) {
-		list( $entityType, $numericId ) = json_decode( $serialized );
+		$array = json_decode( $serialized );
+
+		if ( !is_array( $array ) ) {
+			$this->entityId = unserialize( $serialized );
+			return;
+		}
+
+		list( $entityType, $numericId ) = $array;
 
 		try {
 			$entityId = LegacyIdInterpreter::newIdFromTypeAndNumber( $entityType, $numericId );

--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -70,7 +70,7 @@ class ItemId extends EntityId implements Int32EntityId {
 	 * @return string
 	 */
 	public function serialize() {
-		return json_encode( [ 'item', $this->serialization ] );
+		return $this->serialization;
 	}
 
 	/**
@@ -79,7 +79,8 @@ class ItemId extends EntityId implements Int32EntityId {
 	 * @param string $serialized
 	 */
 	public function unserialize( $serialized ) {
-		list( , $this->serialization ) = json_decode( $serialized );
+		$array = json_decode( $serialized );
+		$this->serialization = is_array( $array ) ? $array[1] : $serialized;
 	}
 
 	/**

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -70,7 +70,7 @@ class PropertyId extends EntityId implements Int32EntityId {
 	 * @return string
 	 */
 	public function serialize() {
-		return json_encode( [ 'property', $this->serialization ] );
+		return $this->serialization;
 	}
 
 	/**
@@ -79,7 +79,8 @@ class PropertyId extends EntityId implements Int32EntityId {
 	 * @param string $serialized
 	 */
 	public function unserialize( $serialized ) {
-		list( , $this->serialization ) = json_decode( $serialized );
+		$array = json_decode( $serialized );
+		$this->serialization = is_array( $array ) ? $array[1] : $serialized;
 	}
 
 	/**

--- a/tests/unit/Entity/EntityIdTest.php
+++ b/tests/unit/Entity/EntityIdTest.php
@@ -69,12 +69,12 @@ class EntityIdTest extends \PHPUnit_Framework_TestCase {
 	 * It is just here to catch unintentional changes.
 	 */
 	public function testSerializationStability() {
-		$v05serialization = 'C:32:"Wikibase\DataModel\Entity\ItemId":15:{["item","Q123"]}';
+		$serialization = 'C:32:"Wikibase\DataModel\Entity\ItemId":4:{Q123}';
 		$id = new ItemId( 'q123' );
 
 		$this->assertEquals(
 			serialize( $id ),
-			$v05serialization
+			$serialization
 		);
 	}
 

--- a/tests/unit/Entity/EntityIdValueTest.php
+++ b/tests/unit/Entity/EntityIdValueTest.php
@@ -87,8 +87,7 @@ class EntityIdValueTest extends PHPUnit_Framework_TestCase {
 	public function testSerializationCompatibility() {
 		$id = new EntityIdValue( new ItemId( 'Q31337' ) );
 
-		// This is the serialization format from when the EntityIdValue was still together with EntityId.
-		$this->assertEquals( '["item",31337]', $id->serialize() );
+		$this->assertEquals( 'C:32:"Wikibase\DataModel\Entity\ItemId":6:{Q31337}', $id->serialize() );
 	}
 
 	public function testDeserializationCompatibility() {

--- a/tests/unit/Entity/ItemIdTest.php
+++ b/tests/unit/Entity/ItemIdTest.php
@@ -92,7 +92,7 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 
 	public function testSerialize() {
 		$id = new ItemId( 'Q1' );
-		$this->assertSame( '["item","Q1"]', $id->serialize() );
+		$this->assertSame( 'Q1', $id->serialize() );
 	}
 
 	/**
@@ -106,6 +106,7 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 
 	public function serializationProvider() {
 		return [
+			[ 'Q2', 'Q2' ],
 			[ '["item","Q2"]', 'Q2' ],
 
 			// All these cases are kind of an injection vector and allow constructing invalid ids.
@@ -114,7 +115,7 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 			[ '["",""]', '' ],
 			[ '["",2]', 2 ],
 			[ '["",null]', null ],
-			[ '', null ],
+			[ '', '' ],
 		];
 	}
 

--- a/tests/unit/Entity/PropertyIdTest.php
+++ b/tests/unit/Entity/PropertyIdTest.php
@@ -92,7 +92,7 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 
 	public function testSerialize() {
 		$id = new PropertyId( 'P1' );
-		$this->assertSame( '["property","P1"]', $id->serialize() );
+		$this->assertSame( 'P1', $id->serialize() );
 	}
 
 	/**
@@ -106,6 +106,7 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 
 	public function serializationProvider() {
 		return [
+			[ 'P2', 'P2' ],
 			[ '["property","P2"]', 'P2' ],
 
 			// All these cases are kind of an injection vector and allow constructing invalid ids.
@@ -114,7 +115,7 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 			[ '["",""]', '' ],
 			[ '["",2]', 2 ],
 			[ '["",null]', null ],
-			[ '', null ],
+			[ '', '' ],
 		];
 	}
 


### PR DESCRIPTION
This is an alternative draft for #716. Pinging @brightbyte and @JeroenDeDauw.

This patch does 2 things:
1. Change EntityIdValue::serialize to use the native `serialize` instead of JSON.
2. Simplify both ItemId and PropertyId serializations to the straight string.

The 1st change makes the serialized string much longer, the 2nd change minimizes it again.

In all cases I keep compatibility with the previous serialization formats.