### PR TITLE
Streamline ItemId and PropertyId constructors a little

### DIFF
--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -22,19 +22,14 @@ class ItemId extends EntityId implements Int32EntityId {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $idSerialization ) {
-		$serializationParts = self::splitSerialization( $idSerialization );
-		$localId = strtoupper( $serializationParts[2] );
-		$this->assertValidIdFormat( $localId );
+		$parts = self::splitSerialization( $idSerialization );
+		$this->assertValidIdFormat( $parts[2] );
 		parent::__construct( self::joinSerialization(
-			[ $serializationParts[0], $serializationParts[1], $localId ] )
-		);
+			[ $parts[0], $parts[1], strtoupper( $parts[2] ) ]
+		) );
 	}
 
 	private function assertValidIdFormat( $idSerialization ) {
-		if ( !is_string( $idSerialization ) ) {
-			throw new InvalidArgumentException( '$idSerialization must be a string' );
-		}
-
 		if ( !preg_match( self::PATTERN, $idSerialization ) ) {
 			throw new InvalidArgumentException( '$idSerialization must match ' . self::PATTERN );
 		}

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -22,19 +22,14 @@ class PropertyId extends EntityId implements Int32EntityId {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $idSerialization ) {
-		$serializationParts = self::splitSerialization( $idSerialization );
-		$localId = strtoupper( $serializationParts[2] );
-		$this->assertValidIdFormat( $localId );
+		$parts = self::splitSerialization( $idSerialization );
+		$this->assertValidIdFormat( $parts[2] );
 		parent::__construct( self::joinSerialization(
-			[ $serializationParts[0], $serializationParts[1], $localId ] )
-		);
+			[ $parts[0], $parts[1], strtoupper( $parts[2] ) ]
+		) );
 	}
 
 	private function assertValidIdFormat( $idSerialization ) {
-		if ( !is_string( $idSerialization ) ) {
-			throw new InvalidArgumentException( '$idSerialization must be a string' );
-		}
-
 		if ( !preg_match( self::PATTERN, $idSerialization ) ) {
 			throw new InvalidArgumentException( '$idSerialization must match ' . self::PATTERN );
 		}


### PR DESCRIPTION
* Remove two is_string checks that are effectively dead code. The variable is coming from a splitSerialization call, which is guaranteed to return strings. And even if, the next preg_match check will still catch all errors.
* I move the strtoupper down, mostly for performance reasons.
* The shorter variable name $parts makes this much better readable. Before, this short method repeated the word "serialization" 8 times.