### PR TITLE
Switch to the Wikibase CodeSniffer rule set

### DIFF
--- a/Aliases.php
+++ b/Aliases.php
@@ -4,4 +4,8 @@
 // It should not be included anywhere.
 // Actual aliasing happens in the entry point using class_alias.
 
-namespace { throw new Exception( 'This code is not meant to be executed' ); }
+namespace {
+
+	throw new Exception( 'This code is not meant to be executed' );
+
+}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"ockcyp/covers-validator": "~0.4.0",
 		"phpmd/phpmd": "~2.3",
 		"phpunit/phpunit": "~4.8",
-		"squizlabs/php_codesniffer": "~2.3"
+		"wikibase/wikibase-codesniffer": "^0.1.0"
 	},
 	"autoload": {
 		"files" : [
@@ -58,8 +58,8 @@
 	"scripts": {
 		"test": [
 			"@validate --no-interaction",
-			"vendor/bin/phpunit",
-			"vendor/bin/covers-validator"
+			"phpunit",
+			"covers-validator"
 		],
 		"cs": [
 			"@phpcs",
@@ -70,10 +70,10 @@
 			"@cs"
 		],
 		"phpcs": [
-			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp"
+			"phpcs -p -s"
 		],
 		"phpmd": [
-			"vendor/bin/phpmd src/ text phpmd.xml"
+			"phpmd src/ text phpmd.xml"
 		]
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,103 +1,23 @@
 <?xml version="1.0"?>
-<!--
-	- https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
-	- https://github.com/squizlabs/PHP_CodeSniffer/tree/master/CodeSniffer/Standards
--->
 <ruleset name="WikibaseDataModel">
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
+	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase">
+		<exclude name="PSR2.Methods.MethodDeclaration" />
+	</rule>
 
-    <rule ref="Generic.Classes" />
-    <rule ref="Generic.ControlStructures" />
+	<rule ref="Generic.Files.LineLength">
+		<properties>
+			<property name="lineLimit" value="120" />
+		</properties>
+	</rule>
 
-    <rule ref="Generic.Files.ByteOrderMark" />
-    <rule ref="Generic.Files.EndFileNewline" />
-    <rule ref="Generic.Files.InlineHTML" />
-    <rule ref="Generic.Files.LineEndings" />
-    <rule ref="Generic.Files.LineLength">
-        <properties>
-            <property name="lineLimit" value="125" />
-            <property name="absoluteLineLimit" value="125" />
-        </properties>
-    </rule>
-    <rule ref="Generic.Files.OneClassPerFile" />
-    <rule ref="Generic.Files.OneInterfacePerFile" />
-    <rule ref="Generic.Files.OneTraitPerFile" />
+	<!-- Metrics are intentionally not part of the base Wikibase CodeSniffer rule set. -->
+	<rule ref="Generic.Metrics.CyclomaticComplexity" />
+	<rule ref="Generic.Metrics.NestingLevel" />
 
-    <rule ref="Generic.Formatting.DisallowMultipleStatements" />
+	<rule ref="Generic.NamingConventions.CamelCapsFunctionName" />
+	<rule ref="PSR1.Files.SideEffects" />
+	<rule ref="Squiz.Arrays.ArrayBracketSpacing" />
+	<rule ref="Squiz.Strings.DoubleQuoteUsage" />
 
-    <rule ref="Generic.Functions.CallTimePassByReference" />
-    <rule ref="Generic.Functions.FunctionCallArgumentSpacing" />
-    <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
-
-    <rule ref="Generic.Metrics.CyclomaticComplexity">
-        <properties>
-            <property name="complexity" value="10" />
-        </properties>
-    </rule>
-    <rule ref="Generic.Metrics.NestingLevel">
-        <properties>
-            <property name="nestingLevel" value="3" />
-        </properties>
-    </rule>
-
-    <rule ref="Generic.NamingConventions" />
-    <rule ref="Generic.NamingConventions.CamelCapsFunctionName.ScopeNotCamelCaps">
-        <!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
-        <exclude-pattern>tests.unit*Test\.php</exclude-pattern>
-    </rule>
-
-    <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag" />
-    <rule ref="Generic.PHP.DeprecatedFunctions" />
-    <rule ref="Generic.PHP.DisallowShortOpenTag" />
-    <rule ref="Generic.PHP.ForbiddenFunctions" />
-    <rule ref="Generic.PHP.LowerCaseConstant" />
-    <rule ref="Generic.PHP.LowerCaseKeyword" />
-    <rule ref="Generic.PHP.NoSilencedErrors" />
-    <rule ref="Generic.PHP.SAPIUsage" />
-
-    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent" />
-
-    <rule ref="PSR1" />
-    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
-        <!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
-        <exclude-pattern>tests.unit*Test\.php</exclude-pattern>
-    </rule>
-
-    <rule ref="PSR2.Classes.PropertyDeclaration" />
-    <rule ref="PSR2.ControlStructures.ElseIfDeclaration" />
-    <rule ref="PSR2.Files" />
-    <rule ref="PSR2.Namespaces" />
-
-    <rule ref="Squiz.Arrays.ArrayBracketSpacing" />
-    <rule ref="Squiz.CSS.SemicolonSpacing" />
-    <rule ref="Squiz.Classes.DuplicateProperty" />
-    <rule ref="Squiz.Classes.SelfMemberReference" />
-    <rule ref="Squiz.Classes.ValidClassName" />
-    <rule ref="Squiz.Functions.FunctionDuplicateArgument" />
-    <rule ref="Squiz.Functions.GlobalFunction" />
-    <rule ref="Squiz.Scope" />
-
-    <rule ref="Squiz.Strings.DoubleQuoteUsage">
-        <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar" />
-    </rule>
-
-    <rule ref="Squiz.WhiteSpace.CastSpacing" />
-    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing" />
-    <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing" />
-    <rule ref="Squiz.WhiteSpace.FunctionSpacing">
-        <properties>
-            <property name="spacing" value="1" />
-        </properties>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
-        <properties>
-            <property name="ignoreNewlines" value="true" />
-        </properties>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace" />
-    <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing" />
-    <rule ref="Squiz.WhiteSpace.SemicolonSpacing" />
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace" />
-
-    <rule ref="Zend.Files.ClosingTag" />
+	<file>.</file>
 </ruleset>

--- a/src/HashArray.php
+++ b/src/HashArray.php
@@ -111,8 +111,7 @@ abstract class HashArray extends ArrayObject {
 
 		if ( $hasHash ) {
 			return false;
-		}
-		else {
+		} else {
 			$this->offsetHashes[$hash] = $index;
 
 			return true;
@@ -203,9 +202,8 @@ abstract class HashArray extends ArrayObject {
 			$offset = $this->offsetHashes[$elementHash];
 			return $this->offsetGet( $offset );
 		}
-		else {
-			return false;
-		}
+
+		return false;
 	}
 
 	/**

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -110,8 +110,7 @@ class AliasGroupList implements Countable, IteratorAggregate {
 	public function setGroup( AliasGroup $group ) {
 		if ( $group->isEmpty() ) {
 			unset( $this->groups[$group->getLanguageCode()] );
-		}
-		else {
+		} else {
 			$this->groups[$group->getLanguageCode()] = $group;
 		}
 	}

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -121,8 +121,7 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 	public function setTerm( Term $term ) {
 		if ( $term->getText() === '' ) {
 			unset( $this->terms[$term->getLanguageCode()] );
-		}
-		else {
+		} else {
 			$this->terms[$term->getLanguageCode()] = $term;
 		}
 	}

--- a/tests/unit/HashArray/HashArrayWithoutDuplicatesTest.php
+++ b/tests/unit/HashArray/HashArrayWithoutDuplicatesTest.php
@@ -106,8 +106,7 @@ class HashArrayWithoutDuplicatesTest extends HashArrayTest {
 
 			if ( $elementCount % 2 === 0 ) {
 				$array->removeElement( $element );
-			}
-			else {
+			} else {
 				$array->removeByElementHash( $element->getHash() );
 			}
 

--- a/tests/unit/Snak/SnakListTest.php
+++ b/tests/unit/Snak/SnakListTest.php
@@ -131,8 +131,7 @@ class SnakListTest extends HashArrayTest {
 
 			if ( $elementCount % 2 === 0 ) {
 				$array->removeSnak( $element );
-			}
-			else {
+			} else {
 				$array->removeSnakHash( $element->getHash() );
 			}
 


### PR DESCRIPTION
I did a diff of what `phpcs -e` ("explain a standard by showing the sniffs it includes") outputs before and after the changes I'm doing in this patch:
* A series of 5 `Generic.CodeAnalysis.…` rules is added.
* `Generic.Formatting.MultipleStatementAlignment` is new.
* 12 `MediaWiki.…` are added.
* `Squiz.ControlStructures.ControlSignature` is new.
* `Squiz.Classes.DuplicateProperty` is removed. This is fine, because this is a JavaScript-only sniff that was included by mistake.