### PR TITLE
phpdoc: TermList::getIterator can return an Iterator

### DIFF
--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -6,6 +6,7 @@ use ArrayIterator;
 use Comparable;
 use Countable;
 use InvalidArgumentException;
+use Iterator;
 use IteratorAggregate;
 use OutOfBoundsException;
 use Traversable;
@@ -66,7 +67,7 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 
 	/**
 	 * @see IteratorAggregate::getIterator
-	 * @return Traversable|Term[]
+	 * @return Traversable|Iterator|Term[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->terms );

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -9,7 +9,6 @@ use InvalidArgumentException;
 use Iterator;
 use IteratorAggregate;
 use OutOfBoundsException;
-use Traversable;
 
 /**
  * Unordered list of Term objects.
@@ -67,7 +66,7 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 
 	/**
 	 * @see IteratorAggregate::getIterator
-	 * @return Traversable|Iterator|Term[]
+	 * @return Iterator|Term[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->terms );


### PR DESCRIPTION
Without this type hint we get an IDE error (and probably further static analysis errors) as
SpecialNewLexeme::createSummary calls getIterator and calls current() on the result
which doesn't exist in the current typehint.

This is a 2 part fix, getIterator should document that it can return an Iterator, and also
the createSummary method should probably check that it actually has a Iterator instead
of a just a Traversable.