### PR TITLE
Update Wikibase PHPCS rule set to latest release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"ockcyp/covers-validator": "~0.5.0",
 		"phpmd/phpmd": "~2.6",
 		"phpunit/phpunit": "~5.7",
-		"wikibase/wikibase-codesniffer": "^0.3.0"
+		"wikibase/wikibase-codesniffer": "^0.5.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Assert/RepositoryNameAssert.php
+++ b/src/Assert/RepositoryNameAssert.php
@@ -14,7 +14,7 @@ use Wikimedia\Assert\ParameterAssertionException;
  *
  * @since 6.3
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 class RepositoryNameAssert {
 

--- a/src/ByPropertyIdArray.php
+++ b/src/ByPropertyIdArray.php
@@ -41,7 +41,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  * @since 0.2
  * @deprecated since 5.0, use a DataModel Service instead
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author H. Snater < mediawiki@snater.com >
  */
 class ByPropertyIdArray extends ArrayObject {

--- a/src/Entity/BasicEntityIdParser.php
+++ b/src/Entity/BasicEntityIdParser.php
@@ -7,7 +7,7 @@ namespace Wikibase\DataModel\Entity;
  *
  * @since 4.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class BasicEntityIdParser implements EntityIdParser {

--- a/src/Entity/ClearableEntity.php
+++ b/src/Entity/ClearableEntity.php
@@ -7,7 +7,7 @@ namespace Wikibase\DataModel\Entity;
  *
  * @since 7.5
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 interface ClearableEntity {
 

--- a/src/Entity/DispatchingEntityIdParser.php
+++ b/src/Entity/DispatchingEntityIdParser.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 /**
  * @since 4.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class DispatchingEntityIdParser implements EntityIdParser {

--- a/src/Entity/EntityDocument.php
+++ b/src/Entity/EntityDocument.php
@@ -11,7 +11,7 @@ use InvalidArgumentException;
  *
  * @since 0.8.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */

--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -10,7 +10,7 @@ use Serializable;
  * @since 0.5
  * Abstract since 2.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 abstract class EntityId implements Comparable, Serializable {
 

--- a/src/Entity/EntityIdParser.php
+++ b/src/Entity/EntityIdParser.php
@@ -7,7 +7,7 @@ namespace Wikibase\DataModel\Entity;
  *
  * @since 4.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 interface EntityIdParser {

--- a/src/Entity/EntityIdParsingException.php
+++ b/src/Entity/EntityIdParsingException.php
@@ -7,7 +7,7 @@ use RuntimeException;
 /**
  * @since 4.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class EntityIdParsingException extends RuntimeException {

--- a/src/Entity/EntityIdValue.php
+++ b/src/Entity/EntityIdValue.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\LegacyIdInterpreter;
 /**
  * @since 0.5
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  * @author Daniel Kinzler

--- a/src/Entity/EntityRedirect.php
+++ b/src/Entity/EntityRedirect.php
@@ -9,7 +9,7 @@ use InvalidArgumentException;
  *
  * @since 4.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class EntityRedirect {

--- a/src/Entity/Int32EntityId.php
+++ b/src/Entity/Int32EntityId.php
@@ -16,7 +16,7 @@ namespace Wikibase\DataModel\Entity;
  *
  * @since 6.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 interface Int32EntityId {

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -22,7 +22,7 @@ use Wikibase\DataModel\Term\TermList;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */

--- a/src/Entity/ItemId.php
+++ b/src/Entity/ItemId.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 /**
  * @since 0.5
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 class ItemId extends EntityId implements Int32EntityId {
 

--- a/src/Entity/ItemIdParser.php
+++ b/src/Entity/ItemIdParser.php
@@ -11,7 +11,7 @@ use InvalidArgumentException;
  *
  * @since 4.4
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class ItemIdParser implements EntityIdParser {

--- a/src/Entity/ItemIdSet.php
+++ b/src/Entity/ItemIdSet.php
@@ -15,7 +15,7 @@ use Traversable;
  *
  * @since 0.7.4
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ItemIdSet implements IteratorAggregate, Countable, Comparable {

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -19,7 +19,7 @@ use Wikibase\DataModel\Term\TermList;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */

--- a/src/Entity/PropertyId.php
+++ b/src/Entity/PropertyId.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 /**
  * @since 0.5
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 class PropertyId extends EntityId implements Int32EntityId {
 

--- a/src/Entity/StatementListProvidingEntity.php
+++ b/src/Entity/StatementListProvidingEntity.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Statement\StatementListProvider;
  *
  * @since 7.6
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 interface StatementListProvidingEntity extends EntityDocument, StatementListProvider {
 }

--- a/src/Internal/MapValueHasher.php
+++ b/src/Internal/MapValueHasher.php
@@ -11,7 +11,7 @@ use Traversable;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class MapValueHasher {

--- a/src/LegacyIdInterpreter.php
+++ b/src/LegacyIdInterpreter.php
@@ -16,7 +16,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  *
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacyIdInterpreter {

--- a/src/PropertyIdProvider.php
+++ b/src/PropertyIdProvider.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
 interface PropertyIdProvider {

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -16,7 +16,7 @@ use Wikibase\DataModel\Snak\SnakList;
  *
  * @since 0.1, instantiable since 0.4
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class Reference implements Hashable, Comparable, Immutable, Countable {

--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -19,7 +19,7 @@ use Wikibase\DataModel\Snak\Snak;
  * Does not implement References anymore since 2.0
  * Does not extend SplObjectStorage since 5.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author H. Snater < mediawiki@snater.com >
  * @author Thiemo Kreuz

--- a/src/SiteLink.php
+++ b/src/SiteLink.php
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Entity\ItemIdSet;
  *
  * @since 0.4
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Michał Łazowik
  * @author Thiemo Kreuz

--- a/src/SiteLinkList.php
+++ b/src/SiteLinkList.php
@@ -19,7 +19,7 @@ use Wikibase\DataModel\Entity\ItemIdSet;
  *
  * @since 0.7
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SiteLinkList implements IteratorAggregate, Countable, Comparable {

--- a/src/Snak/DerivedPropertyValueSnak.php
+++ b/src/Snak/DerivedPropertyValueSnak.php
@@ -24,7 +24,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  *
  * @since 3.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class DerivedPropertyValueSnak extends PropertyValueSnak {

--- a/src/Snak/PropertyNoValueSnak.php
+++ b/src/Snak/PropertyNoValueSnak.php
@@ -8,7 +8,7 @@ namespace Wikibase\DataModel\Snak;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class PropertyNoValueSnak extends SnakObject {

--- a/src/Snak/PropertySomeValueSnak.php
+++ b/src/Snak/PropertySomeValueSnak.php
@@ -8,7 +8,7 @@ namespace Wikibase\DataModel\Snak;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class PropertySomeValueSnak extends SnakObject {

--- a/src/Snak/PropertyValueSnak.php
+++ b/src/Snak/PropertyValueSnak.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Daniel Kinzler
  */

--- a/src/Snak/Snak.php
+++ b/src/Snak/Snak.php
@@ -14,7 +14,7 @@ use Wikibase\DataModel\PropertyIdProvider;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 interface Snak extends Serializable, Hashable, Immutable, Comparable, PropertyIdProvider {

--- a/src/Snak/SnakList.php
+++ b/src/Snak/SnakList.php
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Internal\MapValueHasher;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Addshore
  */

--- a/src/Snak/SnakObject.php
+++ b/src/Snak/SnakObject.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 abstract class SnakObject implements Snak {

--- a/src/Snak/SnakRole.php
+++ b/src/Snak/SnakRole.php
@@ -7,7 +7,7 @@ namespace Wikibase\DataModel\Snak;
  *
  * @since 0.4
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SnakRole {

--- a/src/Snak/TypedSnak.php
+++ b/src/Snak/TypedSnak.php
@@ -5,7 +5,7 @@ namespace Wikibase\DataModel\Snak;
 /**
  * @since 0.7
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class TypedSnak {

--- a/src/Statement/ReferencedStatementFilter.php
+++ b/src/Statement/ReferencedStatementFilter.php
@@ -8,7 +8,7 @@ namespace Wikibase\DataModel\Statement;
  *
  * @since 4.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ReferencedStatementFilter implements StatementFilter {

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -18,7 +18,7 @@ use Wikibase\DataModel\Snak\SnakList;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */

--- a/src/Statement/StatementByGuidMap.php
+++ b/src/Statement/StatementByGuidMap.php
@@ -17,7 +17,7 @@ use Traversable;
  *
  * @since 3.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */

--- a/src/Statement/StatementFilter.php
+++ b/src/Statement/StatementFilter.php
@@ -5,7 +5,7 @@ namespace Wikibase\DataModel\Statement;
 /**
  * @since 4.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 interface StatementFilter {

--- a/src/Statement/StatementGuid.php
+++ b/src/Statement/StatementGuid.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 3.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class StatementGuid implements Comparable {

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -23,7 +23,7 @@ use Wikibase\DataModel\Snak\SnakList;
  *
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  * @author Thiemo Kreuz

--- a/src/Statement/StatementListHolder.php
+++ b/src/Statement/StatementListHolder.php
@@ -9,7 +9,7 @@ namespace Wikibase\DataModel\Statement;
  * @deprecated since 5.1, will be removed in favor of StatementListProvider, which
  *  gives the guarantee to return an object by reference. Changes to that object change the entity.
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 interface StatementListHolder extends StatementListProvider {

--- a/src/Statement/StatementListProvider.php
+++ b/src/Statement/StatementListProvider.php
@@ -8,7 +8,7 @@ namespace Wikibase\DataModel\Statement;
  *
  * @since 2.2.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Marius Hoch < hoo@online.de >
  */
 interface StatementListProvider {

--- a/src/Term/AliasGroup.php
+++ b/src/Term/AliasGroup.php
@@ -13,7 +13,7 @@ use InvalidArgumentException;
  *
  * @since 0.7.3
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class AliasGroup implements Comparable, Countable {

--- a/src/Term/AliasGroupFallback.php
+++ b/src/Term/AliasGroupFallback.php
@@ -12,7 +12,7 @@ use InvalidArgumentException;
  *
  * @since 2.4.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jan Zerebecki < jan.wikimedia@zerebecki.de >
  */
 class AliasGroupFallback extends AliasGroup {

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -18,7 +18,7 @@ use Traversable;
  *
  * @since 0.7.3
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class AliasGroupList implements Countable, IteratorAggregate {

--- a/src/Term/AliasesProvider.php
+++ b/src/Term/AliasesProvider.php
@@ -8,7 +8,7 @@ namespace Wikibase\DataModel\Term;
  *
  * @since 4.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
 interface AliasesProvider {

--- a/src/Term/DescriptionsProvider.php
+++ b/src/Term/DescriptionsProvider.php
@@ -9,7 +9,7 @@ namespace Wikibase\DataModel\Term;
  *
  * @since 4.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
 interface DescriptionsProvider {

--- a/src/Term/Fingerprint.php
+++ b/src/Term/Fingerprint.php
@@ -13,7 +13,7 @@ use OutOfBoundsException;
  *
  * @since 0.7.3
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/src/Term/FingerprintProvider.php
+++ b/src/Term/FingerprintProvider.php
@@ -8,7 +8,7 @@ namespace Wikibase\DataModel\Term;
  *
  * @since 0.7.3
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 interface FingerprintProvider {

--- a/src/Term/LabelsProvider.php
+++ b/src/Term/LabelsProvider.php
@@ -8,7 +8,7 @@ namespace Wikibase\DataModel\Term;
  *
  * @since 4.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
 interface LabelsProvider {

--- a/src/Term/Term.php
+++ b/src/Term/Term.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
  *
  * @since 0.7.3
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class Term implements Comparable {

--- a/src/Term/TermFallback.php
+++ b/src/Term/TermFallback.php
@@ -9,7 +9,7 @@ use InvalidArgumentException;
  *
  * @since 2.4.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jan Zerebecki < jan.wikimedia@zerebecki.de >
  */
 class TermFallback extends Term {

--- a/src/Term/TermList.php
+++ b/src/Term/TermList.php
@@ -17,7 +17,7 @@ use OutOfBoundsException;
  *
  * @since 0.7.3
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class TermList implements Countable, IteratorAggregate, Comparable {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,7 @@
 /**
  * PHPUnit test bootstrap file for the Wikibase DataModel component.
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 

--- a/tests/fixtures/CustomEntityId.php
+++ b/tests/fixtures/CustomEntityId.php
@@ -7,7 +7,7 @@ use Wikibase\DataModel\Entity\EntityId;
 /**
  * Dummy custom EntityId implementation for use with EntityIdValueTest
  *
- * @license GPL 2+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class CustomEntityId extends EntityId {

--- a/tests/unit/Assert/RepositoryNameAssertTest.php
+++ b/tests/unit/Assert/RepositoryNameAssertTest.php
@@ -8,7 +8,7 @@ use Wikimedia\Assert\ParameterAssertionException;
 /**
  * @covers \Wikibase\DataModel\Assert\RepositoryNameAssert
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 class RepositoryNameAssertTest extends \PHPUnit_Framework_TestCase {
 

--- a/tests/unit/ByPropertyIdArrayTest.php
+++ b/tests/unit/ByPropertyIdArrayTest.php
@@ -26,7 +26,7 @@ use Wikibase\DataModel\Statement\Statement;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author H. Snater < mediawiki@snater.com >
  */

--- a/tests/unit/Entity/BasicEntityIdParserTest.php
+++ b/tests/unit/Entity/BasicEntityIdParserTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\PropertyId;
 /**
  * @covers \Wikibase\DataModel\Entity\BasicEntityIdParser
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/tests/unit/Entity/DispatchingEntityIdParserTest.php
+++ b/tests/unit/Entity/DispatchingEntityIdParserTest.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Entity\PropertyId;
 /**
  * @covers \Wikibase\DataModel\Entity\DispatchingEntityIdParser
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/tests/unit/Entity/EntityIdTest.php
+++ b/tests/unit/Entity/EntityIdTest.php
@@ -16,7 +16,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author John Erling Blad < jeblad@gmail.com >
  */

--- a/tests/unit/Entity/EntityIdValueTest.php
+++ b/tests/unit/Entity/EntityIdValueTest.php
@@ -16,7 +16,7 @@ use Wikibase\DataModel\Fixtures\CustomEntityId;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  * @author Daniel Kinzler

--- a/tests/unit/Entity/EntityRedirectTest.php
+++ b/tests/unit/Entity/EntityRedirectTest.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class EntityRedirectTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Entity/ItemIdParserTest.php
+++ b/tests/unit/Entity/ItemIdParserTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Entity\ItemIdParser;
 /**
  * @covers \Wikibase\DataModel\Entity\ItemIdParser
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class ItemIdParserTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Entity/ItemIdSetTest.php
+++ b/tests/unit/Entity/ItemIdSetTest.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Entity\ItemIdSet;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ItemIdSetTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Entity/ItemIdTest.php
+++ b/tests/unit/Entity/ItemIdTest.php
@@ -13,7 +13,7 @@ use InvalidArgumentException;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ItemIdTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Entity/ItemTest.php
+++ b/tests/unit/Entity/ItemTest.php
@@ -24,7 +24,7 @@ use Wikibase\DataModel\Term\TermList;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author John Erling Blad < jeblad@gmail.com >
  * @author Michał Łazowik

--- a/tests/unit/Entity/PropertyIdTest.php
+++ b/tests/unit/Entity/PropertyIdTest.php
@@ -13,7 +13,7 @@ use InvalidArgumentException;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class PropertyIdTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Entity/PropertyTest.php
+++ b/tests/unit/Entity/PropertyTest.php
@@ -22,7 +22,7 @@ use Wikibase\DataModel\Term\TermList;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class PropertyTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Internal/MapValueHasherTest.php
+++ b/tests/unit/Internal/MapValueHasherTest.php
@@ -14,7 +14,7 @@ use Wikibase\DataModel\Snak\PropertyNoValueSnak;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class MapValueHasherTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/LegacyIdInterpreterTest.php
+++ b/tests/unit/LegacyIdInterpreterTest.php
@@ -14,7 +14,7 @@ use Wikibase\DataModel\LegacyIdInterpreter;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
 class LegacyIdInterpreterTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -19,7 +19,7 @@ use Wikibase\DataModel\Snak\SnakList;
  * @group WikibaseDataModel
  * @group WikibaseReference
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/tests/unit/ReferenceTest.php
+++ b/tests/unit/ReferenceTest.php
@@ -18,7 +18,7 @@ use Wikibase\DataModel\Snak\SnakList;
  * @group WikibaseDataModel
  * @group WikibaseReference
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ReferenceTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/SiteLinkListTest.php
+++ b/tests/unit/SiteLinkListTest.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\SiteLinkList;
 /**
  * @covers \Wikibase\DataModel\SiteLinkList
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SiteLinkListTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/SiteLinkTest.php
+++ b/tests/unit/SiteLinkTest.php
@@ -14,7 +14,7 @@ use Wikibase\DataModel\SiteLink;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Michał Łazowik
  * @author Thiemo Kreuz

--- a/tests/unit/Snak/DerivedPropertyValueSnakTest.php
+++ b/tests/unit/Snak/DerivedPropertyValueSnakTest.php
@@ -17,7 +17,7 @@ use Wikibase\DataModel\Snak\PropertyValueSnak;
  * @group WikibaseDataModel
  * @group WikibaseSnak
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class DerivedPropertyValueSnakTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Snak/PropertyNoValueSnakTest.php
+++ b/tests/unit/Snak/PropertyNoValueSnakTest.php
@@ -18,7 +18,7 @@ use Wikibase\DataModel\Snak\Snak;
  * @group WikibaseDataModel
  * @group WikibaseSnak
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class PropertyNoValueSnakTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Snak/PropertySomeValueSnakTest.php
+++ b/tests/unit/Snak/PropertySomeValueSnakTest.php
@@ -18,7 +18,7 @@ use Wikibase\DataModel\Snak\Snak;
  * @group WikibaseDataModel
  * @group WikibaseSnak
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class PropertySomeValueSnakTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Snak/PropertyValueSnakTest.php
+++ b/tests/unit/Snak/PropertyValueSnakTest.php
@@ -23,7 +23,7 @@ use Wikibase\DataModel\Snak\Snak;
  * @group WikibaseDataModel
  * @group WikibaseSnak
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/tests/unit/Snak/SnakListTest.php
+++ b/tests/unit/Snak/SnakListTest.php
@@ -16,7 +16,7 @@ use Wikibase\DataModel\Snak\SnakList;
 /**
  * @covers \Wikibase\DataModel\Snak\SnakList
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Addshore
  * @author Thiemo Kreuz

--- a/tests/unit/Snak/SnakTest.php
+++ b/tests/unit/Snak/SnakTest.php
@@ -25,7 +25,7 @@ use Wikibase\DataModel\Snak\Snak;
  * @group WikibaseDataModel
  * @group WikibaseSnak
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SnakTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Snak/TypedSnakTest.php
+++ b/tests/unit/Snak/TypedSnakTest.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Snak\TypedSnak;
  * @group WikibaseDataModel
  * @group WikibaseSnak
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class TypedSnakTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/ReferencedStatementFilterTest.php
+++ b/tests/unit/Statement/ReferencedStatementFilterTest.php
@@ -14,7 +14,7 @@ use Wikibase\DataModel\Statement\Statement;
 /**
  * @covers \Wikibase\DataModel\Statement\ReferencedStatementFilter
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ReferencedStatementFilterTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/StatementByGuidMapTest.php
+++ b/tests/unit/Statement/StatementByGuidMapTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Statement\StatementByGuidMap;
 /**
  * @covers \Wikibase\DataModel\Statement\StatementByGuidMap
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */

--- a/tests/unit/Statement/StatementGuidTest.php
+++ b/tests/unit/Statement/StatementGuidTest.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Entity\ItemId;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class StatementGuidTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/StatementListTest.php
+++ b/tests/unit/Statement/StatementListTest.php
@@ -20,7 +20,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @covers \Wikibase\DataModel\Statement\StatementList
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -20,7 +20,7 @@ use Wikibase\DataModel\Statement\Statement;
  * @group Wikibase
  * @group WikibaseDataModel
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class StatementTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Term/AliasGroupFallbackTest.php
+++ b/tests/unit/Term/AliasGroupFallbackTest.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Term\AliasGroupFallback;
 /**
  * @covers \Wikibase\DataModel\Term\AliasGroupFallback
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jan Zerebecki < jan.wikimedia@zerebecki.de >
  */
 class AliasGroupFallbackTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Term/AliasGroupListTest.php
+++ b/tests/unit/Term/AliasGroupListTest.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Term\AliasGroupList;
  * @covers \Wikibase\DataModel\Term\AliasGroupList
  * @uses \Wikibase\DataModel\Term\AliasGroup
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class AliasGroupListTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Term/AliasGroupTest.php
+++ b/tests/unit/Term/AliasGroupTest.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Term\AliasGroupFallback;
 /**
  * @covers \Wikibase\DataModel\Term\AliasGroup
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class AliasGroupTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Term/FingerprintTest.php
+++ b/tests/unit/Term/FingerprintTest.php
@@ -17,7 +17,7 @@ use Wikibase\DataModel\Term\TermList;
  * @uses \Wikibase\DataModel\Term\Term
  * @uses \Wikibase\DataModel\Term\TermList
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/tests/unit/Term/TermFallbackTest.php
+++ b/tests/unit/Term/TermFallbackTest.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Term\TermFallback;
 /**
  * @covers \Wikibase\DataModel\Term\TermFallback
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jan Zerebecki < jan.wikimedia@zerebecki.de >
  */
 class TermFallbackTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Term/TermListTest.php
+++ b/tests/unit/Term/TermListTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Term\TermList;
  * @covers \Wikibase\DataModel\Term\TermList
  * @uses \Wikibase\DataModel\Term\Term
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class TermListTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Term/TermTest.php
+++ b/tests/unit/Term/TermTest.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Term\TermFallback;
 /**
  * @covers \Wikibase\DataModel\Term\Term
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class TermTest extends \PHPUnit_Framework_TestCase {


### PR DESCRIPTION
The only change is an update to all `@license` tags, to match the new SPDX version.