### PR TITLE
WikibaseDataModel: PHP 7.4 CI fails

### DIFF
--- a/phpmd.xml
+++ b/phpmd.xml
@@ -15,7 +15,7 @@
     </rule>
     <rule ref="rulesets/codesize.xml/TooManyPublicMethods">
         <properties>
-            <property name="ignorepattern" value="(^(set|get|test))i" />
+            <property name="ignorepattern" value="(^(set|get|test|__))i" />
             <property name="maxmethods" value="14" />
         </properties>
     </rule>

--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -26,7 +26,6 @@ use Wikibase\DataModel\Snak\Snak;
  * @author Bene* < benestar.wikimedia@gmail.com >
  *
  * @phpcs:disable MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName
- * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 class ReferenceList implements Comparable, Countable, IteratorAggregate, Serializable {
 

--- a/src/ReferenceList.php
+++ b/src/ReferenceList.php
@@ -24,6 +24,9 @@ use Wikibase\DataModel\Snak\Snak;
  * @author H. Snater < mediawiki@snater.com >
  * @author Thiemo Kreuz
  * @author Bene* < benestar.wikimedia@gmail.com >
+ *
+ * @phpcs:disable MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 class ReferenceList implements Comparable, Countable, IteratorAggregate, Serializable {
 
@@ -230,6 +233,26 @@ class ReferenceList implements Comparable, Countable, IteratorAggregate, Seriali
 	 */
 	public function serialize() {
 		return serialize( array_values( $this->references ) );
+	}
+
+	/**
+	 * @see https://wiki.php.net/rfc/custom_object_serialization
+	 *
+	 * @return array
+	 */
+	public function __serialize() {
+		return [
+			'references' => array_values( $this->references )
+		];
+	}
+
+	/**
+	 * @see https://wiki.php.net/rfc/custom_object_serialization
+	 *
+	 * @param array $data
+	 */
+	public function __unserialize( array $data ) : void {
+		$this->references = $data['references'];
 	}
 
 	/**

--- a/src/Snak/SnakList.php
+++ b/src/Snak/SnakList.php
@@ -20,7 +20,6 @@ use Wikibase\DataModel\Internal\MapValueHasher;
  * @author Addshore
  *
  * @phpcs:disable MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName
- * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 class SnakList extends ArrayObject implements Comparable, Hashable {
 

--- a/src/Snak/SnakList.php
+++ b/src/Snak/SnakList.php
@@ -18,6 +18,9 @@ use Wikibase\DataModel\Internal\MapValueHasher;
  * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Addshore
+ *
+ * @phpcs:disable MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 class SnakList extends ArrayObject implements Comparable, Hashable {
 
@@ -275,10 +278,7 @@ class SnakList extends ArrayObject implements Comparable, Hashable {
 	 * @return string
 	 */
 	public function serialize() {
-		return serialize( [
-			'data' => $this->getArrayCopy(),
-			'index' => $this->indexOffset,
-		] );
+		return serialize( $this->__serialize() );
 	}
 
 	/**
@@ -288,14 +288,34 @@ class SnakList extends ArrayObject implements Comparable, Hashable {
 	 */
 	public function unserialize( $serialized ) {
 		$serializationData = unserialize( $serialized );
+		$this->__unserialize( $serializationData );
+	}
 
-		foreach ( $serializationData['data'] as $offset => $value ) {
+	/**
+	 * @see https://wiki.php.net/rfc/custom_object_serialization
+	 *
+	 * @return array
+	 */
+	public function __serialize(): array {
+		return [
+			'data' => $this->getArrayCopy(),
+			'index' => $this->indexOffset,
+		];
+	}
+
+	/**
+	 * @see https://wiki.php.net/rfc/custom_object_serialization
+	 *
+	 * @param array $data
+	 */
+	public function __unserialize( $data ) : void {
+		foreach ( $data['data'] as $offset => $value ) {
 			// Just set the element, bypassing checks and offset resolving,
 			// as these elements have already gone through this.
 			parent::offsetSet( $offset, $value );
 		}
 
-		$this->indexOffset = $serializationData['index'];
+		$this->indexOffset = $data['index'];
 	}
 
 	/**

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -412,6 +412,21 @@ class ReferenceListTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $references->isEmpty() );
 	}
 
+	/**
+	 * This integration test (relies on ReferenceList::getValueHash) is supposed to break whenever the hash
+	 * calculation changes.
+	 */
+	public function testGetValueHashStability() {
+		$array = new ReferenceList();
+		$snak1 = new PropertyNoValueSnak( 1 );
+		$snak2 = new PropertyNoValueSnak( 3 );
+		$snak3 = new PropertyNoValueSnak( 2 );
+
+		$array->addNewReference( $snak1, $snak2, $snak3 );
+		$expectedHash = '92244e1a91f60b7fa922d42441995442bf50adb5';
+		$this->assertSame( $expectedHash, $array->getValueHash() );
+	}
+
 	public function testRemoveReferenceHashRemovesIdenticalObjects() {
 		$reference = new Reference( [ new PropertyNoValueSnak( 1 ) ] );
 		$references = new ReferenceList( [ $reference, $reference ] );
@@ -505,11 +520,17 @@ class ReferenceListTest extends \PHPUnit\Framework\TestCase {
 	public function testSerializationStability() {
 		$list = new ReferenceList();
 		$list->addNewReference( new PropertyNoValueSnak( 1 ) );
-		$this->assertSame(
-			"a:1:{i:0;O:28:\"Wikibase\\DataModel\\Reference\":1:{s:35:\"\x00Wikibase\\DataModel\\"
+
+		$testString = "a:1:{i:0;O:28:\"Wikibase\\DataModel\\Reference\":1:{s:35:\"\x00Wikibase\\DataModel\\"
 			. "Reference\x00snaks\";C:32:\"Wikibase\\DataModel\\Snak\\SnakList\":100:{a:2:{s:4:\""
 			. 'data";a:1:{i:0;C:43:"Wikibase\\DataModel\\Snak\\PropertyNoValueSnak":2:{P1}}s:5'
-			. ':"index";i:0;}}}}',
+			. ':"index";i:0;}}}}';
+
+		$secondList = new ReferenceList();
+		$secondList->unserialize( $testString );
+
+		$this->assertSame(
+			$testString,
 			$list->serialize()
 		);
 	}

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -517,17 +517,29 @@ class ReferenceListTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( 'a:0:{}', $list->serialize() );
 	}
 
+	/**
+	 * This test will change when the serialization format changes.
+	 * If it is being changed intentionally, the test should be updated.
+	 * It is just here to catch unintentional changes.
+	 */
 	public function testSerializationStability() {
 		$list = new ReferenceList();
 		$list->addNewReference( new PropertyNoValueSnak( 1 ) );
 
-		$testString = "a:1:{i:0;O:28:\"Wikibase\\DataModel\\Reference\":1:{s:35:\"\x00Wikibase\\DataModel\\"
-			. "Reference\x00snaks\";C:32:\"Wikibase\\DataModel\\Snak\\SnakList\":100:{a:2:{s:4:\""
-			. 'data";a:1:{i:0;C:43:"Wikibase\\DataModel\\Snak\\PropertyNoValueSnak":2:{P1}}s:5'
-			. ':"index";i:0;}}}}';
-
-		$secondList = new ReferenceList();
-		$secondList->unserialize( $testString );
+		/*
+		 * https://wiki.php.net/rfc/custom_object_serialization
+		 */
+		if ( version_compare( phpversion(), '7.4', '>=' ) ) {
+			$testString = "a:1:{i:0;O:28:\"Wikibase\\DataModel\\Reference\":1:{s:35:\"\x00Wikibase\\DataModel\\"
+				. "Reference\x00snaks\";O:32:\"Wikibase\\DataModel\\Snak\\SnakList\":2:{s:4:\""
+				. 'data";a:1:{i:0;C:43:"Wikibase\\DataModel\\Snak\\PropertyNoValueSnak":2:{P1}}s:5'
+				. ':"index";i:0;}}}';
+		} else {
+			$testString = "a:1:{i:0;O:28:\"Wikibase\\DataModel\\Reference\":1:{s:35:\"\x00Wikibase\\DataModel\\"
+				. "Reference\x00snaks\";C:32:\"Wikibase\\DataModel\\Snak\\SnakList\":100:{a:2:{s:4:\""
+				. 'data";a:1:{i:0;C:43:"Wikibase\\DataModel\\Snak\\PropertyNoValueSnak":2:{P1}}s:5'
+				. ':"index";i:0;}}}}';
+		}
 
 		$this->assertSame(
 			$testString,


### PR DESCRIPTION
PHP 7.4 exposes two new magic functions __serialize and __unserialize
for custom object serialization. These are required to be implemented to
support migration from older PHP versions.

see https://wiki.php.net/rfc/custom_object_serialization for more
detail.

Bug: T243590