### PR TITLE
Ensure hash stability

### DIFF
--- a/tests/unit/ReferenceTest.php
+++ b/tests/unit/ReferenceTest.php
@@ -188,6 +188,11 @@ class ReferenceTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $reference0->equals( $reference1 ) );
 	}
 
+	public function testReferenceHashStability() {
+		$reference = new Reference( [ new PropertyNoValueSnak( 42 ) ] );
+		$this->assertSame( 'f2be45ba65676e69367433547812db03b8c661ef', $reference->getHash() );
+	}
+
 	public function testReferenceDoesNotEqualReferenceWithMoreSnaks() {
 		$reference0 = new Reference( [ new PropertyNoValueSnak( 42 ) ] );
 

--- a/tests/unit/Statement/StatementTest.php
+++ b/tests/unit/Statement/StatementTest.php
@@ -79,6 +79,12 @@ class StatementTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( 'foobar', $statement->getGuid() );
 	}
 
+	public function testHashStability() {
+		$mainSnak = new PropertyNoValueSnak( new PropertyId( 'P42' ) );
+		$statement = new Statement( $mainSnak );
+		$this->assertSame( '50c73da6759fd31868fb0cc9c218969fa776f62c', $statement->getHash() );
+	}
+
 	public function testSetAndGetMainSnak() {
 		$mainSnak = new PropertyNoValueSnak( new PropertyId( 'P42' ) );
 		$statement = new Statement( $mainSnak );


### PR DESCRIPTION
Reviewed and added tests for the missing ones.

ReferenceList: exists
Statement: new
Reference: new
SnakList: exists

SnakObject
- DerivedPropertyValueSnakTest: exists
- PropertyNoValueSnakTest: exists
- PropertySomeValueSnakTest: exists
- PropertyValueSnakTest: exists

Bug: T253637

https://phabricator.wikimedia.org/T253637