### PR TITLE
Undeprecate SiteLink methods in Item

### DIFF
--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -204,7 +204,6 @@ class Item implements EntityDocument, FingerprintProvider, StatementListHolder,
 	 * If there already is a site link with the site id of the provided site link,
 	 * then that one will be overridden by the provided one.
 	 *
-	 * @deprecated since 0.8, use getSiteLinkList()->addSiteLink() instead.
 	 * @since 0.6
 	 *
 	 * @param SiteLink $siteLink
@@ -220,7 +219,6 @@ class Item implements EntityDocument, FingerprintProvider, StatementListHolder,
 	/**
 	 * Removes the sitelink with specified site ID if the Item has such a sitelink.
 	 *
-	 * @deprecated since 0.8, use getSiteLinkList()->removeLinkWithSiteId() instead.
 	 * @since 0.1
 	 *
 	 * @param string $siteId the target site's id
@@ -230,7 +228,6 @@ class Item implements EntityDocument, FingerprintProvider, StatementListHolder,
 	}
 
 	/**
-	 * @deprecated since 0.8, use getSiteLinkList()->getBySiteId() instead.
 	 * @since 0.6
 	 *
 	 * @param string $siteId
@@ -243,7 +240,6 @@ class Item implements EntityDocument, FingerprintProvider, StatementListHolder,
 	}
 
 	/**
-	 * @deprecated since 0.8, use getSiteLinkList()->hasLinkWithSiteId() instead.
 	 * @since 0.4
 	 *
 	 * @param string $siteId


### PR DESCRIPTION
They where deprecated years ago and never removed, presumably cause there is no clear motivation to do so.

IIRC I deprecated this stuff, but at present I no longer think this makes things better.

Note that this leaves one of them in place (since I do think that one does not make sense to have here): https://github.com/wmde/WikibaseDataModel/issues/733