### PR TITLE
Fix forgotten Item/Property::setId documentation and exception

### DIFF
--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -83,21 +83,18 @@ class Item implements EntityDocument, FingerprintProvider, StatementListHolder,
 	}
 
 	/**
-	 * Can be integer since 0.1.
-	 * Can be ItemId since 0.5.
-	 * Can be null since 1.0.
+	 * @since 0.5, can be null since 1.0
 	 *
 	 * @param ItemId|null $id
 	 *
 	 * @throws InvalidArgumentException
 	 */
 	public function setId( $id ) {
-		if ( $id === null || $id instanceof ItemId ) {
-			$this->id = $id;
-		} else {
-			throw new InvalidArgumentException( '$id must be an instance of ItemId, an integer,'
-				. ' or null' );
+		if ( !( $id instanceof ItemId ) && $id !== null ) {
+			throw new InvalidArgumentException( '$id must be an ItemId or null' );
 		}
+
+		$this->id = $id;
 	}
 
 	/**

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -81,21 +81,18 @@ class Property implements EntityDocument, FingerprintProvider, StatementListHold
 	}
 
 	/**
-	 * Can be integer since 0.1.
-	 * Can be PropertyId since 0.5.
-	 * Can be null since 1.0.
+	 * @since 0.5, can be null since 1.0
 	 *
 	 * @param PropertyId|null $id
 	 *
 	 * @throws InvalidArgumentException
 	 */
 	public function setId( $id ) {
-		if ( $id === null || $id instanceof PropertyId ) {
-			$this->id = $id;
-		} else {
-			throw new InvalidArgumentException( '$id must be an instance of PropertyId, an integer,'
-				. ' or null' );
+		if ( !( $id instanceof PropertyId ) && $id !== null ) {
+			throw new InvalidArgumentException( '$id must be a PropertyId or null' );
 		}
+
+		$this->id = $id;
 	}
 
 	/**


### PR DESCRIPTION
Introduced in #753.

Three people discussed there, and a fourth person noticed this mistake, but 5 days later nobody was able to fix it. I find this quite fascinating.

I agree with Jeroen in so far that the removal done in #753 was not required to fulfill what the ticket asked for: it's perfectly possible to **not** call `setId` with integers, even if the method still accepts integers. However, it's obviously much easier to find unwanted usages if `setId` fails with an exception if ever called with an integer.

The only downside of the removal is that test code becomes harder to write. I agree that calls like `$item->setId( 1 )` must be burned with fire. But `$item->setId( new ItemId( 'Q1' ) )` is quite ugly. What about allowing `$item->setId( 'Q1' )`? Is this worth it? (I know we already have `NewItem::withId( 'Q1' )->build()`.)