### PR TITLE
Fix @since of StatementListProvidingEntity

### DIFF
--- a/src/Entity/StatementListProvidingEntity.php
+++ b/src/Entity/StatementListProvidingEntity.php
@@ -7,7 +7,7 @@ use Wikibase\DataModel\Statement\StatementListProvider;
 /**
  * Interface for EntityDocument objects that are also StatementListProviders
  *
- * @since 7.6
+ * @since 8.0
  *
  * @license GPL-2.0-or-later
  */


### PR DESCRIPTION
There never was a 7.6 release, its changes were combined with breaking changes into 8.0 instead.