### PR TITLE
Reduce line length and simplify PHPCS rule set

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -4,7 +4,7 @@
 
 	<rule ref="Generic.Files.LineLength">
 		<properties>
-			<property name="lineLimit" value="116" />
+			<property name="lineLimit" value="115" />
 		</properties>
 	</rule>
 
@@ -12,14 +12,9 @@
 	<rule ref="Generic.Metrics.CyclomaticComplexity" />
 	<rule ref="Generic.Metrics.NestingLevel" />
 
-	<rule ref="Generic.NamingConventions.CamelCapsFunctionName">
-		<!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
-		<exclude-pattern>tests*Test*\.php</exclude-pattern>
-	</rule>
 	<rule ref="PSR1.Files.SideEffects">
 		<exclude-pattern>WikibaseDataModel\.php</exclude-pattern>
 	</rule>
-	<rule ref="Squiz.Arrays.ArrayBracketSpacing" />
 	<rule ref="Squiz.Strings.DoubleQuoteUsage">
 		<exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar" />
 	</rule>

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -125,7 +125,8 @@ class ReferenceListTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(
 			$list->hasReference( $sameReference ),
-			'hasReference should return true when a reference with the same value is present, even when its another instance'
+			'hasReference should return true when a reference with the same value is present, even '
+				. 'when its another instance'
 		);
 	}
 


### PR DESCRIPTION
* I'm always trying to reduce the line length in tiny steps, to have diffs that are as small and as easy to review as possible.
* The removed CamelCapsFunctionName sniff is obsolete. This is already covered by two other sniffs.
* The ArrayBracketSpacing sniff is in conflict with the MediaWiki code style that suggests to use spaces inside `$array[ $index ]`. We should not enforce a conflicting style. For now, both is allowed.