### PR TITLE
Add getter for statement guid part

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel release notes
 
+## Version 9.4.0 (development)
+
+* Added `getGuidPart` to `StatementGuid`
+
 ## Version 9.3.0 (2020-03-10)
 
 * Raised minimum PHP version to 7.1

--- a/src/Statement/StatementGuid.php
+++ b/src/Statement/StatementGuid.php
@@ -31,6 +31,11 @@ class StatementGuid implements Comparable {
 	/**
 	 * @var string
 	 */
+	private $guid;
+
+	/**
+	 * @var string
+	 */
 	private $serialization;
 
 	/**
@@ -46,6 +51,7 @@ class StatementGuid implements Comparable {
 
 		$this->serialization = $entityId->getSerialization() . self::SEPARATOR . $guid;
 		$this->entityId = $entityId;
+		$this->guid = $guid;
 	}
 
 	/**
@@ -53,6 +59,13 @@ class StatementGuid implements Comparable {
 	 */
 	public function getEntityId() {
 		return $this->entityId;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getGuid() {
+		return $this->guid;
 	}
 
 	/**

--- a/src/Statement/StatementGuid.php
+++ b/src/Statement/StatementGuid.php
@@ -31,7 +31,7 @@ class StatementGuid implements Comparable {
 	/**
 	 * @var string
 	 */
-	private $guid;
+	private $guidPart;
 
 	/**
 	 * @var string
@@ -51,7 +51,7 @@ class StatementGuid implements Comparable {
 
 		$this->serialization = $entityId->getSerialization() . self::SEPARATOR . $guid;
 		$this->entityId = $entityId;
-		$this->guid = $guid;
+		$this->guidPart = $guid;
 	}
 
 	/**
@@ -62,10 +62,12 @@ class StatementGuid implements Comparable {
 	}
 
 	/**
+	 * @since 9.4
+	 *
 	 * @return string
 	 */
-	public function getGuid() {
-		return $this->guid;
+	public function getGuidPart() {
+		return $this->guidPart;
 	}
 
 	/**

--- a/tests/unit/Statement/StatementGuidTest.php
+++ b/tests/unit/Statement/StatementGuidTest.php
@@ -26,7 +26,7 @@ class StatementGuidTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertSame( $expected, $statementGuid->getSerialization() );
 		$this->assertEquals( $entityId, $statementGuid->getEntityId() );
-		$this->assertEquals( $guid, $statementGuid->getGuid() );
+		$this->assertEquals( $guid, $statementGuid->getGuidPart() );
 	}
 
 	public function provideConstructionData() {

--- a/tests/unit/Statement/StatementGuidTest.php
+++ b/tests/unit/Statement/StatementGuidTest.php
@@ -26,6 +26,7 @@ class StatementGuidTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertSame( $expected, $statementGuid->getSerialization() );
 		$this->assertEquals( $entityId, $statementGuid->getEntityId() );
+		$this->assertEquals( $guid, $statementGuid->getGuid() );
 	}
 
 	public function provideConstructionData() {


### PR DESCRIPTION
This would be useful for reconstructing another StatementGuid based on its existing parts.
EntityId can already be gotten from a StatementGuid object, and now the GUID would too - that's the 2 required arguments for constructing a new StatementGuid with the same (or derived) data.

Use case: https://gerrit.wikimedia.org/r/c/mediawiki/extensions/WikibaseMediaInfo/+/573315/1/src/WikibaseMediaInfoHooks.php