### PR TITLE
Fix Snak interface

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,13 @@
 # Wikibase DataModel release notes
 
-## Version 9.6.0
+## Version 9.6.1 (TODO)
+
+* `Snak` now declares `getHash()` and `equals()` methods again,
+  which it used to inherit from the `Hashable` and `Immutable` interfaces prior to version 9.6.0.
+  (The methods were never removed from any specific classes,
+  but since `Snak` is an interface, Phan started complaining that the methods were unknown.)
+
+## Version 9.6.0 (2021-03-31)
 
 * `ReferenceList::addNewReference()`, `Statement::addNewReference()` and the `StatementList` constructor
   supported being called with a variadic argument list, with a single array argument,

--- a/src/Snak/Snak.php
+++ b/src/Snak/Snak.php
@@ -25,4 +25,16 @@ interface Snak extends Serializable, PropertyIdProvider {
 	 */
 	public function getType();
 
+	/**
+	 *
+	 * @return string
+	 */
+	public function getHash();
+
+	/**
+	 * @param mixed $value
+	 * @return boolean
+	 */
+	public function equals( $value );
+
 }


### PR DESCRIPTION
The Snak interface used to implement the Hashable and Comparable interfaces
which had `getHash` and `equals` functions.
We need those for avoid a bunch of errors in Wikibase.