### PR TITLE
Ignore phpunit tests result cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ build/
 
 .floo
 .flooignore
+
+.phpunit.result.cache


### PR DESCRIPTION
As part of removing interface usages for the release of DataValues, I noticed this file was not ignored.