### PR TITLE
Fix broken Item and Property::testSetEmptyAlias tests

### DIFF
--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -489,29 +489,17 @@ class ItemTest extends PHPUnit_Framework_TestCase {
 		}
 	}
 
-	/**
-	 * @dataProvider aliasesProvider
-	 */
-	public function testSetEmptyAlias( array $aliasesLists ) {
-		$entity = $this->getNewEmpty();
+	public function testSetEmptyAlias() {
+		$item = new Item();
 
-		foreach ( $aliasesLists as $langCode => $aliasesList ) {
-			foreach ( $aliasesList as $aliases ) {
-				$entity->setAliases( $langCode, $aliases );
-			}
-		}
-		$entity->setAliases( 'zh', [ 'wind', 'air', '', 'fire' ] );
-		$entity->setAliases( 'zu', [ '', '' ] );
+		$item->setAliases( 'en', [ 'wind', 'air', '', 'fire' ] );
+		$this->assertSame(
+			[ 'wind', 'air', 'fire' ],
+			$item->getAliasGroups()->getByLanguage( 'en' )->getAliases()
+		);
 
-		foreach ( $aliasesLists as $langCode => $aliasesList ) {
-			$expected = array_values( array_unique( array_pop( $aliasesList ) ) );
-			asort( $aliasesList );
-
-			$actual = $entity->getFingerprint()->getAliasGroup( $langCode )->getAliases();
-			asort( $actual );
-
-			$this->assertEquals( $expected, $actual );
-		}
+		$item->setAliases( 'en', [ '', '' ] );
+		$this->assertFalse( $item->getAliasGroups()->hasGroupForLanguage( 'en' ) );
 	}
 
 	public function instanceProvider() {

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -366,29 +366,17 @@ class PropertyTest extends PHPUnit_Framework_TestCase {
 		}
 	}
 
-	/**
-	 * @dataProvider aliasesProvider
-	 */
-	public function testSetEmptyAlias( array $aliasesLists ) {
-		$entity = $this->getNewEmpty();
+	public function testSetEmptyAlias() {
+		$property = Property::newFromType( 'string' );
 
-		foreach ( $aliasesLists as $langCode => $aliasesList ) {
-			foreach ( $aliasesList as $aliases ) {
-				$entity->setAliases( $langCode, $aliases );
-			}
-		}
-		$entity->setAliases( 'zh', [ 'wind', 'air', '', 'fire' ] );
-		$entity->setAliases( 'zu', [ '', '' ] );
+		$property->setAliases( 'en', [ 'wind', 'air', '', 'fire' ] );
+		$this->assertSame(
+			[ 'wind', 'air', 'fire' ],
+			$property->getAliasGroups()->getByLanguage( 'en' )->getAliases()
+		);
 
-		foreach ( $aliasesLists as $langCode => $aliasesList ) {
-			$expected = array_values( array_unique( array_pop( $aliasesList ) ) );
-			asort( $aliasesList );
-
-			$actual = $entity->getFingerprint()->getAliasGroup( $langCode )->getAliases();
-			asort( $actual );
-
-			$this->assertEquals( $expected, $actual );
-		}
+		$property->setAliases( 'en', [ '', '' ] );
+		$this->assertFalse( $property->getAliasGroups()->hasGroupForLanguage( 'en' ) );
 	}
 
 	public function instanceProvider() {


### PR DESCRIPTION
I'm not sure how this happened, but this is what these two tests did:
* Create an empty entity.
* Set some aliases as provided. The provider only provides some "en" and "de" aliases.
* Set "zh" and "zu" aliases.
* Compare the "en" and "de" aliases.

That's all. It never checked what happened with the "zh" and "zu" aliases.