### PR TITLE
Add SubEntityProvider interface

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel release notes
 
+## Version 10.0.0 (dev)
+
+* Added `SubEntityProvider`
+
 ## Version 9.0.0 (2018-11-01)
 
 * Breaking change: `EntityDocument` no longer extends `ClearableEntity` (8.0.0 revert)

--- a/src/Entity/SubEntityProvider.php
+++ b/src/Entity/SubEntityProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace Wikibase\DataModel\Entity;
+
+/**
+ * Common interface for classes (typically entities) that may contain subentities.
+ *
+ * This only provides a way to enumerate the subentities;
+ * there is no generic mechanism for modifying them.
+ *
+ * @license GPL-2.0-or-later
+ */
+interface SubEntityProvider {
+
+	/**
+	 * Returns the subentities of this object,
+	 * not necessarily in any particular order.
+	 * Note that the returned list may be empty.
+	 *
+	 * @return EntityDocument[]
+	 */
+	public function getSubEntitities(): array;
+
+}


### PR DESCRIPTION
This provides users with a generic way to enumerate the subentities of an entity.

Bug: [T204066](https://phabricator.wikimedia.org/T204066)

---

Note that I have omitted some important formation from the interface documentation: what *is* a subentity?

Do we have a clear definition of that? E. g. do the subentities of an entity share the parent entity’s storage mechanism (in Wikibase: MediaWiki pages)?

Would it be acceptable to merge this PR without any such definition?