### PR TITLE
Inline all abstract stuff from HashArrayTest to the implementations

### DIFF
--- a/tests/unit/HashArray/HashArrayTest.php
+++ b/tests/unit/HashArray/HashArrayTest.php
@@ -14,29 +14,6 @@ namespace Wikibase\DataModel\Tests\HashArray;
  */
 abstract class HashArrayTest extends \PHPUnit_Framework_TestCase {
 
-	public abstract function constructorProvider();
-
-	/**
-	 * Returns the name of the concrete class being tested.
-	 *
-	 * @since 0.4
-	 *
-	 * @return string
-	 */
-	abstract public function getInstanceClass();
-
-	public function instanceProvider() {
-		$class = $this->getInstanceClass();
-
-		$instances = [];
-
-		foreach ( $this->constructorProvider() as $args ) {
-			$instances[] = [ new $class( array_key_exists( 0, $args ) ? $args[0] : [] ) ];
-		}
-
-		return $instances;
-	}
-
 	/**
 	 * @param array $elements
 	 *

--- a/tests/unit/HashArray/HashArrayWithoutDuplicatesTest.php
+++ b/tests/unit/HashArray/HashArrayWithoutDuplicatesTest.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel\Tests\HashArray;
 
 use Hashable;
 use Wikibase\DataModel\Fixtures\HashArrayElement;
+use Wikibase\DataModel\Fixtures\HashArrayWithoutDuplicates;
 use Wikibase\DataModel\HashArray;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 
@@ -19,17 +20,10 @@ use Wikibase\DataModel\Snak\PropertyNoValueSnak;
  */
 class HashArrayWithoutDuplicatesTest extends HashArrayTest {
 
-	public function constructorProvider() {
-		$argLists = [];
-
-		$argLists[] = [ HashArrayElement::getInstances() ];
-		$argLists[] = [ array_merge( HashArrayElement::getInstances(), HashArrayElement::getInstances() ) ];
-
-		return $argLists;
-	}
-
-	public function getInstanceClass() {
-		return 'Wikibase\DataModel\Fixtures\HashArrayWithoutDuplicates';
+	public function instanceProvider() {
+		return [
+			[ new HashArrayWithoutDuplicates( HashArrayElement::getInstances() ) ],
+		];
 	}
 
 	public function elementInstancesProvider() {

--- a/tests/unit/Snak/SnakListTest.php
+++ b/tests/unit/Snak/SnakListTest.php
@@ -33,13 +33,6 @@ use Wikibase\DataModel\Tests\HashArray\HashArrayTest;
  */
 class SnakListTest extends HashArrayTest {
 
-	/**
-	 * @see HashArrayTest::getInstanceClass
-	 */
-	public function getInstanceClass() {
-		return 'Wikibase\DataModel\Snak\SnakList';
-	}
-
 	public function elementInstancesProvider() {
 		$id42 = new PropertyId( 'P42' );
 
@@ -52,25 +45,24 @@ class SnakListTest extends HashArrayTest {
 		return $argLists;
 	}
 
-	public function constructorProvider() {
+	public function instanceProvider() {
 		$id42 = new PropertyId( 'P42' );
 		$id9001 = new PropertyId( 'P9001' );
 
 		return [
-			[],
-			[ [] ],
-			[ [
+			[ new SnakList() ],
+			[ new SnakList( [
 				new PropertyNoValueSnak( $id42 )
-			] ],
-			[ [
+			] ) ],
+			[ new SnakList( [
 				new PropertyNoValueSnak( $id42 ),
 				new PropertyNoValueSnak( $id9001 ),
-			] ],
-			[ [
+			] ) ],
+			[ new SnakList( [
 				new PropertyNoValueSnak( $id42 ),
 				new PropertyNoValueSnak( $id9001 ),
 				new PropertyValueSnak( $id42, new StringValue( 'a' ) ),
-			] ],
+			] ) ],
 		];
 	}
 


### PR DESCRIPTION
All I do here is inlining the three methods from the abstract base class into the two implementations.

You will notice that the base class is almost empty now. A single helper method is left, and this is even used by only one of the two implementations. I'm aware of this, but I stopped working on the code at this point on purpose to make this patch as trivial as it can be. #702 will get rid of the base class along with the second implementation. There is just no point in making this code nicer before killing it.

This patch does the following things:
* It moves all relevant code to `SnakListTest`, making it more robust. This is the test we really care about.
* It removes a redundant test case from `SnakListTest`. Before, it was creating two instances with no arguments and `[]`. These are identical anyway.
* It also removes the second test case from `HashArrayWithoutDuplicatesTest`. It appears this was meant to test the "without duplicates" feature, and created an array with duplicates to do this. But there was never an assertion that tested this behaviour. What the `instanceProvider` returned always was an array with two equal instances. I just removed one now.