### PR TITLE
Remove non-standard Composer commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,18 +62,12 @@
 			"covers-validator"
 		],
 		"cs": [
-			"@phpcs",
-			"@phpmd"
+			"phpcs -p -s",
+			"phpmd src/ text phpmd.xml"
 		],
 		"ci": [
-			"@test",
-			"@cs"
-		],
-		"phpcs": [
-			"phpcs -p -s"
-		],
-		"phpmd": [
-			"phpmd src/ text phpmd.xml"
+			"@cs",
+			"@test"
 		]
 	}
 }


### PR DESCRIPTION
I'm reducing the confusing number of Composer commands to "cs", "test", and "ci". Usually, PHPCS is executed before PHPUnit. This patch also makes sure this order is consistent.