### PR TITLE
Fix earlier ClearbaleEntity revert

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel release notes
 
+## Version 9.0.1 (2018-11-09)
+
+* `Item` and `Property` now implement `ClearableEntity` again
+
 ## Version 9.0.0 (2018-11-01)
 
 * Breaking change: `EntityDocument` no longer extends `ClearableEntity` (8.0.0 revert)

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -27,7 +27,7 @@ use Wikibase\DataModel\Term\TermList;
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
 class Item implements StatementListProvidingEntity, FingerprintProvider, StatementListHolder,
-	LabelsProvider, DescriptionsProvider, AliasesProvider {
+	LabelsProvider, DescriptionsProvider, AliasesProvider, ClearableEntity {
 
 	const ENTITY_TYPE = 'item';
 

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -24,7 +24,7 @@ use Wikibase\DataModel\Term\TermList;
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
 class Property implements StatementListProvidingEntity, FingerprintProvider, StatementListHolder,
-	LabelsProvider, DescriptionsProvider, AliasesProvider {
+	LabelsProvider, DescriptionsProvider, AliasesProvider, ClearableEntity {
 
 	const ENTITY_TYPE = 'property';
 


### PR DESCRIPTION
This completes/fixes the revert started in https://github.com/wmde/WikibaseDataModel/pull/799

With this change the behavior is back to that of DM 7.5.x. (see https://github.com/wmde/WikibaseDataModel/blob/7.x/src/Entity/Item.php#L30 for verification)

Needed to make DM 9.x work in WB.git. Change in behavior spotted by WB.git tests