### PR TITLE
Clarify contract of EntityDocument::isEmpty

### DIFF
--- a/src/Entity/EntityDocument.php
+++ b/src/Entity/EntityDocument.php
@@ -47,7 +47,11 @@ interface EntityDocument extends Comparable {
 	public function setId( $id );
 
 	/**
-	 * Returns true if the entity has no content. Having an id set does not count as having content.
+	 * An entity is considered empty if it does not contain any content that can be removed. Having
+	 * an ID set never counts as having content.
+	 *
+	 * Knowing if an entity is empty is relevant when, for example, moving or merging entities and
+	 * code wants to make sure all content is transferred from the old to the new entity.
 	 *
 	 * @since 4.3
 	 *


### PR DESCRIPTION
This does not make much of a difference for the existing Item and Property entity types. But it became relevant for the Lexeme entity type. In the Lexeme class we made it possible to have nullable constructor parameters, but the corresponding setters do not allow null. This means there are fields that can never be removed from an existing entity that had these fields set before. This becomes relevant when trying to merge two Lexemes. The code doing the merge checks if the old Lexeme was emptied first, and rejects the merge otherwise.

TL;DR: isEmpty does not make much sense if there is no way to empty an entity.