### PR TITLE
Retire interfaces

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,7 @@
   please update your code:
   for instance, change `->addNewReference( [ $x, $y ] )` to `->addNewReference( $x, $y )`,
   and `->addNewReference( $snaks )` to `->addNewReference( ...$snaks )`.
+* `Statement`, `Reference`, `SnakList` and `Snak` no longer depend on the `Hashable` and `Immutable` interfaces from `DataValues/DataValues`.
 
 ## Version 9.5.1 (2020-06-03)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,7 +9,7 @@
   please update your code:
   for instance, change `->addNewReference( [ $x, $y ] )` to `->addNewReference( $x, $y )`,
   and `->addNewReference( $snaks )` to `->addNewReference( ...$snaks )`.
-* `Statement`, `Reference`, `SnakList` and `Snak` no longer depend on the `Hashable` and `Immutable` interfaces from `DataValues/DataValues`.
+* `Statement`, `Reference`, `SnakList` and `Snak` no longer implement the `Hashable` and `Immutable` interfaces from `DataValues/DataValues`.
 
 ## Version 9.5.1 (2020-06-03)
 

--- a/src/Internal/MapValueHasher.php
+++ b/src/Internal/MapValueHasher.php
@@ -2,7 +2,6 @@
 
 namespace Wikibase\DataModel\Internal;
 
-use Hashable;
 use InvalidArgumentException;
 use Traversable;
 
