### PR TITLE
Add TermList::add

### DIFF
--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -200,7 +200,7 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 	 *
 	 * @param iterable|Term[] $terms
 	 */
-	public function add( /* iterable */ $terms ) {
+	public function addAll( /* iterable */ $terms ) {
 		foreach ( $terms as $term ) {
 			$this->setTerm( $term );
 		}

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -195,4 +195,15 @@ class TermList implements Countable, IteratorAggregate, Comparable {
 		$this->terms = [];
 	}
 
+	/**
+	 * @since 8.1
+	 *
+	 * @param iterable|Term[] $terms
+	 */
+	public function add( /* iterable */ $terms ) {
+		foreach ( $terms as $term ) {
+			$this->setTerm( $term );
+		}
+	}
+
 }

--- a/tests/unit/Term/TermListTest.php
+++ b/tests/unit/Term/TermListTest.php
@@ -413,7 +413,7 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 		$deTerm = new Term( 'de', 'bar' );
 
 		$terms = new TermList();
-		$terms->add( [ $enTerm, $deTerm ] );
+		$terms->addAll( [ $enTerm, $deTerm ] );
 
 		$this->assertEquals( $enTerm, $terms->getByLanguage( 'en' ) );
 		$this->assertEquals( $deTerm, $terms->getByLanguage( 'de' ) );
@@ -425,7 +425,7 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 		$newEnTerm = new Term( 'en', 'NEW' );
 
 		$terms = new TermList( [ $enTerm ] );
-		$terms->add( [ $newEnTerm ] );
+		$terms->addAll( [ $newEnTerm ] );
 
 		$this->assertEquals( $newEnTerm, $terms->getByLanguage( 'en' ) );
 	}
@@ -435,7 +435,7 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 		$deTerm = new Term( 'de', 'bar' );
 
 		$terms = new TermList( [ $enTerm ] );
-		$terms->add( [ $deTerm ] );
+		$terms->addAll( [ $deTerm ] );
 
 		$this->assertEquals( $enTerm, $terms->getByLanguage( 'en' ) );
 	}
@@ -444,7 +444,7 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 		$enTerm = new Term( 'en', 'foo' );
 
 		$terms = new TermList();
-		$terms->add( new TermList( [ $enTerm ] ) );
+		$terms->addAll( new TermList( [ $enTerm ] ) );
 
 		$this->assertEquals( $enTerm, $terms->getByLanguage( 'en' ) );
 	}
@@ -452,7 +452,7 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 	public function testWhenAddingEmptyTerms_theyRemoveExistingOnes() {
 		$terms = new TermList( [ new Term( 'en', 'not-empty' ) ] );
 
-		$terms->add( [ new Term( 'en', '' ) ] );
+		$terms->addAll( [ new Term( 'en', '' ) ] );
 
 		$this->assertEquals( new TermList(), $terms );
 	}

--- a/tests/unit/Term/TermListTest.php
+++ b/tests/unit/Term/TermListTest.php
@@ -408,4 +408,53 @@ class TermListTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( new TermList(), $list );
 	}
 
+	public function testWhenAddingTermsToAListThatDoesNotContainThem_theyGetAdded() {
+		$enTerm = new Term( 'en', 'foo' );
+		$deTerm = new Term( 'de', 'bar' );
+
+		$terms = new TermList();
+		$terms->add( [ $enTerm, $deTerm ] );
+
+		$this->assertEquals( $enTerm, $terms->getByLanguage( 'en' ) );
+		$this->assertEquals( $deTerm, $terms->getByLanguage( 'de' ) );
+	}
+
+	public function testWhenAddingTermsToAListThatDoesContainThem_theyOverrideTheExistingOnes() {
+		$enTerm = new Term( 'en', 'foo' );
+
+		$newEnTerm = new Term( 'en', 'NEW' );
+
+		$terms = new TermList( [ $enTerm ] );
+		$terms->add( [ $newEnTerm ] );
+
+		$this->assertEquals( $newEnTerm, $terms->getByLanguage( 'en' ) );
+	}
+
+	public function testWhenAddingTerms_existingOnesAreNotLost() {
+		$enTerm = new Term( 'en', 'foo' );
+		$deTerm = new Term( 'de', 'bar' );
+
+		$terms = new TermList( [ $enTerm ] );
+		$terms->add( [ $deTerm ] );
+
+		$this->assertEquals( $enTerm, $terms->getByLanguage( 'en' ) );
+	}
+
+	public function testCanAddTermIterables() {
+		$enTerm = new Term( 'en', 'foo' );
+
+		$terms = new TermList();
+		$terms->add( new TermList( [ $enTerm ] ) );
+
+		$this->assertEquals( $enTerm, $terms->getByLanguage( 'en' ) );
+	}
+
+	public function testWhenAddingEmptyTerms_theyRemoveExistingOnes() {
+		$terms = new TermList( [ new Term( 'en', 'not-empty' ) ] );
+
+		$terms->add( [ new Term( 'en', '' ) ] );
+
+		$this->assertEquals( new TermList(), $terms );
+	}
+
 }


### PR DESCRIPTION
So TermListMerger in WikibaseLexeme can be removed

Note that TermListMerger does a not needed hasTerm check which has been omitted here