### PR TITLE
[DNM] Replace isForeign with isUnresolved

### DIFF
--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -58,7 +58,8 @@ abstract class EntityId implements Comparable, Serializable {
 	 * Returns an array with 3 elements: the foreign repository name as the first element, the local ID as the last
 	 * element and everything that is in between as the second element.
 	 *
-	 * EntityId::joinSerialization can be used to restore the original serialization from the parts returned.
+	 * self::joinSerialization can be used to restore the original serialization from the parts
+	 * returned.
 	 *
 	 * @since 6.2
 	 *
@@ -81,7 +82,7 @@ abstract class EntityId implements Comparable, Serializable {
 	}
 
 	/**
-	 * Builds an ID serialization from the parts returned by EntityId::splitSerialization.
+	 * Builds an ID serialization from the parts returned by self::splitSerialization.
 	 *
 	 * @since 6.2
 	 *
@@ -104,8 +105,8 @@ abstract class EntityId implements Comparable, Serializable {
 	}
 
 	/**
-	 * Returns '' for local IDs and the foreign repository name for foreign IDs. For chained IDs (e.g. foo:bar:Q42) it
-	 * will return only the first part.
+	 * Returns an empty string for unprefixed, or a repository name for prefixed IDs. For chained
+	 * prefixes (e.g. foo:bar:Q42) it will return only the first prefix.
 	 *
 	 * @since 6.2
 	 *
@@ -131,14 +132,18 @@ abstract class EntityId implements Comparable, Serializable {
 	}
 
 	/**
-	 * Returns true iff EntityId::getRepoName returns a non-empty string.
+	 * Returns true if the ID does have a prefix and is therefore guaranteed to be unresolved. This
+	 * is the same as checking if getRepositoryName() returns a non-empty string. Note that the
+	 * inverse is not necessarily true! An unprefixed ID may still need to be resolved, e.g. when
+	 * the local repository does not support a specific entity type, but a known remote repository
+	 * does.
 	 *
-	 * @since 6.2
+	 * @since 7.0
 	 *
 	 * @return bool
 	 */
-	public function isForeign() {
-		// not actually using EntityId::getRepoName for performance reasons
+	public function isUnresolved() {
+		// Not actually using getRepositoryName() for performance reasons
 		return strpos( $this->serialization, ':' ) > 0;
 	}
 

--- a/tests/unit/Entity/EntityIdTest.php
+++ b/tests/unit/Entity/EntityIdTest.php
@@ -85,12 +85,12 @@ class EntityIdTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInternalType( 'string', $id->__toString() );
 	}
 
-	public function testIsForeign() {
-		$this->assertFalse( ( new ItemId( 'Q42' ) )->isForeign() );
-		$this->assertFalse( ( new ItemId( ':Q42' ) )->isForeign() );
-		$this->assertTrue( ( new ItemId( 'foo:Q42' ) )->isForeign() );
-		$this->assertFalse( ( new PropertyId( ':P42' ) )->isForeign() );
-		$this->assertTrue( ( new PropertyId( 'foo:P42' ) )->isForeign() );
+	public function testIsUnresolved() {
+		$this->assertFalse( ( new ItemId( 'Q42' ) )->isUnresolved() );
+		$this->assertFalse( ( new ItemId( ':Q42' ) )->isUnresolved() );
+		$this->assertTrue( ( new ItemId( 'foo:Q42' ) )->isUnresolved() );
+		$this->assertFalse( ( new PropertyId( ':P42' ) )->isUnresolved() );
+		$this->assertTrue( ( new PropertyId( 'foo:P42' ) )->isUnresolved() );
 	}
 
 	/**


### PR DESCRIPTION
Triggered by the discussion in #720.

It appears we implemented a concept of being "foreign" like it is a specialization. Multiple issues with that:
* All we really know is if an entity ID does have prefixes.
  * If there is no prefix, we know the ID refers to an entity in the local repository.
  * But we can't conclude the opposite. A prefixed ID may still refer to a local entity, either if it's prefixed with the local repository name, or with multiple prefixes that happen to point back to the local repository. The ID of such an entity may be in a "foreign" form, but if the addressed entity is local it's confusing to still describe this concept as being "foreign".
* All entity IDs are prefixed. (In a sense all are "foreign".) It's just that there is special case handling for IDs that happen to have no prefix.
* I don't think we have code that needs the guarantee that an addressed entity is "foreign" (which is a guarantee we can not give anyway, as explained above). But we have code that needs the guarantee that an addressed entity is local, typically when we are going to store it.