@@ -27,7 +26,7 @@ class MapValueHasher {
 	 *
 	 * @since 0.1
 	 *
-	 * @param Traversable|Hashable[] $map
+	 * @param Traversable $map
 	 *
 	 * @return string
 	 * @throws InvalidArgumentException
@@ -39,9 +38,6 @@ class MapValueHasher {
 
 		$hashes = [];
 
-		/**
-		 * @var Hashable $hashable
-		 */
 		foreach ( $map as $hashable ) {
 			$hashes[] = $hashable->getHash();
 		}

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -4,7 +4,6 @@ namespace Wikibase\DataModel;
 
 use Comparable;
 use Countable;
-use Hashable;
 use Immutable;
 use InvalidArgumentException;
 use Wikibase\DataModel\Snak\Snak;
@@ -19,7 +18,7 @@ use Wikibase\DataModel\Snak\SnakList;
  * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class Reference implements Hashable, Comparable, Immutable, Countable {
+class Reference implements Comparable, Immutable, Countable {
 
 	/**
 	 * @var SnakList
@@ -77,8 +76,6 @@ class Reference implements Hashable, Comparable, Immutable, Countable {
 	}
 
 	/**
-	 * @see Hashable::getHash
-	 *
 	 * @since 0.1
 	 *
 	 * @return string

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -4,7 +4,6 @@ namespace Wikibase\DataModel;
 
 use Comparable;
 use Countable;
-use Immutable;
 use InvalidArgumentException;
 use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Snak\SnakList;
@@ -18,7 +17,7 @@ use Wikibase\DataModel\Snak\SnakList;
  * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class Reference implements Comparable, Immutable, Countable {
+class Reference implements Comparable, Countable {
 
 	/**
 	 * @var SnakList

--- a/src/Snak/Snak.php
+++ b/src/Snak/Snak.php
@@ -3,7 +3,6 @@
 namespace Wikibase\DataModel\Snak;
 
 use Comparable;
-use Immutable;
 use Serializable;
 use Wikibase\DataModel\PropertyIdProvider;
 
@@ -16,7 +15,7 @@ use Wikibase\DataModel\PropertyIdProvider;
  * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-interface Snak extends Serializable, Immutable, Comparable, PropertyIdProvider {
+interface Snak extends Serializable, Comparable, PropertyIdProvider {
 
 	/**
 	 * Returns a string that can be used to identify the type of snak.

--- a/src/Snak/Snak.php
+++ b/src/Snak/Snak.php
@@ -3,7 +3,6 @@
 namespace Wikibase\DataModel\Snak;
 
 use Comparable;
-use Hashable;
 use Immutable;
 use Serializable;
 use Wikibase\DataModel\PropertyIdProvider;
@@ -17,7 +16,7 @@ use Wikibase\DataModel\PropertyIdProvider;
  * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-interface Snak extends Serializable, Hashable, Immutable, Comparable, PropertyIdProvider {
+interface Snak extends Serializable, Immutable, Comparable, PropertyIdProvider {
 
 	/**
 	 * Returns a string that can be used to identify the type of snak.

--- a/src/Snak/SnakList.php
+++ b/src/Snak/SnakList.php
@@ -208,6 +208,9 @@ class SnakList extends ArrayObject implements Comparable {
 	 */
 	public function offsetUnset( $index ) {
 		if ( $this->offsetExists( $index ) ) {
+			/**
+			 * @var Snak $element
+			 */
 			$element = $this->offsetGet( $index );
 			$hash = $element->getHash();
 			unset( $this->offsetHashes[$hash] );

--- a/src/Snak/SnakList.php
+++ b/src/Snak/SnakList.php
@@ -4,7 +4,6 @@ namespace Wikibase\DataModel\Snak;
 
 use ArrayObject;
 use Comparable;
-use Hashable;
 use InvalidArgumentException;
 use Traversable;
 use Wikibase\DataModel\Internal\MapValueHasher;
@@ -19,7 +18,7 @@ use Wikibase\DataModel\Internal\MapValueHasher;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Addshore
  */
-class SnakList extends ArrayObject implements Comparable, Hashable {
+class SnakList extends ArrayObject implements Comparable {
 
 	/**
 	 * Maps snak hashes to their offsets.
@@ -144,8 +143,6 @@ class SnakList extends ArrayObject implements Comparable, Hashable {
 	}
 
 	/**
-	 * @see Hashable::getHash
-	 *
 	 * The hash is purely value based. Order of the elements in the array is not held into account.
 	 *
 	 * @since 0.1
@@ -211,9 +208,6 @@ class SnakList extends ArrayObject implements Comparable, Hashable {
 	 */
 	public function offsetUnset( $index ) {
 		if ( $this->offsetExists( $index ) ) {
-			/**
-			 * @var Hashable $element
-			 */
 			$element = $this->offsetGet( $index );
 			$hash = $element->getHash();
 			unset( $this->offsetHashes[$hash] );

--- a/src/Snak/SnakObject.php
+++ b/src/Snak/SnakObject.php
@@ -67,8 +67,6 @@ abstract class SnakObject implements Snak {
 	}
 
 	/**
-	 * @see Hashable::getHash
-	 *
 	 * @return string
 	 */
 	public function getHash() {

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -3,7 +3,6 @@
 namespace Wikibase\DataModel\Statement;
 
 use Comparable;
-use Hashable;
 use InvalidArgumentException;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\PropertyIdProvider;
@@ -22,7 +21,7 @@ use Wikibase\DataModel\Snak\SnakList;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
-class Statement implements Hashable, Comparable, PropertyIdProvider {
+class Statement implements Comparable, PropertyIdProvider {
 
 	/**
 	 * Rank enum. Higher values are more preferred.
@@ -218,8 +217,6 @@ class Statement implements Hashable, Comparable, PropertyIdProvider {
 	}
 
 	/**
-	 * @see Hashable::getHash
-	 *
 	 * @since 0.1
 	 *
 	 * @return string

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -367,6 +367,9 @@ class ReferenceListTest extends \PHPUnit\Framework\TestCase {
 	public function testHasReferenceHash( ReferenceList $references ) {
 		$this->assertFalse( $references->hasReferenceHash( '~=[,,_,,]:3' ) );
 
+		/**
+		 * @var Reference $reference
+		 */
 		foreach ( $references as $reference ) {
 			$this->assertTrue( $references->hasReferenceHash( $reference->getHash() ) );
 		}

--- a/tests/unit/ReferenceListTest.php
+++ b/tests/unit/ReferenceListTest.php
@@ -2,7 +2,6 @@
 
 namespace Wikibase\DataModel\Tests;
 
-use Hashable;
 use InvalidArgumentException;
 use Traversable;
 use Wikibase\DataModel\Entity\PropertyId;
@@ -368,9 +367,6 @@ class ReferenceListTest extends \PHPUnit\Framework\TestCase {
 	public function testHasReferenceHash( ReferenceList $references ) {
 		$this->assertFalse( $references->hasReferenceHash( '~=[,,_,,]:3' ) );
 
-		/**
-		 * @var Hashable $reference
-		 */
 		foreach ( $references as $reference ) {
 			$this->assertTrue( $references->hasReferenceHash( $reference->getHash() ) );
 		}

--- a/tests/unit/Snak/SnakListTest.php
+++ b/tests/unit/Snak/SnakListTest.php
@@ -4,7 +4,6 @@ namespace Wikibase\DataModel\Tests\Snak;
 
 use Comparable;
 use DataValues\StringValue;
-use Hashable;
 use InvalidArgumentException;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
@@ -345,10 +344,6 @@ class SnakListTest extends \PHPUnit\Framework\TestCase {
 				false
 			],
 		];
-	}
-
-	public function testHashableInterface() {
-		$this->assertInstanceOf( Hashable::class, new SnakList() );
 	}
 
 	public function testGetHash() {


### PR DESCRIPTION
Removes interface usages as they were blocking the [release of DataValues/DataValues v 3.0.0](https://github.com/DataValues/DataValues/issues/58#issuecomment-700998895)

Related to: [T260915](https://phabricator.wikimedia.org/T260915)