### PR TITLE
Remove deprecated Item::getSiteLinks

### DIFF
--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -232,16 +232,6 @@ class Item implements EntityDocument, FingerprintProvider, StatementListHolder,
 	}
 
 	/**
-	 * @deprecated since 0.8, use getSiteLinkList() instead,
-	 * @since 0.6
-	 *
-	 * @return SiteLink[]
-	 */
-	public function getSiteLinks() {
-		return array_values( iterator_to_array( $this->siteLinks ) );
-	}
-
-	/**
 	 * @deprecated since 0.8, use getSiteLinkList()->getBySiteId() instead.
 	 * @since 0.6
 	 *

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -116,21 +116,6 @@ class ItemTest extends PHPUnit_Framework_TestCase {
 		return $argLists;
 	}
 
-	/**
-	 * @dataProvider simpleSiteLinksProvider
-	 */
-	public function testGetSiteLinks() {
-		$siteLinks = func_get_args();
-		$item = new Item();
-
-		foreach ( $siteLinks as $siteLink ) {
-			$item->getSiteLinkList()->addSiteLink( $siteLink );
-		}
-
-		$this->assertInternalType( 'array', $item->getSiteLinks() );
-		$this->assertEquals( $siteLinks, $item->getSiteLinks() );
-	}
-
 	public function simpleSiteLinksProvider() {
 		$argLists = [];
 


### PR DESCRIPTION
Unused. Fixes #733. Also see #734.