### PR TITLE
Travis: Don't run phpmd with HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ sudo: false
 
 install: travis_retry composer install
 
-script: composer ci
+# Hack: Don't run phpmd with HHVM
+script: if $(php --version | grep -q HipHop); then composer test; else composer ci; fi
 
 notifications:
   irc:


### PR DESCRIPTION
Currently fails with:
Fatal error: Uncaught Error: Class Symfony\Component\DependencyInjection\Exception\ExceptionInterface may not inherit from sealed interface (Throwable) without being in the whitelist