### PR TITLE
Update wikimedia/assert, minimum PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 dist: trusty
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 	"require": {
 		"php": ">=5.6.99",
 		"data-values/data-values": "~0.1|~1.0|~2.0",
-		"wikimedia/assert": "~0.4.0"
+		"wikimedia/assert": "~0.2.2|~0.3.0|~0.4.0"
 	},
 	"require-dev": {
 		"ockcyp/covers-validator": "~0.5.0",

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=5.6",
+		"php": ">=5.6.99",
 		"data-values/data-values": "~0.1|~1.0|~2.0",
-		"wikimedia/assert": "~0.2.2"
+		"wikimedia/assert": "~0.4.0"
 	},
 	"require-dev": {
 		"ockcyp/covers-validator": "~0.5.0",


### PR DESCRIPTION
Upgrade wikimedia/assert to 0.4.0 (no major changes but needed to avoid incompatible dependencies in mediawiki/vendor). Upgrade PHP requirement to 7.x or HHVM (needed by wikimedia/assert 0.4 and the end-of-life for 5.6 was January 1, anyway).