### PR TITLE
Fix broken PHPCS rule set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.5
   - 5.6

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,10 +14,17 @@
 	<rule ref="Generic.Metrics.CyclomaticComplexity" />
 	<rule ref="Generic.Metrics.NestingLevel" />
 
-	<rule ref="Generic.NamingConventions.CamelCapsFunctionName" />
-	<rule ref="PSR1.Files.SideEffects" />
+	<rule ref="Generic.NamingConventions.CamelCapsFunctionName">
+		<!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
+		<exclude-pattern>tests*Test*\.php</exclude-pattern>
+	</rule>
+	<rule ref="PSR1.Files.SideEffects">
+		<exclude-pattern>WikibaseDataModel\.php</exclude-pattern>
+	</rule>
 	<rule ref="Squiz.Arrays.ArrayBracketSpacing" />
-	<rule ref="Squiz.Strings.DoubleQuoteUsage" />
+	<rule ref="Squiz.Strings.DoubleQuoteUsage">
+		<exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar" />
+	</rule>
 
 	<file>.</file>
 </ruleset>


### PR DESCRIPTION
The changes I made in #745 accidentally removed crucial exclude patterns.

Having these additional sniffs here, locally, and not in the Wikibase rule set, is intended exactly because of these exceptions.