### PR TITLE
Optimize EntityId::isForeign()

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,7 @@
 
 * `TermList` now throws `InvalidArgumentException` when given non-iterable rather than failing silently
 * `SiteLinkList` now throws `InvalidArgumentException` when given non-iterable rather than failing silently
+* Slightly optimized `EntityId::isForeign()` by using `$this->repositoryName` instead of `$this->serialization`
 
 ## Version 9.1.0 (2019-01-24)
 

--- a/src/Entity/EntityId.php
+++ b/src/Entity/EntityId.php
@@ -164,15 +164,14 @@ abstract class EntityId implements Comparable, Serializable {
 	}
 
 	/**
-	 * Returns true iff EntityId::getRepoName returns a non-empty string.
+	 * Returns true iff EntityId::getRepositoryName returns a non-empty string.
 	 *
 	 * @since 6.2
 	 *
 	 * @return bool
 	 */
 	public function isForeign() {
-		// not actually using EntityId::getRepoName for performance reasons
-		return strpos( $this->serialization, ':' ) > 0;
+		return $this->repositoryName !== '';
 	}
 
 	/**


### PR DESCRIPTION
When this method was first introduced, `getRepositoryName()` would split the serialization each time it was called, and using `strpos()` in `isForeign()` was an optimization to avoid that cost. However, since #769 (commit eb6656155b), the serialization is only split once in the constructor, so checking `strpos` each time instead of deferring to the already populated `$repositoryName` is probably slightly more expensive.

As a very minor optimization, we directly access `$this->repositoryName` instead of calling `getRepositoryName()`. Subclasses that for some reason override `getRepositoryName()` to do something different must override `isForeign()` as well.