### PR TITLE
Heavily optimize SnakList::moveSnaksToBottom

### DIFF
--- a/src/Snak/SnakList.php
+++ b/src/Snak/SnakList.php
@@ -180,6 +180,21 @@ class SnakList extends ArrayObject implements Comparable, Hashable {
 	 * @param Snak[] $snaks to remove and re add
 	 */
 	private function moveSnaksToBottom( array $snaks ) {
+		// Skip Snaks that are already at the bottom:
+		// Find the last element in the array by looking at the last element
+		// in the offsetHashes array (this works as they are always added side-by-side).
+		$offsets = $this->offsetHashes;
+
+		$snakCount = count( $snaks );
+		for ( $i = 0; $i < $snakCount; $i++ ) {
+			$lastOffset = array_pop( $offsets );
+			if ( $this[$lastOffset] === $snaks[$i] ) {
+				unset( $snaks[$i] );
+			} else {
+				break;
+			}
+		}
+
 		foreach ( $snaks as $snak ) {
 			$this->removeSnak( $snak );
 			$this->addSnak( $snak );


### PR DESCRIPTION
I found this to be rather inefficient when profiling the dump generation, thus I looked into it. Currently when dumping the first 1,000 entities this takes about 10% of the time, the new version only takes about 6% of the time, thus making the dump approx. 4% faster. This will also effect the API and many other DM users to some extent.

Note: Instead of using $this->offsetHashes, I could have also either used an Iterator or an array derived from the object, but that's slower as it requires generating a new object/ array.