### PR TITLE
[WIP] Implement non-standard "Q" prefixes

### DIFF
--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -90,16 +90,17 @@ class ItemId extends EntityId implements Int32EntityId {
 	 * serialization. Not doing so in new code requires special justification.
 	 *
 	 * @param int|float|string $numericId
+	 * @param string $prefix
 	 *
 	 * @return self
 	 * @throws InvalidArgumentException
 	 */
-	public static function newFromNumber( $numericId ) {
+	public static function newFromNumber( $numericId, $prefix = 'Q' ) {
 		if ( !is_numeric( $numericId ) ) {
 			throw new InvalidArgumentException( '$numericId must be numeric' );
 		}
 
-		return new self( 'Q' . $numericId );
+		return new self( $prefix . $numericId );
 	}
 
 	/**
@@ -109,16 +110,17 @@ class ItemId extends EntityId implements Int32EntityId {
 	 *
 	 * @param string $repositoryName
 	 * @param int|float|string $numericId
+	 * @param string $itemPrefix
 	 *
 	 * @return self
 	 * @throws InvalidArgumentException
 	 */
-	public static function newFromRepositoryAndNumber( $repositoryName, $numericId ) {
+	public static function newFromRepositoryAndNumber( $repositoryName, $numericId, $itemPrefix = 'Q' ) {
 		if ( !is_numeric( $numericId ) ) {
 			throw new InvalidArgumentException( '$numericId must be numeric' );
 		}
 
-		return new self( self::joinSerialization( [ $repositoryName, '', 'Q' . $numericId ] ) );
+		return new self( self::joinSerialization( [ $repositoryName, '', $itemPrefix . $numericId ] ) );
 	}
 
 }

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -90,16 +90,17 @@ class PropertyId extends EntityId implements Int32EntityId {
 	 * serialization. Not doing so in new code requires special justification.
 	 *
 	 * @param int|float|string $numericId
+	 * @param string $prefix
 	 *
 	 * @return self
 	 * @throws InvalidArgumentException
 	 */
-	public static function newFromNumber( $numericId ) {
+	public static function newFromNumber( $numericId, $prefix = 'P' ) {
 		if ( !is_numeric( $numericId ) ) {
 			throw new InvalidArgumentException( '$numericId must be numeric' );
 		}
 
-		return new self( 'P' . $numericId );
+		return new self( $prefix . $numericId );
 	}
 
 	/**
@@ -109,16 +110,17 @@ class PropertyId extends EntityId implements Int32EntityId {
 	 *
 	 * @param string $repositoryName
 	 * @param int|float|string $numericId
+	 * @param string $prefix
 	 *
 	 * @return self
 	 * @throws InvalidArgumentException
 	 */
-	public static function newFromRepositoryAndNumber( $repositoryName, $numericId ) {
+	public static function newFromRepositoryAndNumber( $repositoryName, $numericId, $prefix = 'P' ) {
 		if ( !is_numeric( $numericId ) ) {
 			throw new InvalidArgumentException( '$numericId must be numeric' );
 		}
 
-		return new self( self::joinSerialization( [ $repositoryName, '', 'P' . $numericId ] ) );
+		return new self( self::joinSerialization( [ $repositoryName, '', $prefix . $numericId ] ) );
 	}
 
 }


### PR DESCRIPTION
Allow Wikibase installations to use prefixes
other than 'Q' and 'P' for their items.

This pull request should not be merged yet, but seeks to start
the discussion on the viability of this approach.

See https://phabricator.wikimedia.org/T202676