### PR TITLE
[WIP] Do not build SnakList on top of ArrayObject

### DIFF
--- a/tests/unit/Snak/SnakListTest.php
+++ b/tests/unit/Snak/SnakListTest.php
@@ -82,9 +82,12 @@ class SnakListTest extends PHPUnit_Framework_TestCase {
 		];
 	}
 
-	public function testGivenAssociativeArray_constructorPreservesArrayKeys() {
+	public function testGivenAssociativeArray_constructorDoesNotPreserveArrayKeys() {
 		$snakList = new SnakList( [ 'key' => new PropertyNoValueSnak( 1 ) ] );
-		$this->assertSame( [ 'key' ], array_keys( iterator_to_array( $snakList ) ) );
+		$this->assertSame(
+			[ 'c77761897897f63f151c4a1deb8bd3ad23ac51c6' ],
+			array_keys( iterator_to_array( $snakList ) )
+		);
 	}
 
 	/**


### PR DESCRIPTION
The main reason to touch this file again is the awkward complexity it had before. Note that the data structure was build in a way that it kept track of **two** keys for each element. One key is the snak hash, the other one whatever you provided via the constructor.

WIP mostly because of the Iterator methods (rewind, current, and so on). These expose the internal state of the $this->snaks array. I'm not sure if this is robust enough. The array pointer might change when using other SnakList methods.