### PR TITLE
Change getIterator() type hints to Iterator

### DIFF
--- a/src/Entity/ItemIdSet.php
+++ b/src/Entity/ItemIdSet.php
@@ -52,7 +52,7 @@ class ItemIdSet implements IteratorAggregate, Countable, Comparable {
 	/**
 	 * @see IteratorAggregate::getIterator
 	 *
-	 * @return Traversable|ItemId[]
+	 * @return Iterator|ItemId[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->ids );

--- a/src/Entity/ItemIdSet.php
+++ b/src/Entity/ItemIdSet.php
@@ -7,7 +7,6 @@ use Comparable;
 use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
-use Traversable;
 
 /**
  * Immutable set of ItemId objects. Unordered and unique.

--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -298,7 +298,7 @@ class ReferenceList implements Comparable, Countable, IteratorAggregate, Seriali
 	 *
 	 * @since 5.0
 	 *
-	 * @return Traversable
+	 * @return Iterator|Reference[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( array_values( $this->references ) );

--- a/src/SiteLinkList.php
+++ b/src/SiteLinkList.php
@@ -103,7 +103,7 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	 *
 	 * Returns a Traversable of SiteLink in which the keys are the site ids.
 	 *
-	 * @return Traversable|SiteLink[]
+	 * @return Iterator|SiteLink[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->siteLinks );

--- a/src/SiteLinkList.php
+++ b/src/SiteLinkList.php
@@ -35,7 +35,7 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( /* iterable */ $siteLinks = [] ) {
-		if ( !is_array( $siteLinks ) && !( $siteLinks instanceof \Traversable ) ) {
+		if ( !is_array( $siteLinks ) && !( $siteLinks instanceof Traversable ) ) {
 			throw new InvalidArgumentException( '$siteLinks must be iterable' );
 		}
 
@@ -101,7 +101,7 @@ class SiteLinkList implements IteratorAggregate, Countable, Comparable {
 	/**
 	 * @see IteratorAggregate::getIterator
 	 *
-	 * Returns a Traversable of SiteLink in which the keys are the site ids.
+	 * Returns an Iterator of SiteLink in which the keys are the site ids.
 	 *
 	 * @return Iterator|SiteLink[]
 	 */

--- a/src/Statement/StatementByGuidMap.php
+++ b/src/Statement/StatementByGuidMap.php
@@ -107,7 +107,7 @@ class StatementByGuidMap implements IteratorAggregate, Countable {
 	 * The iterator has the GUIDs of the statements as keys.
 	 *
 	 * @see IteratorAggregate::getIterator
-	 * @return Traversable|Statement[]
+	 * @return Iterator|Statement[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->statements );

--- a/src/Statement/StatementList.php
+++ b/src/Statement/StatementList.php
@@ -240,7 +240,7 @@ class StatementList implements IteratorAggregate, Comparable, Countable {
 	}
 
 	/**
-	 * @return Traversable|Statement[]
+	 * @return Iterator|Statement[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->statements );

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -7,7 +7,6 @@ use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
 use OutOfBoundsException;
-use Traversable;
 
 /**
  * Unordered list of AliasGroup objects.

--- a/src/Term/AliasGroupList.php
+++ b/src/Term/AliasGroupList.php
@@ -52,7 +52,7 @@ class AliasGroupList implements Countable, IteratorAggregate {
 
 	/**
 	 * @see IteratorAggregate::getIterator
-	 * @return Traversable|AliasGroup[]
+	 * @return Iterator|AliasGroup[]
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->groups );


### PR DESCRIPTION
This change of type hints from Traversable to Iterator avoids static
analysis errors by phan. As described in
https://github.com/phan/phan/blob/master/NEWS.md#11-feb-2018-phan-0112
phan's type system still does not support inferring key types for
Iterable or Traversable.