### PR TITLE
Add ItemId and PropertyId::newFromRepositoryAndNumber

### DIFF
--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -103,4 +103,21 @@ class ItemId extends EntityId implements Int32EntityId {
 		return new self( 'Q' . $numericId );
 	}
 
+	/**
+	 * CAUTION: Use the full string serialization whenever you can and avoid using numeric IDs.
+	 *
+	 * @param string $repositoryName
+	 * @param int|float|string $numericId
+	 *
+	 * @return self
+	 * @throws InvalidArgumentException
+	 */
+	public static function newFromRepositoryAndNumber( $repositoryName, $numericId ) {
+		if ( !is_numeric( $numericId ) ) {
+			throw new InvalidArgumentException( '$numericId must be numeric' );
+		}
+
+		return new self( self::joinSerialization( [ $repositoryName, '', 'Q' . $numericId ] ) );
+	}
+
 }

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -103,4 +103,21 @@ class PropertyId extends EntityId implements Int32EntityId {
 		return new self( 'P' . $numericId );
 	}
 
+	/**
+	 * CAUTION: Use the full string serialization whenever you can and avoid using numeric IDs.
+	 *
+	 * @param string $repositoryName
+	 * @param int|float|string $numericId
+	 *
+	 * @return self
+	 * @throws InvalidArgumentException
+	 */
+	public static function newFromRepositoryAndNumber( $repositoryName, $numericId ) {
+		if ( !is_numeric( $numericId ) ) {
+			throw new InvalidArgumentException( '$numericId must be numeric' );
+		}
+
+		return new self( self::joinSerialization( [ $repositoryName, '', 'P' . $numericId ] ) );
+	}
+
 }

--- a/tests/unit/Entity/ItemIdTest.php
+++ b/tests/unit/Entity/ItemIdTest.php
@@ -156,4 +156,14 @@ class ItemIdTest extends PHPUnit_Framework_TestCase {
 		];
 	}
 
+	public function testNewFromRepositoryAndNumber() {
+		$id = ItemId::newFromRepositoryAndNumber( 'foo', 1 );
+		$this->assertSame( 'foo:Q1', $id->getSerialization() );
+	}
+
+	public function testNewFromRepositoryAndNumberWithInvalidNumericId() {
+		$this->setExpectedException( InvalidArgumentException::class );
+		ItemId::newFromRepositoryAndNumber( '', 'Q1' );
+	}
+
 }

--- a/tests/unit/Entity/PropertyIdTest.php
+++ b/tests/unit/Entity/PropertyIdTest.php
@@ -156,4 +156,14 @@ class PropertyIdTest extends PHPUnit_Framework_TestCase {
 		];
 	}
 
+	public function testNewFromRepositoryAndNumber() {
+		$id = PropertyId::newFromRepositoryAndNumber( 'foo', 1 );
+		$this->assertSame( 'foo:P1', $id->getSerialization() );
+	}
+
+	public function testNewFromRepositoryAndNumberWithInvalidNumericId() {
+		$this->setExpectedException( InvalidArgumentException::class );
+		PropertyId::newFromRepositoryAndNumber( '', 'P1' );
+	}
+
 }


### PR DESCRIPTION
A convenience method that allows us to avoid constructing ugly code (see https://gerrit.wikimedia.org/r/337806).