### PR TITLE
Introduce StatementListProvidingEntity interface

### DIFF
--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -26,7 +26,7 @@ use Wikibase\DataModel\Term\TermList;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
-class Item implements EntityDocument, FingerprintProvider, StatementListHolder,
+class Item implements StatementListProvidingEntity, FingerprintProvider, StatementListHolder,
 	LabelsProvider, DescriptionsProvider, AliasesProvider {
 
 	const ENTITY_TYPE = 'item';

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -23,7 +23,7 @@ use Wikibase\DataModel\Term\TermList;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
-class Property implements EntityDocument, FingerprintProvider, StatementListHolder,
+class Property implements StatementListProvidingEntity, FingerprintProvider, StatementListHolder,
 	LabelsProvider, DescriptionsProvider, AliasesProvider {
 
 	const ENTITY_TYPE = 'property';

--- a/src/Entity/StatementListProvidingEntity.php
+++ b/src/Entity/StatementListProvidingEntity.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Wikibase\DataModel\Entity;
+
+use Wikibase\DataModel\Statement\StatementListProvider;
+
+/**
+ * Interface for EntityDocument objects that are also StatementListProviders
+ *
+ * @since 7.6
+ *
+ * @license GPL-2.0+
+ */
+interface StatementListProvidingEntity extends EntityDocument, StatementListProvider {
+}


### PR DESCRIPTION
This interface allows for better type hinting when expecting an `EntityDocument` that has statements, e.g. when merging two lists of statements.

Examples where this would be useful: 
https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/448026/3/repo/includes/Merge/Validator/NoCrossReferencingStatements.php#21
https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/447084/8/repo/includes/Merge/StatementsMerger.php#30

Note: I do realize that `Item` and `Property` do not directly implement `StatementListProvider`, but `StatementListHolder`. `Lexeme`, `Form` and `Sense` implement only `StatementListProvider`. This makes it a little awkward.

Task on Phab: https://phabricator.wikimedia.org/T200024