### PR TITLE
Remove non-informative "getFoo returns foo" comments

### DIFF
--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -358,8 +358,6 @@ abstract class HashArray extends ArrayObject implements Hashable, Comparable {
 	}
 
 	/**
-	 * Returns if the ArrayObject has no elements.
-	 *
 	 * @return bool
 	 */
 	public function isEmpty() {

--- a/src/PropertyIdProvider.php
+++ b/src/PropertyIdProvider.php
@@ -15,8 +15,6 @@ use Wikibase\DataModel\Entity\PropertyId;
 interface PropertyIdProvider {
 
 	/**
-	 * Returns the property id of this object.
-	 *
 	 * @since 1.1
 	 *
 	 * @return PropertyId

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -81,8 +81,6 @@ class Statement implements Hashable, Comparable, PropertyIdProvider {
 	}
 
 	/**
-	 * Returns the GUID of this statement.
-	 *
 	 * @since 0.2
 	 *
 	 * @return string|null


### PR DESCRIPTION
This goes along with https://gerrit.wikimedia.org/r/339131.