### PR TITLE
Improve documentation of EntityId

### DIFF
--- a/docs/foreign-entity-ids.wiki
+++ b/docs/foreign-entity-ids.wiki
@@ -1,10 +1,10 @@
 EntityId contains the logical name of the repository the ID refers to. This serves as a namespace mechanism for entity IDs.
-EntityIds from repositories other than local repository are called '''foreign''' EntityIds,
-and, similarly, repositories other than local are '''foreign''' repositories.
+EntityIds from repositories other than the local default repository are called '''foreign''' EntityIds,
+and, similarly, repositories other than the local default are '''foreign''' repositories.
 
 Notes:
 * The name used to refer to a given repository is local, and can differ from client to client.
-* The empty repository name "" refers to the local wiki.
+* The empty repository name "" refers to the local application's default repository. If the application is a Wikibase repo, "" refers to this repository itself. If the application is a Wikibase client, it refers to that client's default repository.
 * Repository names can be used to look up the repository Site object, which in turn allows the ID to be mapped to the correct URI, URL, or API path for the repository it belongs to.
 * The serialization of the EntityId follows the pattern <code><repository>:<id></code>. If <code><repository></code> is empty, the leading <code>:</code> is optional. This format follows the convention set by XML namespaces, RDF prefixes, and MediaWiki interwiki links.
 * Repository names can be mapped during serialization and deserialization.
@@ -17,7 +17,7 @@ When receiving prefixed entities from another repository, prefixes are "chained"
 
 * When reading <code>d:Q5</code> from repository <code>foo</code>, it is turned into <code>foo:d:Q5</code>, meaning ''<code>Q5</code> at the repo that repo <code>foo</code> calls <code>d</code>''
 * The local repository may have mappings defined for the prefixes used by other wikis, e.g. <code>foo:d</code> would be known to be the same as the local prefix <code>wd</code> for Wikidata. Mappings are defined as a two-dimensional array, e.g. part of mapping definition for example mentioned here would look like below:
-<code> [ ... 'foo' => [ 'd' => 'wd' ], ... ]</code>
+<code> array( ... 'foo' => array( 'd' => 'wd' ), ... )</code>
 
 * When deserializing data from another repository, the name of the source repository is always added as a prefix, and then any known mappings are resolved: <code>d:Q5</code> from <code>foo</code> becomes <code>foo:d:Q5</code> and then <code>wd:Q5</code>.
 * If no mapping is known, the "chained" version of the ID (<code>foo:d:Q5</code>) is stored locally. If this kind of ID is sent to yet another repo, that may result in longer "chains" of prefixes, like <code>xyz:foo:d:Q5</code>.


### PR DESCRIPTION
This patch documents the intended semantics of the methods in the
EntityId base class, to align them to the behavior defined in
docs/foreign-entity-ids.wiki